### PR TITLE
Lunar Eclipse Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,7 @@ Base.horner(x, coefficients) // Polynomial evaluation with Horner's method
 const events = lunarEclipseEvents(eclipse) // Contact sequence (P1, U1, U2, MAX, U3, U4, P4) by eclipse type
 const geometry = computeLunarEclipseMapGeometry(eclipse, getSunMoonPosition, options) // Per-contact Moon rise/set horizon curves
 const paths = lunarEclipseMapToSvgPaths(geometry, projection, options) // Project and serialize the curves to SVG path data
+const filled = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true, fillRegion: 'belowHorizon' }) // Closed region polygons (moonRiseSetFill) for shading/gradients
 
 const local = computeLocalLunarEclipseCircumstances(eclipse, longitude, latitude, getSunMoonPosition, options) // Alt/Az, P/Z angles, magnitudes, visibility
 const view = computeLocalLunarEclipseViewGeometry(local, eclipse, options) // Local View shapes: umbra/penumbra rings, Moon disks, horizon

--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@ const filled = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true, fil
 
 const local = computeLocalLunarEclipseCircumstances(eclipse, longitude, latitude, getSunMoonPosition, options) // Alt/Az, P/Z angles, magnitudes, visibility
 const view = computeLocalLunarEclipseViewGeometry(local, eclipse, options) // Local View shapes: umbra/penumbra rings, Moon disks, horizon
+const list = listLocalLunarEclipses(longitude, latitude, startTime, endTime, getSunMoonPosition, options) // Eclipses observable from a location in a date range, with their local circumstances
 ```
 
 ### Moon ![](bun.webp) ![](browser.webp)

--- a/README.md
+++ b/README.md
@@ -930,6 +930,17 @@ Base.limb(bodyRa, bodyDec, sunRa, sunDec) // Position angle of the bright limb m
 Base.horner(x, coefficients) // Polynomial evaluation with Horner's method
 ```
 
+### Lunar Eclipse Map ![](bun.webp) ![](browser.webp)
+
+```ts
+const events = lunarEclipseEvents(eclipse) // Contact sequence (P1, U1, U2, MAX, U3, U4, P4) by eclipse type
+const geometry = computeLunarEclipseMapGeometry(eclipse, getSunMoonPosition, options) // Per-contact Moon rise/set horizon curves
+const paths = lunarEclipseMapToSvgPaths(geometry, projection, options) // Project and serialize the curves to SVG path data
+
+const local = computeLocalLunarEclipseCircumstances(eclipse, longitude, latitude, getSunMoonPosition, options) // Alt/Az, P/Z angles, magnitudes, visibility
+const view = computeLocalLunarEclipseViewGeometry(local, eclipse, options) // Local View shapes: umbra/penumbra rings, Moon disks, horizon
+```
+
 ### Moon ![](bun.webp) ![](browser.webp)
 
 ```ts

--- a/scripts/lunar.eclipse.ts
+++ b/scripts/lunar.eclipse.ts
@@ -1,0 +1,197 @@
+import { PI, PIOVERTWO, TAU } from '../src/constants'
+import { sphericalSeparation, type Point } from '../src/geometry'
+import { PlateCarree } from '../src/projection'
+// oxfmt-ignore
+import { parseArgs } from 'node:util'
+import { deg } from '../src/angle'
+import { sunMoonPosition, type EclipseGeoCurve, type EclipseGeoPoint } from '../src/eclipse'
+import { nearestLunarEclipse } from '../src/moon'
+import { computeLunarEclipseMapGeometry, lunarEclipseMapToSvgPaths, type LunarEclipseContactKind, type LunarEclipseMapGeometry, type LunarEclipseMapGeometryOptions, type LunarEclipseMapSvgPaths } from '../src/moon.eclipse.map'
+import { timeYMD, toJulianDay, timeToDate } from '../src/time'
+import { longestProjectedSegment } from '../tests/eclipse.util'
+
+const CATALOG_STEP = deg(0.5)
+const LUNAR_ECLIPSE_MAP_GEOMETRY_OPTIONS: LunarEclipseMapGeometryOptions = { maxAngularStep: CATALOG_STEP }
+// Largest geodesic gap allowed between neighboring horizon-ring samples (a few sampling steps); a bigger gap means
+// the ring is broken or under-sampled.
+const CATALOG_MAX_DRAWABLE_GAP = CATALOG_STEP * 4
+// Canonical chronological order of the seven possible lunar contacts; resolved events must be a subsequence of it.
+const CATALOG_CONTACT_ORDER: readonly LunarEclipseContactKind[] = ['P1', 'U1', 'U2', 'MAX', 'U3', 'U4', 'P4']
+
+const CURRENT_YEAR = new Date().getFullYear().toFixed(0)
+
+const { values: args } = parseArgs({
+	args: Bun.argv,
+	allowPositionals: true,
+	options: {
+		from: { type: 'string' },
+		to: { type: 'string' },
+		success: { type: 'boolean', default: false },
+		save: { type: 'boolean', default: false },
+	},
+})
+
+const FROM_YEAR = +(args.from?.trim() || CURRENT_YEAR)
+const TO_YEAR = +(args.to?.trim() || FROM_YEAR)
+
+if (!Number.isFinite(FROM_YEAR) || !Number.isFinite(TO_YEAR)) {
+	console.error('invalid from/to year:', FROM_YEAR, TO_YEAR)
+	process.exit(1)
+}
+
+function marker(point: Point | undefined | null, label: string, color: string) {
+	return point ? `<circle cx="${point.x.toFixed(2)}" cy="${point.y.toFixed(2)}" r="3" fill="${color}"/><text x="${(point.x + 5).toFixed(2)}" y="${(point.y - 5).toFixed(2)}">${label}</text>` : ''
+}
+
+function makeSvg(paths: LunarEclipseMapSvgPaths, width: number, height: number) {
+	return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}"><style>.ocean { fill: #103099; } .P1, .P4, .U1, .U2, .U3, .U4, .MAX { fill: #000000; stroke: #000000; opacity: 0.1; stroke-width: 1; stroke-linecap: round; } text { font: 14px sans-serif; font-weight: bold; fill: #fff; }</style><rect class="ocean" x="0" y="0" width="${width}" height="${height}"/><path class="P1" d="${paths.moonRiseSet.P1}"/><path class="U1" d="${paths.moonRiseSet.U1}"/><path class="U2" d="${paths.moonRiseSet.U2}"/><path class="MAX" d="${paths.moonRiseSet.MAX}"/><path class="U3" d="${paths.moonRiseSet.U3}"/><path class="U4" d="${paths.moonRiseSet.U4}"/><path class="P4" d="${paths.moonRiseSet.P4}"/>${marker(paths.sublunarPoints.P1, 'P1', '#FF9F1C')}${marker(paths.sublunarPoints.P4, 'P4', '#FF9F1C')}${marker(paths.sublunarPoints.U1, 'U1', '#FF9F1C')}${marker(paths.sublunarPoints.U2, 'U2', '#FF9F1C')}${marker(paths.sublunarPoints.U3, 'U3', '#FF9F1C')}${marker(paths.sublunarPoints.U4, 'U4', '#FF9F1C')}${marker(paths.sublunarPoints.MAX, 'MAX', '#FF9F1C')}</svg>`
+}
+
+const MAP_WIDTH = 2400
+const MAP_HEIGHT = 1200
+const projection = new PlateCarree(0, { scale: MAP_WIDTH / TAU, falseEasting: MAP_WIDTH / 2, falseNorthing: MAP_HEIGHT / 2, yAxisDirection: 'southUp', centralMeridian: 0, longitudeWrapMode: 'pi', maxLatitude: PIOVERTWO })
+
+function catalogAssert(condition: boolean, description: string) {
+	if (!condition) throw new Error(description)
+}
+
+// Validates one geographic point: finite and within the map's longitude/latitude range.
+function validateCatalogPoint(point: EclipseGeoPoint, name: string) {
+	catalogAssert(Number.isFinite(point.x), `${name} has non-finite longitude`)
+	catalogAssert(Number.isFinite(point.y), `${name} has non-finite latitude`)
+	catalogAssert(point.x >= -PI - 1e-9 && point.x <= PI + 1e-9, `${name} longitude is out of range`)
+	catalogAssert(point.y >= -PIOVERTWO - 1e-9 && point.y <= PIOVERTWO + 1e-9, `${name} latitude is out of range`)
+}
+
+// A horizon curve is the small circle where the topocentric Moon altitude equals the visibility horizon, centered
+// on the sublunar point, so every vertex sits at the SAME geocentric angular distance (the cap radius) from it.
+// Checking that this separation is constant - plus that the ring is closed, finite, in range and densely sampled -
+// catches a malformed, mis-centered or degenerate curve without depending on the engine's private cap radius.
+function validateHorizonRing(curve: EclipseGeoCurve | undefined, sublunar: EclipseGeoPoint, name: string) {
+	catalogAssert(curve !== undefined && curve.length > 0, `${name} horizon curve is missing`)
+	const ring = curve![0]
+	catalogAssert(ring.length >= 24, `${name} horizon ring is not drawable`)
+
+	const first = ring[0]
+	const last = ring.at(-1)!
+	catalogAssert(Math.abs(first.x - last.x) < 1e-9 && Math.abs(first.y - last.y) < 1e-9, `${name} horizon ring is not closed`)
+
+	let minSeparation = Infinity
+	let maxSeparation = -Infinity
+	for (let k = 0; k < ring.length; k++) {
+		const point = ring[k]
+		validateCatalogPoint(point, `${name}[${k}]`)
+		const separation = sphericalSeparation(sublunar.x, sublunar.y, point.x, point.y)
+		minSeparation = Math.min(minSeparation, separation)
+		maxSeparation = Math.max(maxSeparation, separation)
+		if (k > 0) catalogAssert(sphericalSeparation(ring[k - 1].x, ring[k - 1].y, point.x, point.y) <= CATALOG_MAX_DRAWABLE_GAP, `${name} horizon ring has a large drawable gap`)
+	}
+
+	catalogAssert(minSeparation > 1e-6, `${name} horizon ring collapses onto the sublunar point`)
+	catalogAssert(maxSeparation - minSeparation < 1e-6, `${name} horizon ring is not a circle centered on the sublunar point`)
+}
+
+// Validates a serialized SVG path: finite numbers, starts with a move, and (for the closed fill polygons) ends
+// with a Z. Empty strings are skipped (an absent contact has no path).
+function validatePathString(path: string, name: string, closed: boolean) {
+	if (path.length === 0) return
+	catalogAssert(!path.includes('NaN'), `${name} path contains NaN`)
+	catalogAssert(!path.includes('Infinity'), `${name} path contains Infinity`)
+	catalogAssert(path.startsWith('M'), `${name} path does not start with a move`)
+	if (closed) catalogAssert(path.endsWith('Z'), `${name} fill path is not closed`)
+}
+
+// Basic validation of one eclipse's map geometry and its serialized paths. Lunar geometry is far simpler than
+// solar: there is no Besselian shadow on the ground, only per-contact moon rise/set small circles, their sublunar
+// centers and the contact ordering. The checks assert those invariants and that the paths are finite and drawable.
+function validateCatalogGeometry(geometry: LunarEclipseMapGeometry, openPaths: LunarEclipseMapSvgPaths, fillPaths: LunarEclipseMapSvgPaths) {
+	const events = geometry.events
+	catalogAssert(events.length > 0, 'no contacts resolved')
+
+	// Contacts appear in canonical chronological order and strictly advance in time; the penumbral contacts and the
+	// maximum are present for every lunar eclipse.
+	const present = new Set<LunarEclipseContactKind>()
+	let previousOrder = -1
+	for (let i = 0; i < events.length; i++) {
+		const event = events[i]
+		const order = CATALOG_CONTACT_ORDER.indexOf(event.kind)
+		catalogAssert(order > previousOrder, 'contacts are out of canonical order')
+		previousOrder = order
+		present.add(event.kind)
+		validateCatalogPoint(event.sublunar, `${event.kind} sublunar`)
+		if (i > 0) catalogAssert(event.jd > events[i - 1].jd, 'contacts are out of chronological order')
+	}
+
+	catalogAssert(present.has('P1') && present.has('MAX') && present.has('P4'), 'missing a penumbral contact or the maximum')
+
+	// Each existing contact's horizon curve is a proper small circle centered on its sublunar point.
+	for (const event of events) validateHorizonRing(geometry.lines.moonRiseSet[event.kind], event.sublunar, event.kind)
+
+	// Serialized paths are finite; an open curve never spans half the map (a projected antimeridian jump would).
+	for (const kind of CATALOG_CONTACT_ORDER) {
+		const open = openPaths.moonRiseSet[kind]
+		validatePathString(open, `${kind} open`, false)
+		validatePathString(fillPaths.moonRiseSet[kind], `${kind} fill`, true)
+		if (open.length > 0) catalogAssert(longestProjectedSegment(open) < MAP_WIDTH / 2, `${kind} open curve has a projected jump`)
+	}
+}
+
+const start = timeYMD(Math.min(FROM_YEAR, TO_YEAR), 1, 1)
+const endJD = toJulianDay(timeYMD(Math.max(FROM_YEAR, TO_YEAR) + 1, 1, 1))
+
+let cursor = start
+let prevJd = -Infinity
+let total = 0
+let failed = 0
+
+async function draw(file: Bun.BunFile, paths: LunarEclipseMapSvgPaths) {
+	const svg = makeSvg(paths, MAP_WIDTH, MAP_HEIGHT)
+	await Bun.write(file, svg)
+}
+
+console.info('🌑  validating lunar eclipses from %s-01-01 to %s-12-31', FROM_YEAR, TO_YEAR)
+
+while (true) {
+	const eclipse = nearestLunarEclipse(cursor, true)
+	const jd = toJulianDay(eclipse.maximalTime)
+
+	if (jd >= endJD) break
+
+	// Guard against the enumeration stalling on the same eclipse (an infinite loop), independently of the map engine.
+	catalogAssert(jd > prevJd, 'catalog enumeration did not advance in time')
+
+	const abortTimer = setTimeout(() => {
+		console.info('❌', name, ':', 'timed out', '|', (endTime - startTime).toFixed(0), 'ms', '| time:', eclipse.maximalTime.day + eclipse.maximalTime.fraction, '| type:', eclipse.type, '| gamma:', eclipse.gamma.toFixed(6), '| magnitude:', eclipse.magnitude.toFixed(4))
+		process.exit(-1)
+	}, 5000)
+
+	const date = timeToDate(eclipse.maximalTime)
+	const name = `${date[0] < 0 ? '-' : ''}${Math.abs(date[0]).toFixed(0).padStart(4, '0')}-${date[1].toFixed(0).padStart(2, '0')}-${date[2].toFixed(0).padStart(2, '0')}`
+
+	const startTime = performance.now()
+	const geometry = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition, LUNAR_ECLIPSE_MAP_GEOMETRY_OPTIONS)
+	const openPaths = lunarEclipseMapToSvgPaths(geometry, projection)
+	const paths = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true })
+	const endTime = performance.now()
+	const file = Bun.file(`data/eclipse/${name}-${eclipse.type}.svg`)
+
+	try {
+		validateCatalogGeometry(geometry, openPaths, paths)
+		if (args.save) await draw(file, paths)
+		if (args.success) console.info('✅', name, '| type:', eclipse.type, '| gamma:', eclipse.gamma.toFixed(6), '| magnitude:', eclipse.magnitude.toFixed(4), '|', (endTime - startTime).toFixed(0), 'ms')
+	} catch (e) {
+		await draw(file, paths)
+		console.info('❌', name, ':', (e as Error).message, '|', (endTime - startTime).toFixed(0), 'ms', '| time:', eclipse.maximalTime.day + eclipse.maximalTime.fraction, '| type:', eclipse.type, '| gamma:', eclipse.gamma.toFixed(6), '| magnitude:', eclipse.magnitude.toFixed(4))
+		failed++
+	} finally {
+		clearInterval(abortTimer)
+	}
+
+	prevJd = jd
+	cursor = eclipse.maximalTime
+	total++
+}
+
+console.info(failed, 'failed of', total, 'eclipses')
+
+process.exitCode = failed

--- a/scripts/solar.eclipse.ts
+++ b/scripts/solar.eclipse.ts
@@ -4,10 +4,11 @@ import { sphericalSeparation, type Point } from '../src/geometry'
 import { PlateCarree } from '../src/projection'
 import { nearestSolarEclipse, type SolarEclipse } from '../src/sun'
 // oxfmt-ignore
-import { BRANCH_MAX_DRAWABLE_GAP, type GeoBranch, type GeoCurve, type GeoPoint, type PolynomialBesselianElements, type SolarEclipseMapGeometry, type SolarEclipseMapGeometryOptions, type SolarEclipseMapSvgPaths, centralAxisIntersectsEarth, computePolynomialBesselianElements, computeSolarEclipseMapGeometry, solarAltitudeAtPoint, solarEclipseMapToSvgPaths } from '../src/sun.eclipse.map'
+import { BRANCH_MAX_DRAWABLE_GAP, type SolarEclipseGeoPoint, type PolynomialBesselianElements, type SolarEclipseMapGeometry, type SolarEclipseMapGeometryOptions, type SolarEclipseMapSvgPaths, centralAxisIntersectsEarth, computePolynomialBesselianElements, computeSolarEclipseMapGeometry, solarAltitudeAtPoint, solarEclipseMapToSvgPaths, type SolarEclipseGeoCurve, type SolarEclipseGeoBranch } from '../src/sun.eclipse.map'
 import { parseArgs } from 'node:util'
+import { sunMoonPosition } from '../src/eclipse'
 import { timeYMD, toJulianDay, timeToDate } from '../src/time'
-import { catalogBranchRetraces, endpointRetraces, hasContinuousCurveBetween, limitTangencyResidual, longestProjectedSegment, sunMoonPosition } from '../tests/sun.eclipse.util'
+import { catalogBranchRetraces, endpointRetraces, hasContinuousCurveBetween, limitTangencyResidual, longestProjectedSegment } from '../tests/eclipse.util'
 
 const CATALOG_STEP = deg(0.5)
 const CATALOG_MAX_DRAWABLE_GAP = Math.max(BRANCH_MAX_DRAWABLE_GAP, CATALOG_STEP * 4)
@@ -58,7 +59,7 @@ function makeSvg(paths: SolarEclipseMapSvgPaths, width: number, height: number) 
 	return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}"><style>.ocean { fill: #103099; } .umbra { fill: none; stroke: #FFE66D; stroke-width: 2; stroke-linecap: round; } .center { fill: none; stroke: #FF2ED1; stroke-width: 2; stroke-linecap: round; } .penumbra { fill: none; stroke: #FF9F1C; stroke-width: 2; stroke-linecap: round; } .riseset { fill: none; stroke: #00E5FF; stroke-width: 2; }text { font: 14px sans-serif; font-weight: bold; fill: #fff; }</style><rect class="ocean" x="0" y="0" width="${width}" height="${height}"/><path class="penumbra" d="${paths.penumbraNorth}"/><path class="penumbra" d="${paths.penumbraSouth}"/><path class="riseset" d="${paths.riseSetCurves}"/><path class="umbra" d="${paths.umbraNorth}"/><path class="umbra" d="${paths.umbraSouth}"/><path class="center" d="${paths.centerLine}"/>${marker(paths.points.P1, 'P1', '#FF9F1C')}${marker(paths.points.P4, 'P4', '#FF9F1C')}${marker(paths.points.P2, 'P2', '#FF9F1C')}${marker(paths.points.P3, 'P3', '#FF9F1C')}${marker(paths.points.U1, 'U1', '#FFE66D')}${marker(paths.points.U4, 'U4', '#FFE66D')}${marker(paths.points.U2, 'U2', '#FFE66D')}${marker(paths.points.U3, 'U3', '#FFE66D')}${marker(paths.points.C1, 'C1', '#FF7BEA')}${marker(paths.points.C2, 'C2', '#FF7BEA')}${marker(paths.points.N1, 'N1', '#35FF7A')}${marker(paths.points.N2, 'N2', '#35FF7A')}${marker(paths.points.S1, 'S1', '#FF4D4D')}${marker(paths.points.S2, 'S2', '#FF4D4D')}${marker(paths.points.Max, 'Max', '#FFFFFF')}</svg>`
 }
 
-function validateCatalogPoint(point: GeoPoint, name: string, requireJd: boolean) {
+function validateCatalogPoint(point: SolarEclipseGeoPoint, name: string, requireJd: boolean) {
 	catalogAssert(Number.isFinite(point.x), `${name} has non-finite longitude`)
 	catalogAssert(Number.isFinite(point.y), `${name} has non-finite latitude`)
 	catalogAssert(point.x >= -PI && point.x <= PI, `${name} longitude is out of range`)
@@ -67,13 +68,13 @@ function validateCatalogPoint(point: GeoPoint, name: string, requireJd: boolean)
 	else if (point.jd !== undefined) catalogAssert(Number.isFinite(point.jd), `${name} has non-finite jd`)
 }
 
-function minDistanceToBranches(point: GeoPoint, curve: GeoCurve) {
+function minDistanceToBranches(point: SolarEclipseGeoPoint, curve: SolarEclipseGeoCurve) {
 	let min = Infinity
 	for (const branch of curve) for (const sample of branch) min = Math.min(min, sphericalSeparation(point.x, point.y, sample.x, sample.y))
 	return min
 }
 
-function validatePointAnchor(point: GeoPoint | undefined, name: string, curve: GeoCurve, tolerance: Angle) {
+function validatePointAnchor(point: SolarEclipseGeoPoint | undefined, name: string, curve: SolarEclipseGeoCurve, tolerance: Angle) {
 	if (!point) return
 	validateCatalogPoint(point, name, true)
 	catalogAssert(curve.length > 0, `${name} exists but its drawable family is empty`)
@@ -89,14 +90,14 @@ const UMBRAL_CONTACT_ATTACH_MIN_ALTITUDE = deg(0.5)
 
 // Validates a U-contact's attachment to the umbra family, but only when it occurs above the horizon, where a
 // day-side umbra limit can exist; a contact at or below the horizon is exempt (see the constant above).
-function validateUmbralContactAnchor(elements: PolynomialBesselianElements, point: GeoPoint | undefined, name: string, curve: GeoCurve) {
+function validateUmbralContactAnchor(elements: PolynomialBesselianElements, point: SolarEclipseGeoPoint | undefined, name: string, curve: SolarEclipseGeoCurve) {
 	if (!point) return
 	validateCatalogPoint(point, name, true)
 	if (solarAltitudeAtPoint(elements, point) < UMBRAL_CONTACT_ATTACH_MIN_ALTITUDE) return
 	validatePointAnchor(point, name, curve, CATALOG_ANCHOR_TOLERANCE)
 }
 
-function validateNoBridgeableEndpointGaps(elements: PolynomialBesselianElements, curve: GeoCurve, name: string, i: -1 | 1, G: number) {
+function validateNoBridgeableEndpointGaps(elements: PolynomialBesselianElements, curve: SolarEclipseGeoCurve, name: string, i: -1 | 1, G: number) {
 	for (let a = 0; a < curve.length; a++) {
 		const branchA = curve[a]
 		const endpointsA = [branchA[0], branchA.at(-1)!] as const
@@ -117,7 +118,7 @@ function validateNoBridgeableEndpointGaps(elements: PolynomialBesselianElements,
 	}
 }
 
-function validateCatalogBranches(elements: PolynomialBesselianElements, curve: GeoCurve, name: string, i: -1 | 1, G: number) {
+function validateCatalogBranches(elements: PolynomialBesselianElements, curve: SolarEclipseGeoCurve, name: string, i: -1 | 1, G: number) {
 	for (let b = 0; b < curve.length; b++) {
 		const branch = curve[b]
 		catalogAssert(branch.length >= 2, `${name}[${b}] is not drawable`)
@@ -135,16 +136,16 @@ function validateCatalogBranches(elements: PolynomialBesselianElements, curve: G
 	validateNoBridgeableEndpointGaps(elements, curve, name, i, G)
 }
 
-function validateNoEndpointRetrace(branch: GeoBranch, name: string) {
+function validateNoEndpointRetrace(branch: SolarEclipseGeoBranch, name: string) {
 	catalogAssert(!endpointRetraces(branch, true), `${name} retraces a loop from its start endpoint`)
 	catalogAssert(!endpointRetraces(branch, false), `${name} retraces a loop from its end endpoint`)
 }
 
-function pushCatalogBranchPoint(out: GeoBranch, point: GeoPoint) {
+function pushCatalogBranchPoint(out: SolarEclipseGeoBranch, point: SolarEclipseGeoPoint) {
 	if (out.length === 0 || sphericalSeparation(out.at(-1)!.x, out.at(-1)!.y, point.x, point.y) > 1e-12) out.push(point)
 }
 
-function appendCatalogBranchPoints(out: GeoBranch, branch: GeoBranch, reverse: boolean) {
+function appendCatalogBranchPoints(out: SolarEclipseGeoBranch, branch: SolarEclipseGeoBranch, reverse: boolean) {
 	if (reverse) {
 		for (let k = branch.length - 1; k >= 0; k--) pushCatalogBranchPoint(out, branch[k])
 	} else {
@@ -152,14 +153,14 @@ function appendCatalogBranchPoints(out: GeoBranch, branch: GeoBranch, reverse: b
 	}
 }
 
-function mergeCatalogBranches(a: GeoBranch, b: GeoBranch, endpointA: 0 | 1, endpointB: 0 | 1) {
-	const out: GeoBranch = []
+function mergeCatalogBranches(a: SolarEclipseGeoBranch, b: SolarEclipseGeoBranch, endpointA: 0 | 1, endpointB: 0 | 1) {
+	const out: SolarEclipseGeoBranch = []
 	appendCatalogBranchPoints(out, a, endpointA === 0)
 	appendCatalogBranchPoints(out, b, endpointB === 1)
 	return out
 }
 
-function validateCatalogRiseSetCurves(elements: PolynomialBesselianElements, curve: GeoCurve) {
+function validateCatalogRiseSetCurves(elements: PolynomialBesselianElements, curve: SolarEclipseGeoCurve) {
 	for (let b = 0; b < curve.length; b++) {
 		const branch = curve[b]
 		catalogAssert(branch.length >= 2, `riseSetCurves[${b}] is not drawable`)
@@ -263,7 +264,7 @@ function validateCatalogGeometry(eclipse: SolarEclipse, elements: PolynomialBess
 	}
 }
 
-function validateOptionalOrder(a: GeoPoint | undefined, b: GeoPoint | undefined, name: string) {
+function validateOptionalOrder(a: SolarEclipseGeoPoint | undefined, b: SolarEclipseGeoPoint | undefined, name: string) {
 	if (a?.jd !== undefined && b?.jd !== undefined) catalogAssert(a.jd <= b.jd, `${name} is out of chronological order`)
 }
 

--- a/src/eclipse.ts
+++ b/src/eclipse.ts
@@ -1,0 +1,557 @@
+import * as elpmpp02 from '../src/elpmpp02'
+import { precessionNutationMatrix, timeShift, type Time } from '../src/time'
+import * as vsop87e from '../src/vsop87e'
+import { normalizeAngle, normalizePI, type Angle } from './angle'
+import type { PositionAndVelocityOverTime } from './astrometry'
+import { AU_KM, DAYSEC, DEG2RAD, EARTH_RADIUS_KM, LIGHT_TIME_AU, PI, SPEED_OF_LIGHT_AU_DAY, TAU, WGS84_FLATTENING } from './constants'
+import type { EquatorialCoordinate } from './coordinate'
+import { deltaTByEspenakMeeus2006 } from './deltat'
+import { eraAb, eraP2s, eraEpj } from './erfa'
+import type { Point } from './geometry'
+import { matMulVec } from './mat3'
+import { clamp } from './math'
+import { type RootFindingOptions, bisection, brentRoot } from './optimization'
+import type { CylindricalProjection, ProjectionOptions } from './projection'
+import { vecDivScalar, vecDot, vecMinus, vecLength, vecMulScalar } from './vec3'
+
+// Earth polar/equatorial radius ratio (1 - flattening).
+export const F = 1 - WGS84_FLATTENING
+// Reciprocal of F, used by the geographic-latitude conversion.
+export const INV_F = 1 / F
+// Squared eccentricity of the Earth ellipsoid used for limb flattening, e^2 = 1 - (b/a)^2.
+export const EARTH_E2 = 1 - F * F
+// Callers building PolynomialBesselianElements from a dynamical-time (TDT) tabulation set deltaTLongitudeCorrection to
+// DELTA_T_LONGITUDE_FACTOR * deltaT; elements with UT-based mu (this module's own) use 0.
+export const DELTA_T_LONGITUDE_FACTOR = 0.00417807 * DEG2RAD
+
+const AU_IN_EARTH_RADII = AU_KM / EARTH_RADIUS_KM
+// Light travel time per AU in days, used to retard body positions to their emission epoch.
+const LIGHT_TIME_DAYS_PER_AU = LIGHT_TIME_AU / DAYSEC
+// Light-time iterations. Two passes converge the retarded geocentric position well below the map's
+// angular resolution for the Sun (~8.3 min one-way) and the Moon (~1.3 s one-way).
+const LIGHT_TIME_ITERATIONS = 2
+
+// Numerical tolerance for tangential circle/ellipse intersections: a squared half-chord slightly below
+// zero is treated as a grazing (single) contact rather than no contact.
+export const GEOMETRY_TANGENCY_EPSILON = 1e-14
+// Residual tolerance (squared Earth radii) for a tangential circle/limb-ellipse intersection detected as
+// a near-zero local extremum of g(theta) = distanceSquared - radius^2 that never changes sign. A genuine
+// tangency is a double root; this catches it when it does not land exactly on a scan sample.
+const LIMB_TANGENCY_RESIDUAL = 1e-9
+
+// Apparent/Geocentric Sun/Moon position provider at a dynamical time (TT/TDB), as produced by computeSunMoonPositionAt.
+export type SunMoonProvider = (time: Time) => SunMoonPosition
+
+// Geographic point returned by the eclipse geometry engine.
+export type EclipseGeoPoint<T extends Record<string, unknown> = {}> = T & {
+	// Longitude in radians, east-positive, normalized to [-PI, PI].
+	readonly x: Angle
+	// Latitude in radians, normalized to [-PI/2, PI/2].
+	readonly y: Angle
+	// Optional Julian Day associated with this point.
+	readonly jd?: number
+}
+
+export type EclipseGeoBranch<P extends EclipseGeoPoint = EclipseGeoPoint> = P[]
+
+export type EclipseGeoCurve<P extends EclipseGeoPoint = EclipseGeoPoint> = EclipseGeoBranch<P>[]
+
+// Apparent or geocentric Sun and Moon position sample used to generate Besselian elements.
+export interface SunMoonPosition {
+	// Apparent or geocentric Sun equatorial coordinate.
+	readonly sun: Required<EquatorialCoordinate>
+	// Apparent or geocentric Moon equatorial coordinate.
+	readonly moon: Required<EquatorialCoordinate>
+	// Delta T in seconds for this sample.
+	readonly deltaT?: number
+}
+
+// Nearest and farthest points of the Earth-limb ellipse to a fundamental-plane point, with the signed
+// inside/outside flag. This replaces the unit-circle distance used previously for
+// contacts and rise/set, so the oblique projection of the ellipsoid is honored exactly.
+export interface EarthLimbExtremes {
+	// Distance to the nearest limb point, in Earth equatorial radii.
+	readonly minDistance: number
+	// Distance to the farthest limb point, in Earth equatorial radii.
+	readonly maxDistance: number
+	// theta of the nearest limb point, in radians.
+	readonly nearestTheta: number
+	// theta of the farthest limb point, in radians.
+	readonly farthestTheta: number
+	// Whether (cx, cy) lies inside the limb ellipse.
+	readonly inside: boolean
+}
+
+// Computes the apparent geocentric Sun and Moon positions used to derive Besselian elements. Both bodies
+// are corrected for light-time (retarded emission position) and annual aberration (the geocenter's
+// barycentric velocity), then rotated from ICRF/J2000 into the true equator and equinox of date. Delta T
+// is taken from the Espenak and Meeus 2006 polynomials for the sample epoch.
+//
+// Time-scale contract: the dynamical steps (ephemeris sampling, precession and nutation) are
+// dynamical-time operations, so the input time should be TT/TDB; the providers and
+// precessionNutationMatrix convert internally and the scale difference is sub-millisecond either way.
+// Earth rotation enters only later, in instantBesselianFromSunMoon, where mu is built from UT1 (= TT -
+// Delta T) and Greenwich apparent sidereal time, keeping the rotation strictly in UT.
+//   time: instant of evaluation in a dynamical scale (TT or TDB); other scales convert internally.
+//   sun: barycentric Sun position and velocity provider, in AU and AU/day, equatorial ICRF/J2000.
+//   earth: barycentric Earth position and velocity provider, in AU and AU/day, equatorial ICRF/J2000.
+//   moon: geocentric Moon position and velocity provider, in AU and AU/day, equatorial ICRF/J2000.
+export function computeSunMoonPositionAt(time: Time, sun: PositionAndVelocityOverTime, earth: PositionAndVelocityOverTime, moon: PositionAndVelocityOverTime): SunMoonPosition {
+	const earthBarycentric = earth(time)
+	const earthPosition = earthBarycentric[0]
+
+	// Observer (geocenter) barycentric velocity in units of the speed of light, plus the reciprocal Lorentz
+	// factor, both consumed by eraAb for annual aberration.
+	const aberrationVelocity = vecDivScalar(earthBarycentric[1], SPEED_OF_LIGHT_AU_DAY)
+	const reciprocalLorentz = Math.sqrt(1 - vecDot(aberrationVelocity, aberrationVelocity))
+
+	// Light-time corrected geocentric Sun position: seen where it was when its light departed.
+	let sunGeometric = vecMinus(sun(time)[0], earthPosition)
+
+	for (let i = 0; i < LIGHT_TIME_ITERATIONS; i++) {
+		const tau = vecLength(sunGeometric) * LIGHT_TIME_DAYS_PER_AU
+		sunGeometric = vecMinus(sun(timeShift(time, -tau))[0], earthPosition)
+	}
+
+	const sunDistance = vecLength(sunGeometric)
+
+	// Light-time corrected geocentric Moon position. The Moon provider is geocentric (Moon - Earth at the
+	// sampled epoch); retarding it alone would also recede the origin, yielding Moon(t - tau) - Earth(t -
+	// tau). The apparent geocentric vector must keep the observer at the geocenter of the observation
+	// epoch, so the Earth displacement Earth(t) - Earth(t - tau) is added back.
+	let moonGeometric = moon(time)[0]
+
+	for (let i = 0; i < LIGHT_TIME_ITERATIONS; i++) {
+		const tau = vecLength(moonGeometric) * LIGHT_TIME_DAYS_PER_AU
+		const retarded = timeShift(time, -tau)
+		moonGeometric = vecMinus(moon(retarded)[0], vecMinus(earthPosition, earth(retarded)[0]))
+	}
+
+	const moonDistance = vecLength(moonGeometric)
+	const pnm = precessionNutationMatrix(time)
+
+	// Apply annual aberration to the unit direction (the Sun-observer distance drives the relativistic
+	// deflection term), restore the body distance, then rotate ICRF/J2000 into the true equator of date.
+	const sunApparent = vecDivScalar(sunGeometric, sunDistance)
+	eraAb(sunApparent, aberrationVelocity, sunDistance, reciprocalLorentz, sunApparent)
+	vecMulScalar(sunApparent, sunDistance, sunApparent)
+	matMulVec(pnm, sunApparent, sunApparent)
+
+	const moonApparent = vecDivScalar(moonGeometric, moonDistance)
+	eraAb(moonApparent, aberrationVelocity, sunDistance, reciprocalLorentz, moonApparent)
+	vecMulScalar(moonApparent, moonDistance, moonApparent)
+	matMulVec(pnm, moonApparent, moonApparent)
+
+	const [sRA, sDEC, sD] = eraP2s(...sunApparent)
+	const [mRA, mDEC, mD] = eraP2s(...moonApparent)
+
+	// Decimal year for the Delta T model. The sub-minute scale difference between time scales is irrelevant
+	// for Delta T, which varies on the order of a second per year.
+	const year = eraEpj(time.day, time.fraction)
+
+	return {
+		sun: {
+			rightAscension: sRA,
+			declination: sDEC,
+			distance: sD * AU_IN_EARTH_RADII,
+		},
+		moon: {
+			rightAscension: mRA,
+			declination: mDEC,
+			distance: mD * AU_IN_EARTH_RADII,
+		},
+		deltaT: deltaTByEspenakMeeus2006(year),
+	}
+}
+
+// Apparent Sun/Moon position provider from the analytical VSOP87E + ELP/MPP02 ephemerides.
+export function sunMoonPosition(time: Time) {
+	return computeSunMoonPositionAt(time, vsop87e.sun, vsop87e.earth, elpmpp02.moon)
+}
+
+const BISECT_ROOT_OPTIONS: RootFindingOptions = { tolerance: 1e-8 }
+
+export function bisectRoot(f: (x: number) => number, min: number, max: number) {
+	try {
+		return bisection(f, min, max, BISECT_ROOT_OPTIONS).root
+	} catch {
+		return undefined
+	}
+}
+
+// Refines a bracketed root, preferring Brent (superlinear) and falling back to bisection if Brent rejects the bracket.
+export function refineRoot(f: (x: number) => number, min: number, max: number) {
+	try {
+		return brentRoot(f, min, max, BISECT_ROOT_OPTIONS).root
+	} catch {
+		return bisectRoot(f, min, max)
+	}
+}
+
+// Number of uniform theta samples used to bracket extrema and crossings on the Earth-limb ellipse. The
+// limb is smooth and nearly circular (flattening ~1/298), so a 2 deg scan reliably brackets every
+// extremum/intersection basin before local refinement (ternary search for extrema, bisection for
+// crossings), which then converges to full precision independently of this resolution.
+const LIMB_SCAN_STEPS = 180
+
+// Precomputed cos/sin of the uniform limb scan grid (theta = TAU*k/LIMB_SCAN_STEPS), since those angles are
+// always the same; the continuous refinements still call Math.cos/sin on off-grid theta.
+const LIMB_SCAN_COS = new Float64Array(LIMB_SCAN_STEPS)
+const LIMB_SCAN_SIN = new Float64Array(LIMB_SCAN_STEPS)
+
+for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
+	const theta = (TAU * k) / LIMB_SCAN_STEPS
+	LIMB_SCAN_COS[k] = Math.cos(theta)
+	LIMB_SCAN_SIN[k] = Math.sin(theta)
+}
+
+// Reused scan buffer for earthLimbCircleIntersections, avoiding a Float64Array allocation per call. Safe as
+// a single module workspace: the function is synchronous and never re-enters itself.
+const LIMB_SCAN_VALUES = new Float64Array(LIMB_SCAN_STEPS)
+
+// Squared distance to (cx, cy) from a limb-scan grid point given its precomputed cos/sin.
+export function limbDistanceSquaredFromCosSin(cos: number, sin: number, cx: number, cy: number, omega: number) {
+	const dx = cos - cx
+	const dy = sin / omega - cy
+	return dx * dx + dy * dy
+}
+
+function EarthLimbCircleIntersectionPointComparator(a: readonly [number, number], b: readonly [number, number]) {
+	return b[1] - a[1]
+}
+
+// Returns the point on the Earth-limb ellipse x^2 + (omega y)^2 = 1 at parameter theta.
+export function earthLimbPoint(theta: number, omega: number) {
+	return [Math.cos(theta), Math.sin(theta) / omega] as const
+}
+
+export function earthLimbDistanceSquared(theta: number, cx: number, cy: number, omega: number) {
+	const dx = Math.cos(theta) - cx
+	const dy = Math.sin(theta) / omega - cy
+	return dx * dx + dy * dy
+}
+
+// Intersections of a circle of the given radius centered at (cx, cy) with the Earth-limb ellipse,
+// returned as limb points (cos theta, sin theta / omega) ordered by descending y. The circle and the
+// ellipse can meet in up to four points, so g(theta) = earthLimbDistanceSquared(theta) - radius^2 is
+// scanned uniformly and every root is captured: exact zeros and sign changes (the transversal crossings),
+// plus near-zero local extrema that never change sign (tangencies, which are double roots and would
+// otherwise be missed unless they landed exactly on a sample). This is the ellipse counterpart of
+// findCircleIntersections for rise/set.
+export function earthLimbCircleIntersections(cx: number, cy: number, omega: number, radius: number) {
+	if (!Number.isFinite(radius) || radius < 0 || !Number.isFinite(cx) || !Number.isFinite(cy)) return []
+
+	const r2 = radius * radius
+	const g = (theta: number) => earthLimbDistanceSquared(theta, cx, cy, omega) - r2
+	const step = TAU / LIMB_SCAN_STEPS
+
+	// g is TAU-periodic, so sample [0, TAU) once (reusing the scan buffer) and read neighbors modularly.
+	const values = LIMB_SCAN_VALUES
+	for (let k = 0; k < LIMB_SCAN_STEPS; k++) values[k] = limbDistanceSquaredFromCosSin(LIMB_SCAN_COS[k], LIMB_SCAN_SIN[k], cx, cy, omega) - r2
+
+	const thetas: number[] = []
+
+	// Transversal crossings: exact zeros on a sample and sign changes between neighbors.
+	for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
+		const value = values[k]
+		const next = values[(k + 1) % LIMB_SCAN_STEPS]
+
+		if (Math.abs(value) <= GEOMETRY_TANGENCY_EPSILON) thetas.push(k * step)
+		else if (value * next < 0) {
+			const root = bisectRoot(g, k * step, (k + 1) * step)
+			if (root !== undefined) thetas.push(root)
+		}
+	}
+
+	// Tangencies: a strict local minimum or maximum of g whose refined extremum value is within tolerance
+	// of zero is a grazing (double) contact that the sign-change pass cannot see.
+	for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
+		const previous = values[(k - 1 + LIMB_SCAN_STEPS) % LIMB_SCAN_STEPS]
+		const value = values[k]
+		const next = values[(k + 1) % LIMB_SCAN_STEPS]
+		const isMinimum = value < previous && value < next
+		const isMaximum = value > previous && value > next
+
+		if (isMinimum || isMaximum) {
+			const extreme = refineLimbExtreme(k * step, step, cx, cy, omega, isMinimum)
+			if (Math.abs(g(extreme)) <= LIMB_TANGENCY_RESIDUAL) thetas.push(extreme)
+		}
+	}
+
+	const roots = deduplicateAngularRoots(thetas, 1e-7)
+	const points: (readonly [number, number])[] = []
+	for (const theta of roots) points.push(earthLimbPoint(theta, omega))
+	points.sort(EarthLimbCircleIntersectionPointComparator)
+	return points
+}
+
+export function earthLimbExtremes(cx: number, cy: number, omega: number): EarthLimbExtremes {
+	const step = TAU / LIMB_SCAN_STEPS
+	let minTheta = 0
+	let maxTheta = 0
+	let minD2 = Infinity
+	let maxD2 = -Infinity
+
+	for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
+		const d2 = limbDistanceSquaredFromCosSin(LIMB_SCAN_COS[k], LIMB_SCAN_SIN[k], cx, cy, omega)
+		if (d2 < minD2) {
+			minD2 = d2
+			minTheta = k * step
+		}
+		if (d2 > maxD2) {
+			maxD2 = d2
+			maxTheta = k * step
+		}
+	}
+
+	const nearestTheta = refineLimbExtreme(minTheta, step, cx, cy, omega, true)
+	const farthestTheta = refineLimbExtreme(maxTheta, step, cx, cy, omega, false)
+	const omegaCy = omega * cy
+
+	return {
+		minDistance: Math.sqrt(earthLimbDistanceSquared(nearestTheta, cx, cy, omega)),
+		maxDistance: Math.sqrt(earthLimbDistanceSquared(farthestTheta, cx, cy, omega)),
+		nearestTheta,
+		farthestTheta,
+		inside: cx * cx + omegaCy * omegaCy < 1,
+	}
+}
+
+// Signed distance from a fundamental-plane point to the Earth-limb ellipse boundary: negative inside,
+// positive outside. The classical contact equations on the unit circle (hypot - 1 -+ r) become
+// signedDistance -+ r on the ellipse.
+export function earthLimbSignedDistance(cx: number, cy: number, omega: number) {
+	const extremes = earthLimbExtremes(cx, cy, omega)
+	return extremes.inside ? -extremes.minDistance : extremes.minDistance
+}
+
+// Computes the flattening scale for the Earth-limb ellipse in the fundamental plane:
+// the limb is x^2 + (omega*y)^2 = 1 with omega = 1 / sqrt(1 - e^2 cos^2 d).
+export function earthLimbOmega(d: Angle) {
+	const cosD = Math.cos(d)
+	return 1 / Math.sqrt(1 - EARTH_E2 * cosD * cosD)
+}
+
+// Derivative d(omega)/d(d) of the limb flattening scale, used to carry the d-dependence of the limb
+// into the central-line endpoint solver: omega = s^(-1/2), s = 1 - e^2 cos^2 d,
+// so d(omega)/dd = -e^2 cos d sin d * s^(-3/2).
+export function derivativeEarthLimbOmega(d: Angle) {
+	const cosD = Math.cos(d)
+	const sinD = Math.sin(d)
+	const s = 1 - EARTH_E2 * cosD * cosD
+	return (-EARTH_E2 * cosD * sinD) / (s * Math.sqrt(s))
+}
+
+// Ternary search of a unimodal limb extremum within a one-step bracket. Robust fallback for refineLimbExtreme.
+function ternaryLimbExtreme(thetaGuess: number, halfWidth: number, cx: number, cy: number, omega: number, minimize: boolean) {
+	let lo = thetaGuess - halfWidth
+	let hi = thetaGuess + halfWidth
+
+	for (let i = 0; i < 60 && hi - lo > 1e-12; i++) {
+		const m1 = lo + (hi - lo) / 3
+		const m2 = hi - (hi - lo) / 3
+		const f1 = earthLimbDistanceSquared(m1, cx, cy, omega)
+		const f2 = earthLimbDistanceSquared(m2, cx, cy, omega)
+		if (minimize ? f1 < f2 : f1 > f2) hi = m2
+		else lo = m1
+	}
+
+	return (lo + hi) * 0.5
+}
+
+// Refines a limb extremum (minimum or maximum of the squared distance to (cx, cy)) from a scan guess.
+// Newton on the first derivative of D^2(theta) converges in a handful of evaluations (the limb is nearly
+// circular, so the basin is convex), replacing the 60-step ternary search; it falls back to ternary
+// whenever the curvature has the wrong sign or a step would leave the one-step bracket.
+function refineLimbExtreme(thetaGuess: number, halfWidth: number, cx: number, cy: number, omega: number, minimize: boolean) {
+	const lo = thetaGuess - halfWidth
+	const hi = thetaGuess + halfWidth
+	let theta = thetaGuess
+
+	for (let i = 0; i < 12; i++) {
+		const cos = Math.cos(theta)
+		const sin = Math.sin(theta)
+		const dx = cos - cx
+		const dy = sin / omega - cy
+		// First and second derivatives of D^2(theta) = dx^2 + dy^2.
+		const first = 2 * (dx * -sin + (dy * cos) / omega)
+		const second = 2 * (sin * sin - dx * cos + (cos * cos) / (omega * omega) - (dy * sin) / omega)
+
+		// A minimum needs positive curvature, a maximum negative; otherwise Newton would walk the wrong way.
+		if (!Number.isFinite(second) || second === 0 || (minimize ? second < 0 : second > 0)) break
+
+		const step = first / second
+		theta -= step
+
+		if (!Number.isFinite(theta) || theta < lo || theta > hi) break
+		if (Math.abs(step) < 1e-13) return theta
+	}
+
+	return ternaryLimbExtreme(thetaGuess, halfWidth, cx, cy, omega, minimize)
+}
+
+// Collapses thetas that are within tolerance of each other (also across the 0/TAU wrap) into a single
+// representative, keeping the input order. Used to drop duplicate circle/limb intersection angles that a
+// sign-change and a tangency pass can both report for the same root.
+function deduplicateAngularRoots(thetas: readonly number[], tolerance: number) {
+	const out: number[] = []
+
+	for (const theta of thetas) {
+		const wrapped = normalizeAngle(theta)
+		let duplicate = false
+
+		for (const kept of out) {
+			const delta = Math.abs(normalizePI(wrapped - kept))
+			if (delta <= tolerance) {
+				duplicate = true
+				break
+			}
+		}
+
+		if (!duplicate) out.push(wrapped)
+	}
+
+	return out
+}
+
+// Single source of truth for the hour-angle -> longitude conversion. The project uses east-positive
+// longitude, so lambda = H - mu + correction, where the correction is 0.00417807 deg per second of
+// Delta T in radians. The sign is pinned by tests against NASA eclipse path tables and the subsolar point.
+export function longitudeFromHourAngle(hourAngle: Angle, mu: Angle, correction: Angle) {
+	return normalizeLongitude(hourAngle - mu + correction)
+}
+
+export function normalizeLongitude(longitude: Angle) {
+	return longitude === PI || longitude === -PI ? longitude : normalizePI(longitude)
+}
+
+// Inverse of longitudeFromHourAngle: local hour angle of the shadow axis at an east-positive longitude.
+export function hourAngleFromLongitude(longitude: Angle, mu: Angle, correction: Angle) {
+	return longitude + mu - correction
+}
+
+function samePoint(a: EclipseGeoPoint, b: EclipseGeoPoint) {
+	return Math.abs(a.x - b.x) < 1e-9 && Math.abs(a.y - b.y) < 1e-9 && Math.abs((a.jd ?? 0) - (b.jd ?? 0)) < 1e-10
+}
+
+// Splits a geographic polyline into drawable antimeridian-safe segments.
+export function splitPolylineAtAntimeridian(line: EclipseGeoBranch) {
+	return splitGeoLineAtAntimeridian(line, false)
+}
+
+// Splits a geographic polygon ring into antimeridian-safe drawable rings.
+export function splitPolygonAtAntimeridian(ring: EclipseGeoBranch) {
+	return splitGeoLineAtAntimeridian(ring, true)
+}
+
+export function splitGeoLineAtAntimeridian(line: EclipseGeoBranch, close: boolean) {
+	if (line.length < 2) return []
+
+	const segments: EclipseGeoCurve = []
+	let current: EclipseGeoBranch = [line[0]]
+	const count = close ? line.length + 1 : line.length
+
+	for (let i = 1; i < count; i++) {
+		const previous = line[(i - 1) % line.length]
+		const point = line[i % line.length]
+		const delta = point.x - previous.x
+
+		if (Math.abs(delta) > PI) {
+			const crossingLon = delta > 0 ? -PI : PI
+			const oppositeLon = -crossingLon
+			const t = (crossingLon - previous.x) / (point.x + (delta > 0 ? -TAU : TAU) - previous.x)
+			const clampedT = clamp(t, 0, 1)
+			const lat = previous.y + (point.y - previous.y) * clampedT
+			const jd = previous.jd !== undefined && point.jd !== undefined ? previous.jd + (point.jd - previous.jd) * clampedT : undefined
+			current.push({ x: crossingLon, y: lat, jd })
+			if (current.length > 1) segments.push(current)
+			current = [{ x: oppositeLon, y: lat, jd }, point]
+		} else {
+			current.push(point)
+		}
+	}
+
+	if (current.length > 1) segments.push(current)
+
+	// For a closed ring whose first vertex is not on the seam, the opening arc (the first segment) and
+	// the closing arc (the last segment) both belong to the start hemisphere and were split apart at
+	// line[0]; rejoin them so the hemisphere closes along the antimeridian seam rather than across the
+	// map interior. Each remaining segment already enters and leaves on the same seam, so closing it with
+	// Z follows the seam edge.
+	if (close && segments.length >= 2) {
+		const firstSegment = segments[0]
+		const lastSegment = segments.at(-1)!
+
+		if (samePoint(firstSegment[0], lastSegment.at(-1)!)) {
+			lastSegment.pop()
+			const joined: EclipseGeoBranch = []
+			for (const point of lastSegment) joined.push(point)
+			for (const point of firstSegment) joined.push(point)
+			segments[0] = joined
+			segments.pop()
+		}
+	}
+
+	return segments
+}
+
+// Splits one geographic line (or ring when close is true) at the antimeridian with the exact +-180
+// crossing inserted, then projects each piece. Inserting the crossing keeps every piece reaching the map
+// edge instead of stopping at the last sample before the wrap, which otherwise leaves a visible gap or
+// angular "beak" near +-180. The 'pi'-mode projection preserves an exact +-PI seam vertex, so the post-wrap
+// piece resumes on the left edge (-PI) rather than being folded back onto the right one (+PI). The split
+// happens only here, at serialization time: the geographic geometry itself is never mutated.
+export function projectSplitPieces(geo: EclipseGeoBranch, close: boolean, projection: CylindricalProjection, options?: ProjectionOptions) {
+	const pieces: Point[][] = []
+
+	for (const segment of splitGeoLineAtAntimeridian(geo, close)) {
+		let piece: Point[] = []
+
+		for (const point of segment) {
+			const projected = projection.project(point.x, point.y, undefined, options)
+
+			if (projected === undefined) {
+				if (piece.length >= 2) pieces.push(piece)
+				piece = []
+			} else {
+				piece.push(projected)
+			}
+		}
+
+		if (piece.length >= 2) pieces.push(piece)
+	}
+
+	return pieces
+}
+
+// Projects geographic polylines and serializes them into one SVG path data string of open subpaths,
+// split at the antimeridian during projection only.
+export function geoPolylinesToSvgPathData(lines: readonly EclipseGeoBranch[], projection: CylindricalProjection, precision: number = 2, projectionOptions?: ProjectionOptions) {
+	const pieces: Point[][] = []
+	for (const line of lines) for (const piece of projectSplitPieces(line, false, projection, projectionOptions)) pieces.push(piece)
+	return pointsToSvgPathData(pieces, false, precision)
+}
+
+// Serializes projected polyline or polygon pieces into an SVG path data string. Each piece becomes one
+// subpath (M ... L ...); pieces with fewer than two points are skipped. When close is true each subpath
+// is closed with Z, suitable for filled polygons.
+export function pointsToSvgPathData(pieces: readonly (readonly Point[])[], close = false, precision: number = 2) {
+	const subpaths: string[] = []
+
+	function formatCoordinate(value: number) {
+		return Number(value.toFixed(precision)).toString()
+	}
+
+	for (const piece of pieces) {
+		if (piece.length < 2) continue
+
+		// Build each subpath from tokens joined once, instead of growing a string with repeated `+=`.
+		const tokens: string[] = [`M${formatCoordinate(piece[0].x)} ${formatCoordinate(piece[0].y)}`]
+		for (let i = 1; i < piece.length; i++) tokens.push(`L${formatCoordinate(piece[i].x)} ${formatCoordinate(piece[i].y)}`)
+		if (close) tokens.push('Z')
+
+		subpaths.push(tokens.join(''))
+	}
+
+	return subpaths.join('')
+}

--- a/src/eclipse.ts
+++ b/src/eclipse.ts
@@ -1,12 +1,12 @@
-import * as elpmpp02 from '../src/elpmpp02'
-import { precessionNutationMatrix, timeShift, type Time } from '../src/time'
-import * as vsop87e from '../src/vsop87e'
+import { precessionNutationMatrix, timeShift, tt, type Time } from '../src/time'
 import { normalizeAngle, normalizePI, type Angle } from './angle'
-import type { PositionAndVelocityOverTime } from './astrometry'
+import type { PositionAndVelocity, PositionAndVelocityOverTime } from './astrometry'
 import { AU_KM, DAYSEC, DEG2RAD, EARTH_RADIUS_KM, LIGHT_TIME_AU, PI, SPEED_OF_LIGHT_AU_DAY, TAU, WGS84_FLATTENING } from './constants'
 import type { EquatorialCoordinate } from './coordinate'
 import { deltaTByEspenakMeeus2006 } from './deltat'
 import { eraAb, eraP2s, eraEpj } from './erfa'
+import { eraEpv00 } from './erfa.earth'
+import { eraMoon98 } from './erfa.moon'
 import type { Point } from './geometry'
 import { matMulVec } from './mat3'
 import { clamp } from './math'
@@ -164,9 +164,24 @@ export function computeSunMoonPositionAt(time: Time, sun: PositionAndVelocityOve
 	}
 }
 
-// Apparent Sun/Moon position provider from the analytical VSOP87E + ELP/MPP02 ephemerides.
+function earth(time: Time) {
+	const { day, fraction } = tt(time)
+	return eraEpv00(day, fraction)[0]
+}
+
+function sun(time: Time): PositionAndVelocity {
+	const { day, fraction } = tt(time)
+	const [pvb, pvh] = eraEpv00(day, fraction)
+	return [vecMinus(pvb[0], pvh[0]), vecMinus(pvb[1], pvh[1])]
+}
+
+function moon(time: Time) {
+	return eraMoon98(time.day, time.fraction) as PositionAndVelocity
+}
+
+// Apparent Sun/Moon position provider from the analytical ERFA/Meeus ephemerides (significantly faster).
 export function sunMoonPosition(time: Time) {
-	return computeSunMoonPositionAt(time, vsop87e.sun, vsop87e.earth, elpmpp02.moon)
+	return computeSunMoonPositionAt(time, sun, earth, moon)
 }
 
 const BISECT_ROOT_OPTIONS: RootFindingOptions = { tolerance: 1e-8 }

--- a/src/eclipse.ts
+++ b/src/eclipse.ts
@@ -11,7 +11,7 @@ import type { Point } from './geometry'
 import { matMulVec } from './mat3'
 import { clamp } from './math'
 import { type RootFindingOptions, bisection, brentRoot } from './optimization'
-import type { CylindricalProjection, ProjectionOptions } from './projection'
+import type { CylindricalProjection, ProjectionOptions, RaAxisDirection } from './projection'
 import { vecDivScalar, vecDot, vecMinus, vecLength, vecMulScalar } from './vec3'
 
 // Earth polar/equatorial radius ratio (1 - flattening).
@@ -510,20 +510,49 @@ export function splitGeoLineAtAntimeridian(line: EclipseGeoBranch, close: boolea
 	return segments
 }
 
+// Recenters a geographic line's longitudes onto the central meridian, mapping each into the signed wrapped offset
+// in (-PI, PI] (east-positive). Latitude and jd are preserved. After recentering, the projection's antimeridian
+// seam sits at +-PI, so the raw-+-PI antimeridian split lands where the map actually wraps.
+//   centralMeridian: geographic longitude (radians) drawn at the map center.
+//   direction: 'east' when longitude increases to the right (the usual map), 'west' otherwise.
+function recenterGeoLine(line: EclipseGeoBranch, centralMeridian: Angle, direction: RaAxisDirection): EclipseGeoBranch {
+	const out: EclipseGeoBranch = new Array(line.length)
+
+	for (let i = 0; i < line.length; i++) {
+		const point = line[i]
+		const delta = direction === 'west' ? centralMeridian - point.x : point.x - centralMeridian
+		out[i] = { x: normalizeLongitude(delta), y: point.y, jd: point.jd }
+	}
+
+	return out
+}
+
 // Splits one geographic line (or ring when close is true) at the antimeridian with the exact +-180
 // crossing inserted, then projects each piece. Inserting the crossing keeps every piece reaching the map
 // edge instead of stopping at the last sample before the wrap, which otherwise leaves a visible gap or
 // angular "beak" near +-180. The 'pi'-mode projection preserves an exact +-PI seam vertex, so the post-wrap
 // piece resumes on the left edge (-PI) rather than being folded back onto the right one (+PI). The split
 // happens only here, at serialization time: the geographic geometry itself is never mutated.
+//
+// The split must land on the projection's antimeridian seam, which for a non-zero central meridian (or a west
+// axis) is NOT at raw +-PI. The line is then recentered onto the central meridian (placing the seam at +-PI) and
+// projected in a central-meridian-neutral frame; otherwise a segment crossing the real seam would be left unsplit
+// and drawn as a full-width horizontal line across the map, with a spurious split appearing at the map center. A
+// zero central meridian on an east axis is the identity and keeps the original behavior (and allocation) exactly.
 export function projectSplitPieces(geo: EclipseGeoBranch, close: boolean, projection: CylindricalProjection, options?: ProjectionOptions) {
 	const pieces: Point[][] = []
 
-	for (const segment of splitGeoLineAtAntimeridian(geo, close)) {
+	const centralMeridian = options?.centralMeridian ?? projection.options?.centralMeridian ?? 0
+	const direction: RaAxisDirection = options?.raAxisDirection ?? projection.options?.raAxisDirection ?? 'east'
+	const neutral = centralMeridian === 0 && direction === 'east'
+	const line = neutral ? geo : recenterGeoLine(geo, centralMeridian, direction)
+	const projectOptions = neutral ? options : { ...options, centralMeridian: 0, raAxisDirection: 'east' as RaAxisDirection, longitudeWrapMode: 'pi' as const }
+
+	for (const segment of splitGeoLineAtAntimeridian(line, close)) {
 		let piece: Point[] = []
 
 		for (const point of segment) {
-			const projected = projection.project(point.x, point.y, undefined, options)
+			const projected = projection.project(point.x, point.y, undefined, projectOptions)
 
 			if (projected === undefined) {
 				if (piece.length >= 2) pieces.push(piece)

--- a/src/erfa.moon.ts
+++ b/src/erfa.moon.ts
@@ -1,0 +1,362 @@
+import { normalizeAngle } from './angle'
+import { AU_M, DAYSPERJC, DEG2RAD, J2000 } from './constants'
+import { eraPfw06, eraS2pv } from './erfa'
+import { matMulVec, matRotX, matRotZ } from './mat3'
+
+// Moon's mean longitude (wrt mean equinox and ecliptic of date)
+const ELP0 = 218.31665436 * DEG2RAD // Simon et al. (1994)
+const ELP1 = 481267.88123421 * DEG2RAD
+const ELP2 = -0.0015786 * DEG2RAD
+const ELP3 = DEG2RAD / 538841
+const ELP4 = -DEG2RAD / 65194000
+
+// Moon's mean elongation
+const D0 = 297.8501921 * DEG2RAD
+const D1 = 445267.1114034 * DEG2RAD
+const D2 = -0.0018819 * DEG2RAD
+const D3 = DEG2RAD / 545868
+const D4 = DEG2RAD / 113065000
+
+// Sun's mean anomaly
+const EM0 = 357.5291092 * DEG2RAD
+const EM1 = 35999.0502909 * DEG2RAD
+const EM2 = -0.0001536 * DEG2RAD
+const EM3 = DEG2RAD / 24490000
+const EM4 = 0
+
+// Moon's mean anomaly
+const EMP0 = 134.9633964 * DEG2RAD
+const EMP1 = 477198.8675055 * DEG2RAD
+const EMP2 = 0.0087414 * DEG2RAD
+const EMP3 = DEG2RAD / 69699
+const EMP4 = -DEG2RAD / 14712000
+
+// Mean distance of the Moon from its ascending node
+const F0 = 93.272095 * DEG2RAD
+const F1 = 483202.0175233 * DEG2RAD
+const F2 = -0.0036539 * DEG2RAD
+const F3 = DEG2RAD / 3526000
+const F4 = DEG2RAD / 863310000
+
+// Meeus A_1, due to Venus (deg)
+const A10 = 119.75 * DEG2RAD
+const A11 = 131.849 * DEG2RAD
+
+// Meeus A_2, due to Jupiter (deg)
+const A20 = 53.09 * DEG2RAD
+const A21 = 479264.29 * DEG2RAD
+
+// Meeus A_3, due to sidereal motion of the Moon in longitude (deg)
+const A30 = 313.45 * DEG2RAD
+const A31 = 481266.484 * DEG2RAD
+
+// Coefficients for Meeus "additive terms" (deg)
+const AL1 = 0.003958
+const AL2 = 0.001962
+const AL3 = 0.000318
+const AB1 = -0.002235
+const AB2 = 0.000382
+const AB3 = 0.000175
+const AB4 = 0.000175
+const AB5 = 0.000127
+const AB6 = -0.000115
+
+// Fixed term in distance (m)
+const R0 = 385000560
+
+// Coefficients for (dimensionless) E factor
+const E1 = -0.002516
+const E2 = -0.0000074
+
+const TLR = [
+	// number of D in argument
+	// M
+	// M'
+	// F
+	// coefficient of L sine argument (deg)
+	// coefficient of R cosine argument (m)
+	[0, 0, 1, 0, 6.288774, -20905355],
+	[2, 0, -1, 0, 1.274027, -3699111],
+	[2, 0, 0, 0, 0.658314, -2955968],
+	[0, 0, 2, 0, 0.213618, -569925],
+	[0, 1, 0, 0, -0.185116, 48888],
+	[0, 0, 0, 2, -0.114332, -3149],
+	[2, 0, -2, 0, 0.058793, 246158],
+	[2, -1, -1, 0, 0.057066, -152138],
+	[2, 0, 1, 0, 0.053322, -170733],
+	[2, -1, 0, 0, 0.045758, -204586],
+	[0, 1, -1, 0, -0.040923, -129620],
+	[1, 0, 0, 0, -0.03472, 108743],
+	[0, 1, 1, 0, -0.030383, 104755],
+	[2, 0, 0, -2, 0.015327, 10321],
+	[0, 0, 1, 2, -0.012528, 0],
+	[0, 0, 1, -2, 0.01098, 79661],
+	[4, 0, -1, 0, 0.010675, -34782],
+	[0, 0, 3, 0, 0.010034, -23210],
+	[4, 0, -2, 0, 0.008548, -21636],
+	[2, 1, -1, 0, -0.007888, 24208],
+	[2, 1, 0, 0, -0.006766, 30824],
+	[1, 0, -1, 0, -0.005163, -8379],
+	[1, 1, 0, 0, 0.004987, -16675],
+	[2, -1, 1, 0, 0.004036, -12831],
+	[2, 0, 2, 0, 0.003994, -10445],
+	[4, 0, 0, 0, 0.003861, -11650],
+	[2, 0, -3, 0, 0.003665, 14403],
+	[0, 1, -2, 0, -0.002689, -7003],
+	[2, 0, -1, 2, -0.002602, 0],
+	[2, -1, -2, 0, 0.00239, 10056],
+	[1, 0, 1, 0, -0.002348, 6322],
+	[2, -2, 0, 0, 0.002236, -9884],
+	[0, 1, 2, 0, -0.00212, 5751],
+	[0, 2, 0, 0, -0.002069, 0],
+	[2, -2, -1, 0, 0.002048, -4950],
+	[2, 0, 1, -2, -0.001773, 4130],
+	[2, 0, 0, 2, -0.001595, 0],
+	[4, -1, -1, 0, 0.001215, -3958],
+	[0, 0, 2, 2, -0.00111, 0],
+	[3, 0, -1, 0, -0.000892, 3258],
+	[2, 1, 1, 0, -0.00081, 2616],
+	[4, -1, -2, 0, 0.000759, -1897],
+	[0, 2, -1, 0, -0.000713, -2117],
+	[2, 2, -1, 0, -0.0007, 2354],
+	[2, 1, -2, 0, 0.000691, 0],
+	[2, -1, 0, -2, 0.000596, 0],
+	[4, 0, 1, 0, 0.000549, -1423],
+	[0, 0, 4, 0, 0.000537, -1117],
+	[4, -1, 0, 0, 0.00052, -1571],
+	[1, 0, -2, 0, -0.000487, -1739],
+	[2, 1, 0, -2, -0.000399, 0],
+	[0, 0, 2, -2, -0.000381, -4421],
+	[1, 1, 1, 0, 0.000351, 0],
+	[3, 0, -2, 0, -0.00034, 0],
+	[4, 0, -3, 0, 0.00033, 0],
+	[2, -1, 2, 0, 0.000327, 0],
+	[0, 2, 1, 0, -0.000323, 1165],
+	[1, 1, -1, 0, 0.000299, 0],
+	[2, 0, 3, 0, 0.000294, 0],
+	[2, 0, -1, -2, 0, 8752],
+] as const
+
+const TB = [
+	// number of D in argument
+	// M
+	// M'
+	// F
+	// coefficient of B sine argument (deg)
+	[0, 0, 0, 1, 5.128122],
+	[0, 0, 1, 1, 0.280602],
+	[0, 0, 1, -1, 0.277693],
+	[2, 0, 0, -1, 0.173237],
+	[2, 0, -1, 1, 0.055413],
+	[2, 0, -1, -1, 0.046271],
+	[2, 0, 0, 1, 0.032573],
+	[0, 0, 2, 1, 0.017198],
+	[2, 0, 1, -1, 0.009266],
+	[0, 0, 2, -1, 0.008822],
+	[2, -1, 0, -1, 0.008216],
+	[2, 0, -2, -1, 0.004324],
+	[2, 0, 1, 1, 0.0042],
+	[2, 1, 0, -1, -0.003359],
+	[2, -1, -1, 1, 0.002463],
+	[2, -1, 0, 1, 0.002211],
+	[2, -1, -1, -1, 0.002065],
+	[0, 1, -1, -1, -0.00187],
+	[4, 0, -1, -1, 0.001828],
+	[0, 1, 0, 1, -0.001794],
+	[0, 0, 0, 3, -0.001749],
+	[0, 1, -1, 1, -0.001565],
+	[1, 0, 0, 1, -0.001491],
+	[0, 1, 1, 1, -0.001475],
+	[0, 1, 1, -1, -0.00141],
+	[0, 1, 0, -1, -0.001344],
+	[1, 0, 0, -1, -0.001335],
+	[0, 0, 3, 1, 0.001107],
+	[4, 0, 0, -1, 0.001021],
+	[4, 0, -1, 1, 0.000833],
+	[0, 0, 1, -3, 0.000777],
+	[4, 0, -2, 1, 0.000671],
+	[2, 0, 0, -3, 0.000607],
+	[2, 0, 2, -1, 0.000596],
+	[2, -1, 1, -1, 0.000491],
+	[2, 0, -2, 1, -0.000451],
+	[0, 0, 3, -1, 0.000439],
+	[2, 0, 2, 1, 0.000422],
+	[2, 0, -3, -1, 0.000421],
+	[2, 1, -1, 1, -0.000366],
+	[2, 1, 0, 1, -0.000351],
+	[4, 0, 0, 1, 0.000331],
+	[2, -1, 1, 1, 0.000315],
+	[2, -2, 0, -1, 0.000302],
+	[0, 0, 1, 3, -0.000283],
+	[2, 1, 1, -1, -0.000229],
+	[1, 1, 0, -1, 0.000223],
+	[1, 1, 0, 1, 0.000223],
+	[0, 1, -2, -1, -0.00022],
+	[2, 1, -1, -1, -0.00022],
+	[1, 0, 1, 1, -0.000185],
+	[2, -1, -2, -1, 0.000181],
+	[0, 1, 2, 1, -0.000177],
+	[4, 0, -2, -1, 0.000176],
+	[4, -1, -1, -1, 0.000166],
+	[1, 0, 1, -1, -0.000164],
+	[4, 0, 1, -1, 0.000132],
+	[1, 0, -1, -1, -0.000119],
+	[4, -1, 0, -1, 0.000115],
+	[2, -2, 0, 1, 0.000107],
+] as const
+
+// Approximate geocentric position and velocity of the Moon.
+export function eraMoon98(tt1: number, tt2: number) {
+	// Centuries since J2000.0
+	const T = (tt1 - J2000 + tt2) / DAYSPERJC
+
+	// Moon's mean longitude.
+	const ELP = normalizeAngle(ELP0 + (ELP1 + (ELP2 + (ELP3 + ELP4 * T) * T) * T) * T)
+	const DELP = ELP1 + (ELP2 * 2 + (ELP3 * 3 + ELP4 * 4 * T) * T) * T
+
+	// Moon's mean elongation.
+	const D = normalizeAngle(D0 + (D1 + (D2 + (D3 + D4 * T) * T) * T) * T)
+	const DD = D1 + (D2 * 2 + (D3 * 3 + D4 * 4 * T) * T) * T
+
+	// Sun's mean anomaly.
+	const EM = normalizeAngle(EM0 + (EM1 + (EM2 + (EM3 + EM4 * T) * T) * T) * T)
+	const DEM = EM1 + (EM2 * 2 + (EM3 * 3 + EM4 * 4 * T) * T) * T
+
+	// Moon's mean anomaly.
+	const EMP = normalizeAngle(EMP0 + (EMP1 + (EMP2 + (EMP3 + EMP4 * T) * T) * T) * T)
+	const DEMP = EMP1 + (EMP2 * 2 + (EMP3 * 3 + EMP4 * 4 * T) * T) * T
+
+	// Mean distance of the Moon from its ascending node.
+	const F = normalizeAngle(F0 + (F1 + (F2 + (F3 + F4 * T) * T) * T) * T)
+	const DF = F1 + (F2 * 2 + (F3 * 3 + F4 * 4 * T) * T) * T
+
+	// Meeus further arguments.
+	const A1 = A10 + A11 * T
+	const DA1 = AL1 * DEG2RAD
+	const A2 = A20 + A21 * T
+	const DA2 = A21
+	const A3 = A30 + A31 * T
+	const DA3 = A31
+
+	// E-factor, and square.
+	const E = 1 + (E1 + E2 * T) * T
+	const DE = E1 + 2 * E2 * T
+	const ESQ = E * E
+	const DESQ = 2 * E * DE
+
+	// Use the Meeus additive terms (deg) to start off the summations.
+	const ELPMF = ELP - F
+	const DELPMF = DELP - DF
+	let VEL = AL1 * Math.sin(A1) + AL2 * Math.sin(ELPMF) + AL3 * Math.sin(A2)
+	let VDEL = AL1 * Math.cos(A1) * DA1 + AL2 * Math.cos(ELPMF) * DELPMF + AL3 * Math.cos(A2) * DA2
+
+	let VR = 0
+	let VDR = 0
+
+	const A1MF = A1 - F
+	const DA1MF = DA1 - DF
+	const A1PF = A1 + F
+	const DA1PF = DA1 + DF
+	const DLPMP = ELP - EMP
+	const SLPMP = ELP + EMP
+
+	let VB = AB1 * Math.sin(ELP) + AB2 * Math.sin(A3) + AB3 * Math.sin(A1MF) + AB4 * Math.sin(A1PF) + AB5 * Math.sin(DLPMP) + AB6 * Math.sin(SLPMP)
+	let VDB = AB1 * Math.cos(ELP) * DELP + AB2 * Math.cos(A3) * DA3 + AB3 * Math.cos(A1MF) * DA1MF + AB4 * Math.cos(A1PF) * DA1PF + AB5 * Math.cos(DLPMP) * (DELP - DEMP) + AB6 * Math.cos(SLPMP) * (DELP + DEMP)
+
+	let EN = 0
+	let DEN = 0
+
+	// Longitude and distance plus derivatives.
+	for (let n = TLR.length - 1; n >= 0; n--) {
+		const [nd, nem, nemp, nf, coefl, coefr] = TLR[n]
+		const DN = nd
+		const I = nem
+		const EMN = I
+		const EMPN = nemp
+		const FN = nf
+
+		switch (Math.abs(I)) {
+			case 1:
+				EN = E
+				DEN = DE
+				break
+			case 2:
+				EN = ESQ
+				DEN = DESQ
+				break
+			default:
+				EN = 1
+				DEN = 0
+		}
+
+		const ARG = DN * D + EMN * EM + EMPN * EMP + FN * F
+		const DARG = DN * DD + EMN * DEM + EMPN * DEMP + FN * DF
+		let FARG = Math.sin(ARG)
+		let V = FARG * EN
+		let DV = Math.cos(ARG) * DARG * EN + FARG * DEN
+		VEL += coefl * V
+		VDEL += coefl * DV
+		FARG = Math.cos(ARG)
+		V = FARG * EN
+		DV = -Math.sin(ARG) * DARG * EN + FARG * DEN
+		VR += coefr * V
+		VDR += coefr * DV
+	}
+
+	const EL = ELP + VEL * DEG2RAD
+	const DEL = (DELP + VDEL * DEG2RAD) / DAYSPERJC
+	const R = (VR + R0) / AU_M
+	const DR = VDR / AU_M / DAYSPERJC
+
+	let B = 0
+	let DB = 0
+
+	// Latitude plus derivative.
+	for (let n = TB.length - 1; n >= 0; n--) {
+		const [nd, nem, nemp, nf, coefb] = TB[n]
+		const DN = nd
+		const I = nem
+		const EMN = I
+		const EMPN = nemp
+		const FN = nf
+
+		switch (Math.abs(I)) {
+			case 1:
+				EN = E
+				DEN = DE
+				break
+			case 2:
+				EN = ESQ
+				DEN = DESQ
+				break
+			default:
+				EN = 1
+				DEN = 0
+		}
+
+		const ARG = DN * D + EMN * EM + EMPN * EMP + FN * F
+		const DARG = DN * DD + EMN * DEM + EMPN * DEMP + FN * DF
+		const FARG = Math.sin(ARG)
+		const V = FARG * EN
+		const DV = Math.cos(ARG) * DARG * EN + FARG * DEN
+		VB += coefb * V
+		VDB += coefb * DV
+	}
+
+	B = VB * DEG2RAD
+	DB = (VDB * DEG2RAD) / DAYSPERJC
+
+	// Longitude, latitude to x, y, z (au)
+	const PV = eraS2pv(EL, B, R, DEL, DB, DR)
+
+	// IAU 2006 Fukushima-Williams bias+precession angles.
+	const [gamb, phib, psib] = eraPfw06(tt1, tt2)
+
+	// Mean ecliptic coordinates to GCRS rotation matrix.
+	const RM = matRotZ(-gamb, matRotX(-phib, matRotZ(psib)))
+
+	matMulVec(RM, PV[0], PV[0])
+	matMulVec(RM, PV[1], PV[1])
+
+	return PV
+}

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -406,6 +406,69 @@ function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, a
 	return false
 }
 
+// Whether the topocentric Moon stays at or above the horizon across the ENTIRE interval [fromJd, toJd].
+//
+// "Entire eclipse visible" cannot be decided from the contact samples alone: every contact can be above the
+// horizon while the Moon still dips below it between contacts (a high-latitude lower culmination during the
+// several-hour penumbral interval). The altitude has at most one interior extremum over a phase interval (its
+// hour-angle span is well under a full turn), so the minimum is at an endpoint or at the single lower
+// culmination; a golden-section minimum search (bracketed around the lowest precomputed sample) finds it and
+// returns false as soon as any evaluated altitude is below the horizon.
+//   scan: precomputed penumbral-interval samples, used to reject an obvious below-horizon sample and to bracket.
+//   altFrom, altTo: topocentric Moon altitudes at the endpoints (already resolved on the contact events).
+function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
+	if (altFrom < horizonAltitude || altTo < horizonAltitude) return false
+	if (!(toJd > fromJd)) return true
+
+	// Lowest precomputed sample strictly inside: a below-horizon one settles it; otherwise it brackets the
+	// continuous minimum (which lies within one step of the lowest sample for an at-most-one-extremum altitude).
+	let lowIndex = -1
+	let lowAltitude = Infinity
+	for (let i = 0; i < scan.jds.length; i++) {
+		if (scan.jds[i] <= fromJd || scan.jds[i] >= toJd) continue
+		if (scan.altitudes[i] < horizonAltitude) return false
+		if (scan.altitudes[i] < lowAltitude) {
+			lowAltitude = scan.altitudes[i]
+			lowIndex = i
+		}
+	}
+
+	let lo = fromJd
+	let hi = toJd
+	if (lowIndex >= 0 && scan.step > 0) {
+		lo = Math.max(fromJd, scan.jds[lowIndex] - scan.step)
+		hi = Math.min(toJd, scan.jds[lowIndex] + scan.step)
+	}
+
+	// Golden-section minimum search, early-exit on a below-horizon point.
+	const altitudeAt = (jd: number) => moonAltitudeAt(timeAtJulianDay(reference, jd), longitude, latitude, getPosition)
+	let c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
+	let d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
+	let fc = altitudeAt(c)
+	let fd = altitudeAt(d)
+	if (fc < horizonAltitude || fd < horizonAltitude) return false
+
+	for (let i = 0; i < PHASE_MAX_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
+		if (fc < fd) {
+			hi = d
+			d = c
+			fd = fc
+			c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
+			fc = altitudeAt(c)
+		} else {
+			lo = c
+			c = d
+			fc = fd
+			d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
+			fd = altitudeAt(d)
+		}
+
+		if (fc < horizonAltitude || fd < horizonAltitude) return false
+	}
+
+	return true
+}
+
 // Builds a Time at a Julian Day, preserving the reference time scale and providers.
 function timeAtJulianDay(reference: Time, julianDay: number) {
 	return timeShift(reference, julianDay - reference.day - reference.fraction)
@@ -444,12 +507,15 @@ export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, lon
 	// penumbral interval it cannot in a sub-interval, so this guard also avoids the extra search cost there.
 	const umbralVisible = penumbralVisible && events.U1 && events.U4 ? phaseReachesHorizon(scan, events.U1.jd, events.U4.jd, events.U1.altitude, events.U4.altitude, longitude, latitude, getSunMoonPosition, horizonAltitude, reference) : false
 	const totalVisible = penumbralVisible && events.U2 && events.U3 ? phaseReachesHorizon(scan, events.U2.jd, events.U3.jd, events.U2.altitude, events.U3.altitude, longitude, latitude, getSunMoonPosition, horizonAltitude, reference) : false
-	const allContactsObservable = contacts.length > 0 && contacts.every((c) => events[c.kind]!.observable)
+
+	// "Entire eclipse visible" requires the Moon to stay above the horizon for the whole [P1, P4] interval, not
+	// merely at the contacts: a high-latitude lower culmination can drop it below the horizon between contacts.
+	const fullyAbove = penumbralVisible && p1 && p4 ? phaseStaysAboveHorizon(scan, p1.jd, p4.jd, p1.altitude, p4.altitude, longitude, latitude, getSunMoonPosition, horizonAltitude, reference) : false
 
 	let kind: LocalLunarEclipseVisibilityKind
 	if (!hasGeometricEclipse) kind = 'notVisible'
 	else if (!penumbralVisible) kind = 'geometricOnlyBelowHorizon'
-	else if (allContactsObservable) kind = 'completelyVisible'
+	else if (fullyAbove) kind = 'completelyVisible'
 	else if (totalVisible) kind = 'totalVisible'
 	else if (umbralVisible) kind = 'partialVisible'
 	else kind = 'penumbralOnlyVisible'

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -761,10 +761,14 @@ function moonDiskOffset(shadowCenterAngle: Angle, ell: number, scale: number, fr
 	return { x: eastSign * scale * ell * Math.sin(angle), y: -scale * ell * Math.cos(angle) }
 }
 
-// Builds the apparent-horizon line and below-horizon band for the selected contact. The horizon sits at the
-// Moon altitude away from the zenith; its distance from the shadow center is scaled by the mean angular size of
-// one Earth radius at the Moon, which is a schematic approximation (the shadow is tiny next to the altitude).
-function buildHorizonShapes(primary: LocalLunarEclipseEvent, options: LocalLunarEclipseViewOptions, cx: number, cy: number, scale: number, eastSign: number): LocalLunarEclipseSvgShape[] {
+// Builds the apparent-horizon line and below-horizon band for the selected contact, anchored at the Moon DISK
+// center (not the shadow center). The horizon sits (altitude - horizonAltitude) below the disk along the zenith
+// direction, so the selected disk is above the band exactly when altitude >= horizonAltitude (matching
+// event.observable), accounting for the disk's own zenith-direction offset from the shadow center. The offset is
+// scaled by the mean angular size of one Earth radius at the Moon, a schematic approximation (the shadow is tiny
+// next to the altitude).
+//   diskCx, diskCy: SVG pixel center of the selected Moon disk.
+function buildHorizonShapes(primary: LocalLunarEclipseEvent, options: LocalLunarEclipseViewOptions, diskCx: number, diskCy: number, scale: number, eastSign: number): LocalLunarEclipseSvgShape[] {
 	// Zenith direction in SVG pixels (y grows downward). In the north frame the zenith is rotated from "up" by
 	// the frame parallactic angle; here the zenith frame keeps it straight up, so the rotation is folded into
 	// the disk angles instead and the horizon is drawn straight.
@@ -772,13 +776,13 @@ function buildHorizonShapes(primary: LocalLunarEclipseEvent, options: LocalLunar
 	const zenithX = eastSign * Math.sin(q)
 	const zenithY = -Math.cos(q)
 
-	// Altitude offset (px) from the shadow center along the zenith direction, measured from the CONFIGURED
-	// horizon (not true altitude 0) so the line matches the observable flag for a raised/obstructed horizon: the
-	// Moon sits above the line exactly when altitude >= horizonAltitude.
+	// Altitude offset (px) from the disk center along the zenith direction, measured from the CONFIGURED horizon
+	// (not true altitude 0) so the line matches the observable flag for a raised/obstructed horizon: the disk
+	// sits above the line exactly when altitude >= horizonAltitude.
 	const horizonAltitude = options.horizonAltitude ?? 0
 	const offsetPx = clamp(((primary.altitude - horizonAltitude) / MEAN_EARTH_RADIUS_ANGULAR_AT_MOON) * scale, -Math.hypot(options.width, options.height) * 2, Math.hypot(options.width, options.height) * 2)
-	const horizonX = cx - offsetPx * zenithX
-	const horizonY = cy - offsetPx * zenithY
+	const horizonX = diskCx - offsetPx * zenithX
+	const horizonY = diskCy - offsetPx * zenithY
 
 	const tangentX = -zenithY
 	const tangentY = zenithX
@@ -835,12 +839,21 @@ export function computeLocalLunarEclipseViewGeometry(circumstances: Pick<LocalLu
 	const primary = selectPrimaryEvent(events, resolved.selectedEvent)
 	const frameParallactic = primary ? primary.positionAngle - primary.zenithAngle : 0
 
+	// Selected disk center: the horizon must be anchored here (not at the shadow center) so the band agrees with
+	// the contact's observable flag despite the disk's own zenith-direction offset from the shadow center.
+	let primaryDiskCenter: Point = { x: cx, y: cy }
+	if (primary) {
+		const ell = contactShadowDistance(primary.kind, eclipse.u, eclipse.gamma)
+		const offset = moonDiskOffset(eventShadowCenterAngle(primary, eclipse.type), ell, scale, frameParallactic, resolved.orientationMode, eastSign)
+		primaryDiskCenter = { x: cx + offset.x, y: cy + offset.y }
+	}
+
 	const shapes: LocalLunarEclipseSvgShape[] = []
 
 	// Below-horizon band first (painted behind), then shadow rings, ghosts, trajectory, primary disk, then the
 	// horizon line on top.
 	if (resolved.includeHorizon && primary) {
-		shapes.push(buildHorizonShapes(primary, resolved, cx, cy, scale, eastSign)[0])
+		shapes.push(buildHorizonShapes(primary, resolved, primaryDiskCenter.x, primaryDiskCenter.y, scale, eastSign)[0])
 	}
 
 	shapes.push({ kind: 'circle', role: 'penumbra', cx, cy, r: penumbraRadiusPx })
@@ -873,14 +886,12 @@ export function computeLocalLunarEclipseViewGeometry(circumstances: Pick<LocalLu
 	}
 
 	if (primary) {
-		const ell = contactShadowDistance(primary.kind, eclipse.u, eclipse.gamma)
-		const offset = moonDiskOffset(eventShadowCenterAngle(primary, eclipse.type), ell, scale, frameParallactic, resolved.orientationMode, eastSign)
-		shapes.push({ kind: 'circle', role: 'moonDisk', event: primary.kind, cx: cx + offset.x, cy: cy + offset.y, r: moonRadiusPx })
+		shapes.push({ kind: 'circle', role: 'moonDisk', event: primary.kind, cx: primaryDiskCenter.x, cy: primaryDiskCenter.y, r: moonRadiusPx })
 	}
 
 	// Horizon line on top of the disks, so the ground occludes the part of the diagram below it.
 	if (resolved.includeHorizon && primary) {
-		shapes.push(buildHorizonShapes(primary, resolved, cx, cy, scale, eastSign)[1])
+		shapes.push(buildHorizonShapes(primary, resolved, primaryDiskCenter.x, primaryDiskCenter.y, scale, eastSign)[1])
 	}
 
 	return {

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -71,10 +71,12 @@ export interface LocalLunarEclipseEvent {
 	readonly altitude: Angle
 	// Topocentric apparent Moon azimuth (radians) at the contact, measured from North through East, in [0, TAU).
 	readonly azimuth: Angle
-	// Position angle of the Earth-shadow center on the lunar disk, from celestial north toward east, in
-	// [0, TAU). This is the P angle of the contact tables.
+	// Position angle of the limb CONTACT point on the lunar disk, from celestial north toward east, in
+	// [0, TAU). This is the P angle of the contact tables: the Earth-shadow-center direction at the external
+	// contacts (P1/U1/U4/P4), and its opposite (shadow center + PI) at the U2/U3 internal tangency of a total
+	// eclipse, where the limb touches the umbra on the far side of the disk.
 	readonly positionAngle: Angle
-	// Same direction in the local zenith-oriented frame (Z = P - parallacticAngle), in [0, TAU).
+	// Same CONTACT-point direction in the local zenith-oriented frame (Z = P - parallacticAngle), in [0, TAU).
 	readonly zenithAngle: Angle
 	// Umbral magnitude at the contact. 0 at U1/U4, 1 at U2/U3, the eclipse magnitude at MAX; negative when the
 	// Moon is wholly outside the umbra (e.g. at the penumbral contacts P1/P4).
@@ -146,6 +148,13 @@ function positionAngleBetween(ra1: Angle, dec1: Angle, ra2: Angle, dec2: Angle) 
 	const y = Math.cos(dec2) * sinDRA
 	const x = Math.cos(dec1) * Math.sin(dec2) - Math.sin(dec1) * Math.cos(dec2) * cosDRA
 	return normalizeAngle(Math.atan2(y, x))
+}
+
+// Whether the contact is the internal (totality) tangency U2/U3 of a total eclipse. There the lunar limb is
+// tangent to the umbra from the inside, so the limb contact point lies on the far side of the disk from the
+// Earth-shadow center; the external contacts (P1/U1/U4/P4) touch on the shadow-center side instead.
+function isInternalTangencyContact(kind: LunarEclipseContactKind, type: LunarEclipse['type']) {
+	return type === 'TOTAL' && (kind === 'U2' || kind === 'U3')
 }
 
 // |shadow-axis distance| (plane Earth radii) of the Moon at one contact, fixed by the contact kind in the
@@ -229,10 +238,13 @@ function computeLocalEvent(contact: LunarEclipseContact, eclipse: LunarEclipse, 
 	const [topoRA, topoDEC] = moonTopocentric(moonRA, moonDEC, position.moon.distance, latitude, lst)
 	const [azimuth, altitude] = equatorialToHorizontal(topoRA, topoDEC, latitude, lst)
 
-	// Earth-shadow center = antisolar point. Its position angle on the lunar disk is the table P angle.
+	// Earth-shadow center = antisolar point; positionAngleBetween gives the shadow-center direction on the
+	// lunar disk. The reported P angle is the limb CONTACT-point angle: the shadow-center direction at the
+	// external contacts, flipped by PI at the U2/U3 internal tangency of a total eclipse (far side of the disk).
 	const shadowRA = position.sun.rightAscension + PI
 	const shadowDEC = -position.sun.declination
-	const positionAngle = positionAngleBetween(moonRA, moonDEC, shadowRA, shadowDEC)
+	const shadowCenterAngle = positionAngleBetween(moonRA, moonDEC, shadowRA, shadowDEC)
+	const positionAngle = isInternalTangencyContact(contact.kind, eclipse.type) ? normalizeAngle(shadowCenterAngle + PI) : shadowCenterAngle
 
 	// Lunar parallactic angle converts the celestial-north P angle into the zenith-oriented Z angle.
 	const hourAngle = normalizePI(lst - topoRA)
@@ -536,18 +548,26 @@ function selectPrimaryEvent(events: Partial<Record<LunarEclipseContactKind, Loca
 	return null
 }
 
-// SVG screen offset (px) of a Moon disk from the shadow center. The Moon sits opposite the shadow-center
-// direction (position angle P + PI) at distance ell. In the zenith frame the celestial-north angle is rotated
+// Shadow-center (disk-placement) direction of a resolved event: the reported limb-contact P angle, undoing the
+// U2/U3 internal-tangency flip so the Moon disk is placed by the geometric shadow-center direction, not the
+// contact-point direction.
+function eventShadowCenterAngle(event: LocalLunarEclipseEvent, type: LunarEclipse['type']) {
+	return isInternalTangencyContact(event.kind, type) ? normalizeAngle(event.positionAngle - PI) : event.positionAngle
+}
+
+// SVG screen offset (px) of a Moon disk from the shadow center. The Moon center sits opposite the shadow-center
+// direction (shadowCenterAngle + PI) at distance ell. In the zenith frame the celestial-north angle is rotated
 // by the frame parallactic angle q so the zenith is up; in the north frame q is 0.
-//   event: the contact to place.
+//   shadowCenterAngle: position angle (radians) of the Earth-shadow center as seen from the Moon. This is the
+//   disk-placement direction, distinct from the reported limb-contact P angle (which is flipped at U2/U3).
 //   ell: shadow-axis distance (plane Earth radii).
 //   scale: pixels per plane Earth radius.
 //   frameParallactic: parallactic angle (radians) of the frame's selected event, applied in zenith mode.
 //   orientationMode: diagram orientation.
 //   eastSign: +1 for eastRight, -1 for eastLeft.
-function moonDiskOffset(event: LocalLunarEclipseEvent, ell: number, scale: number, frameParallactic: Angle, orientationMode: LocalLunarViewOrientationMode, eastSign: number): Point {
+function moonDiskOffset(shadowCenterAngle: Angle, ell: number, scale: number, frameParallactic: Angle, orientationMode: LocalLunarViewOrientationMode, eastSign: number): Point {
 	const q = orientationMode === 'zenith' ? frameParallactic : 0
-	const angle = event.positionAngle + PI - q
+	const angle = shadowCenterAngle + PI - q
 	return { x: eastSign * scale * ell * Math.sin(angle), y: -scale * ell * Math.cos(angle) }
 }
 
@@ -639,7 +659,7 @@ export function computeLocalLunarEclipseViewGeometry(circumstances: Pick<LocalLu
 		const event = events[kind]
 		if (!event) continue
 		const ell = contactShadowDistance(kind, eclipse.u, eclipse.gamma)
-		const offset = moonDiskOffset(event, ell, scale, frameParallactic, resolved.orientationMode, eastSign)
+		const offset = moonDiskOffset(eventShadowCenterAngle(event, eclipse.type), ell, scale, frameParallactic, resolved.orientationMode, eastSign)
 		trajectory.push({ x: cx + offset.x, y: cy + offset.y })
 	}
 	if (trajectory.length >= 2) {
@@ -654,14 +674,14 @@ export function computeLocalLunarEclipseViewGeometry(circumstances: Pick<LocalLu
 			const event = events[kind]
 			if (!event || event === primary) continue
 			const ell = contactShadowDistance(kind, eclipse.u, eclipse.gamma)
-			const offset = moonDiskOffset(event, ell, scale, frameParallactic, resolved.orientationMode, eastSign)
+			const offset = moonDiskOffset(eventShadowCenterAngle(event, eclipse.type), ell, scale, frameParallactic, resolved.orientationMode, eastSign)
 			shapes.push({ kind: 'circle', role: 'ghostMoonDisk', event: kind, cx: cx + offset.x, cy: cy + offset.y, r: moonRadiusPx })
 		}
 	}
 
 	if (primary) {
 		const ell = contactShadowDistance(primary.kind, eclipse.u, eclipse.gamma)
-		const offset = moonDiskOffset(primary, ell, scale, frameParallactic, resolved.orientationMode, eastSign)
+		const offset = moonDiskOffset(eventShadowCenterAngle(primary, eclipse.type), ell, scale, frameParallactic, resolved.orientationMode, eastSign)
 		shapes.push({ kind: 'circle', role: 'moonDisk', event: primary.kind, cx: cx + offset.x, cy: cy + offset.y, r: moonRadiusPx })
 	}
 

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -1,6 +1,6 @@
 import { type Angle, normalizeAngle, normalizePI } from './angle'
 import { parallacticAngle } from './astrometry'
-import { DAYSEC, PI, WGS84_FLATTENING } from './constants'
+import { DAYSEC, PI, TAU, WGS84_FLATTENING } from './constants'
 import { equatorialToHorizontal } from './coordinate'
 import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
@@ -108,8 +108,9 @@ export interface LocalLunarEclipseDetails {
 	readonly partialPhaseDuration: number | null
 	// Total phase duration U3 - U2 in seconds, or null when there is no total phase.
 	readonly totalPhaseDuration: number | null
-	// Total time (seconds) the Moon is at or above the horizon within the penumbral interval, integrated from
-	// the altitude samples used by the continuous visibility check. Never exceeds penumbralPhaseDuration.
+	// Total time (seconds) the Moon is at or above the horizon within the penumbral interval, integrated from the
+	// continuous visibility samples (refining any interval that may hide a sub-sample horizon crossing, so it
+	// stays consistent with hasObservableEclipse). Never exceeds penumbralPhaseDuration.
 	readonly observableDuration: number
 }
 
@@ -313,32 +314,85 @@ function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude:
 	return { jds, altitudes, step }
 }
 
+// Sidereal Earth rotation rate (radians per day). The diurnal altitude rate is bounded by this, so over one
+// scan step the altitude can change by at most EARTH_ROTATION_RATE_PER_DAY * step: a sample interval whose
+// endpoints are on the same side of the horizon can hide a crossing pair only when an endpoint is within that
+// bound of the horizon.
+const EARTH_ROTATION_RATE_PER_DAY = TAU / 0.99726966
+// Sub-steps used to integrate a suspect interval that may hide a horizon crossing pair.
+const REFINE_SUBSTEPS = 16
+
+// Whether the altitude is monotonic across the window around interval [i, i+1] (its neighbours i-1..i+2). A
+// same-side interval can only hide a horizon crossing pair when it is non-monotonic (an interior extremum pokes
+// across), so this restricts the costly refinement to the at most one turning point of the penumbral scan.
+function isMonotonicWindow(altitudes: number[], i: number) {
+	const lo = Math.max(0, i - 1)
+	const hi = Math.min(altitudes.length - 1, i + 2)
+	let nonDecreasing = true
+	let nonIncreasing = true
+
+	for (let k = lo; k < hi; k++) {
+		if (altitudes[k + 1] > altitudes[k]) nonIncreasing = false
+		if (altitudes[k + 1] < altitudes[k]) nonDecreasing = false
+	}
+
+	return nonDecreasing || nonIncreasing
+}
+
+// Above-horizon time (days) within one suspect sample interval, by subdividing it and summing the linear
+// horizon-crossing fraction of each sub-step. The interval spans at most one scan step, over which the altitude
+// is unimodal, so a fixed subdivision resolves a brief peak above the horizon (or a brief dip below it) that the
+// coarse endpoints alone miss.
+function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, reference: Time) {
+	const dt = (toJd - fromJd) / REFINE_SUBSTEPS
+	let previous = moonAltitudeAt(timeAtJulianDay(reference, fromJd), longitude, latitude, getPosition) - horizonAltitude
+	let days = 0
+
+	for (let k = 1; k <= REFINE_SUBSTEPS; k++) {
+		const current = moonAltitudeAt(timeAtJulianDay(reference, fromJd + k * dt), longitude, latitude, getPosition) - horizonAltitude
+		if (previous >= 0 && current >= 0) days += dt
+		else if (previous < 0 && current < 0) days += 0
+		else {
+			const t = previous / (previous - current)
+			days += (previous >= 0 ? t : 1 - t) * dt
+		}
+		previous = current
+	}
+
+	return days
+}
+
 // Total time (days) the Moon is at or above the horizon within the scanned interval. Each sample interval
 // contributes its above-horizon fraction: 1 when both endpoints are above, 0 when both are below, and the
-// linearly interpolated horizon-crossing fraction otherwise. Integrating intervals (not counting samples)
-// avoids the off-by-one-step overcount of a sample count (the scan has samples + 1 points but step =
-// span / samples); the result is capped at the scanned span so it can never exceed P4 - P1.
-function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle) {
+// linearly interpolated horizon-crossing fraction when they straddle the horizon. A same-side interval whose
+// nearer endpoint is within one step's altitude change of the horizon is refined by subdivision, so a short
+// above-horizon stretch that falls between two coarse samples (the same case phaseReachesHorizon catches for
+// the classification) is integrated rather than dropped to zero. The result is capped at the scanned span so it
+// can never exceed P4 - P1.
+function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, reference: Time) {
 	const { jds, altitudes, step } = scan
 	if (!(step > 0) || altitudes.length < 2) return 0
 
+	// A same-side interval can hide a crossing pair only when an endpoint is within this much of the horizon.
+	const refineMargin = EARTH_ROTATION_RATE_PER_DAY * step
 	let days = 0
 
 	for (let i = 0; i + 1 < altitudes.length; i++) {
 		const a = altitudes[i] - horizonAltitude
 		const b = altitudes[i + 1] - horizonAltitude
 
-		let fraction: number
-		if (a >= 0 && b >= 0) fraction = 1
-		else if (a < 0 && b < 0) fraction = 0
-		// One endpoint above, one below: the crossing is at t = a / (a - b) of the step (a - b != 0 here). The
-		// above-horizon part is [0, t] when starting above, else [t, 1].
-		else {
+		if (a >= 0 === b >= 0) {
+			// Both endpoints on the same side of the horizon: confidently the whole step (above) or nothing
+			// (below), unless an endpoint is within one step's altitude change of the horizon AND the window is
+			// non-monotonic, so a brief excursion across the horizon could hide between the samples; then
+			// integrate the sub-interval.
+			if (Math.min(Math.abs(a), Math.abs(b)) < refineMargin && !isMonotonicWindow(altitudes, i)) days += aboveHorizonDaysInInterval(jds[i], jds[i + 1], horizonAltitude, longitude, latitude, getPosition, reference)
+			else days += a >= 0 ? step : 0
+		} else {
+			// The endpoints straddle the horizon: the crossing is at t = a / (a - b) of the step (a - b != 0).
 			const t = a / (a - b)
-			fraction = a >= 0 ? t : 1 - t
+			days += (a >= 0 ? t : 1 - t) * step
 		}
-
-		days += fraction * step
 	}
 
 	return Math.min(days, jds.at(-1)! - jds[0])
@@ -518,9 +572,10 @@ export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, lon
 	else if (umbralVisible) kind = 'partialVisible'
 	else kind = 'penumbralOnlyVisible'
 
-	// Observable duration: integrate the above-horizon fraction of each sample interval (capped at the scanned
-	// span), so a fully-above eclipse reports exactly P4 - P1 rather than one sample step more.
-	const observableDuration = observableDaysFromScan(scan, horizonAltitude) * DAYSEC
+	// Observable duration: integrate the above-horizon fraction of each sample interval (refining intervals that
+	// may hide a sub-sample horizon crossing, and capped at the scanned span), so it stays consistent with
+	// hasObservableEclipse even when the Moon only rises above the horizon between two coarse samples.
+	const observableDuration = observableDaysFromScan(scan, horizonAltitude, longitude, latitude, getSunMoonPosition, reference) * DAYSEC
 
 	const [, maximalPenumbralMagnitude] = shadowMagnitudes(Math.abs(eclipse.gamma), eclipse.u)
 

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -108,8 +108,8 @@ export interface LocalLunarEclipseDetails {
 	readonly partialPhaseDuration: number | null
 	// Total phase duration U3 - U2 in seconds, or null when there is no total phase.
 	readonly totalPhaseDuration: number | null
-	// Total time (seconds) the Moon is at or above the horizon within the penumbral interval. Approximated from
-	// the altitude samples used by the continuous visibility check.
+	// Total time (seconds) the Moon is at or above the horizon within the penumbral interval, integrated from
+	// the altitude samples used by the continuous visibility check. Never exceeds penumbralPhaseDuration.
 	readonly observableDuration: number
 }
 
@@ -303,6 +303,37 @@ function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude:
 	return { jds, altitudes, step }
 }
 
+// Total time (days) the Moon is at or above the horizon within the scanned interval. Each sample interval
+// contributes its above-horizon fraction: 1 when both endpoints are above, 0 when both are below, and the
+// linearly interpolated horizon-crossing fraction otherwise. Integrating intervals (not counting samples)
+// avoids the off-by-one-step overcount of a sample count (the scan has samples + 1 points but step =
+// span / samples); the result is capped at the scanned span so it can never exceed P4 - P1.
+function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle) {
+	const { jds, altitudes, step } = scan
+	if (!(step > 0) || altitudes.length < 2) return 0
+
+	let days = 0
+
+	for (let i = 0; i + 1 < altitudes.length; i++) {
+		const a = altitudes[i] - horizonAltitude
+		const b = altitudes[i + 1] - horizonAltitude
+
+		let fraction: number
+		if (a >= 0 && b >= 0) fraction = 1
+		else if (a < 0 && b < 0) fraction = 0
+		// One endpoint above, one below: the crossing is at t = a / (a - b) of the step (a - b != 0 here). The
+		// above-horizon part is [0, t] when starting above, else [t, 1].
+		else {
+			const t = a / (a - b)
+			fraction = a >= 0 ? t : 1 - t
+		}
+
+		days += fraction * step
+	}
+
+	return Math.min(days, jds.at(-1)! - jds[0])
+}
+
 // Whether the Moon is at or above the horizon at any sample within [fromJd, toJd].
 function anyAboveDuring(scan: AltitudeScan, fromJd: number, toJd: number, horizonAltitude: Angle) {
 	const { jds, altitudes } = scan
@@ -360,10 +391,9 @@ export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, lon
 	else if (umbralVisible) kind = 'partialVisible'
 	else kind = 'penumbralOnlyVisible'
 
-	// Observable duration: count samples above the horizon, scaled by the sample spacing.
-	let aboveCount = 0
-	for (const altitude of scan.altitudes) if (altitude >= horizonAltitude) aboveCount++
-	const observableDuration = aboveCount * scan.step * DAYSEC
+	// Observable duration: integrate the above-horizon fraction of each sample interval (capped at the scanned
+	// span), so a fully-above eclipse reports exactly P4 - P1 rather than one sample step more.
+	const observableDuration = observableDaysFromScan(scan, horizonAltitude) * DAYSEC
 
 	const [, maximalPenumbralMagnitude] = shadowMagnitudes(Math.abs(eclipse.gamma), eclipse.u)
 

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -1,0 +1,624 @@
+import { type Angle, normalizeAngle, normalizePI } from './angle'
+import { parallacticAngle } from './astrometry'
+import { DAYSEC, PI } from './constants'
+import { equatorialToHorizontal } from './coordinate'
+import { eraGst06a } from './erfa'
+import type { Point } from './geometry'
+import { clamp } from './math'
+import type { LunarEclipse } from './moon'
+import { lunarEclipseEvents, type LunarEclipseContact, type LunarEclipseContactKind } from './moon.eclipse.map'
+import type { SunMoonPosition } from './sun.eclipse.map'
+import { timeShift, tt, type Time } from './time'
+import type { Writable } from './types'
+
+// Local lunar eclipse circumstances and Local View geometry.
+//
+// A lunar eclipse happens on the Moon, so its contact instants (P1..P4) are GLOBAL: every observer shares the
+// same times. Only two things vary with the observer's location: whether the Moon is above the horizon at each
+// contact (and across the phases), and the topocentric Alt/Az and the P/Z orientation angles. This module
+// therefore consumes the already-computed LunarEclipse contact times plus an apparent Sun/Moon position
+// provider, and does not rebuild any global eclipse geometry.
+//
+// Unit conventions: angles in radians; longitude east-positive; latitude geodetic; durations in seconds;
+// times are Time (contact times are TT) or Julian Day.
+
+// Shadow model constants (mirrored from moon.ts so the per-contact magnitudes stay consistent with the
+// contact times computed there). All radii are in equatorial Earth radii projected on the eclipse plane.
+
+// Enlarged umbra contact limit: |shadow-axis distance| at the umbral external contacts U1/U4.
+const LUNAR_ECLIPSE_UMBRA_LIMIT = 1.0128
+// Totality limit: |shadow-axis distance| at the total internal contacts U2/U3.
+const LUNAR_ECLIPSE_TOTAL_LIMIT = 0.4678
+// Enlarged penumbra contact limit: |shadow-axis distance| at the penumbral external contacts P1/P4.
+const LUNAR_ECLIPSE_PENUMBRA_LIMIT = 1.5573
+// Magnitude denominator: twice the lunar plane radius (the Moon spans 0..1 magnitude over 2 * 0.2725).
+const LUNAR_ECLIPSE_MAGNITUDE_DENOMINATOR = 0.545
+// Lunar radius in plane Earth radii (half the magnitude denominator); constant in the Meeus model.
+const MOON_RADIUS_EARTH_RADII = 0.2725
+// Mean angular size (radians) of one Earth equatorial radius seen from the Moon (mean distance ~60.27 Earth
+// radii). Used only to scale the schematic Local View horizon offset; not a precise per-event value.
+const MEAN_EARTH_RADIUS_ANGULAR_AT_MOON: Angle = Math.asin(1 / 60.27)
+
+// Coarse local visibility classification of a lunar eclipse for one observer.
+export type LocalLunarEclipseVisibilityKind = 'notVisible' | 'penumbralOnlyVisible' | 'partialVisible' | 'totalVisible' | 'completelyVisible' | 'geometricOnlyBelowHorizon'
+
+// Apparent Sun/Moon position provider at a dynamical time (TT/TDB), as produced by computeSunMoonPositionAt.
+export type LunarEclipsePositionProvider = (time: Time) => SunMoonPosition
+
+// Options controlling the local circumstances computation.
+export interface LocalLunarEclipseCircumstancesOptions {
+	// Altitude (radians) of the apparent horizon; the Moon is observable when at or above it. Default 0.
+	readonly horizonAltitude?: Angle
+	// Number of altitude samples across the penumbral interval for the continuous visibility check. The check
+	// detects observable stretches even when every contact is below the horizon (e.g. moonrise mid-eclipse).
+	// Default 48 (~7 min spacing for a 6 h eclipse), which resolves any lunar phase comfortably.
+	readonly altitudeSamples?: number
+}
+
+// One resolved local contact event.
+export interface LocalLunarEclipseEvent {
+	// Which contact this is.
+	readonly kind: LunarEclipseContactKind
+	// Instant of the contact (TT).
+	readonly time: Time
+	// Julian Day of the contact.
+	readonly jd: number
+	// Whether the Moon is at or above the configured horizon at the contact.
+	readonly observable: boolean
+	// Apparent Moon altitude (radians) at the contact for this observer.
+	readonly altitude: Angle
+	// Apparent Moon azimuth (radians) at the contact, measured from North through East, in [0, TAU).
+	readonly azimuth: Angle
+	// Position angle of the Earth-shadow center on the lunar disk, from celestial north toward east, in
+	// [0, TAU). This is the P angle of the contact tables.
+	readonly positionAngle: Angle
+	// Same direction in the local zenith-oriented frame (Z = P - parallacticAngle), in [0, TAU).
+	readonly zenithAngle: Angle
+	// Umbral magnitude at the contact. 0 at U1/U4, 1 at U2/U3, the eclipse magnitude at MAX; negative when the
+	// Moon is wholly outside the umbra (e.g. at the penumbral contacts P1/P4).
+	readonly umbralMagnitude: number
+	// Penumbral magnitude at the contact. 0 at P1/P4.
+	readonly penumbralMagnitude: number
+}
+
+// Coarse local visibility summary.
+export interface LocalLunarEclipseVisibility {
+	// Classification kind.
+	readonly kind: LocalLunarEclipseVisibilityKind
+	// Human-readable description of the classification.
+	readonly text: string
+	// Whether the eclipse touches the Moon geometrically (always true for a real eclipse, regardless of horizon).
+	readonly hasGeometricEclipse: boolean
+	// Whether any part of the eclipse is observable with the Moon at or above the configured horizon (true even
+	// when every contact is below the horizon but the Moon rises above it between contacts).
+	readonly hasObservableEclipse: boolean
+}
+
+// Maximal magnitudes and phase durations for the local circumstances panel.
+export interface LocalLunarEclipseDetails {
+	// Maximal umbral magnitude (eclipse magnitude for total/partial), or null for a penumbral eclipse.
+	readonly maximalUmbralMagnitude: number | null
+	// Maximal penumbral magnitude at greatest eclipse.
+	readonly maximalPenumbralMagnitude: number
+	// Penumbral-phase duration P4 - P1 in seconds.
+	readonly penumbralPhaseDuration: number
+	// Partial (umbral) phase duration U4 - U1 in seconds, or null when there is no umbral phase.
+	readonly partialPhaseDuration: number | null
+	// Total phase duration U3 - U2 in seconds, or null when there is no total phase.
+	readonly totalPhaseDuration: number | null
+	// Total time (seconds) the Moon is at or above the horizon within the penumbral interval. Approximated from
+	// the altitude samples used by the continuous visibility check.
+	readonly observableDuration: number
+}
+
+// Full local circumstances for one geographic point.
+export interface LocalLunarEclipseCircumstances {
+	readonly location: {
+		// Geographic longitude in radians, east-positive.
+		readonly longitude: Angle
+		// Geodetic latitude in radians.
+		readonly latitude: Angle
+	}
+	// Coarse visibility classification.
+	readonly visibility: LocalLunarEclipseVisibility
+	// Maximal magnitudes and durations.
+	readonly details: LocalLunarEclipseDetails
+	// Resolved per-contact events keyed by contact kind.
+	readonly events: Partial<Record<LunarEclipseContactKind, LocalLunarEclipseEvent>>
+}
+
+// Greenwich apparent sidereal time (radians) at a contact, consistent with the apparent Moon position. The
+// UT1 fraction comes from the dynamical time and the sample Delta T, matching the global engine.
+function contactGast(time: Time, deltaT: number) {
+	const ttTime = tt(time)
+	const ut1Fraction = ttTime.fraction - deltaT / DAYSEC
+	return eraGst06a(ttTime.day, ut1Fraction, ttTime.day, ttTime.fraction)
+}
+
+// Position angle (radians, [0, TAU)) of point 2 as seen from point 1, measured from celestial north toward
+// east. Uses the stable atan2 formulation; the Earth shadow center is the antisolar point.
+function positionAngleBetween(ra1: Angle, dec1: Angle, ra2: Angle, dec2: Angle) {
+	const dRA = ra2 - ra1
+	const sinDRA = Math.sin(dRA)
+	const cosDRA = Math.cos(dRA)
+	const y = Math.cos(dec2) * sinDRA
+	const x = Math.cos(dec1) * Math.sin(dec2) - Math.sin(dec1) * Math.cos(dec2) * cosDRA
+	return normalizeAngle(Math.atan2(y, x))
+}
+
+// |shadow-axis distance| (plane Earth radii) of the Moon at one contact, fixed by the contact kind in the
+// Meeus model: this is what makes the per-contact magnitudes exact (0 at the external contacts, 1 at the
+// total contacts, the eclipse magnitude at MAX).
+//   kind: contact kind.
+//   u: penumbra/umbra enlargement term (eclipse.u).
+//   gamma: least shadow-axis distance at maximum (eclipse.gamma).
+function contactShadowDistance(kind: LunarEclipseContactKind, u: number, gamma: number): number {
+	switch (kind) {
+		case 'P1':
+		case 'P4':
+			return LUNAR_ECLIPSE_PENUMBRA_LIMIT + u
+		case 'U1':
+		case 'U4':
+			return LUNAR_ECLIPSE_UMBRA_LIMIT - u
+		case 'U2':
+		case 'U3':
+			return LUNAR_ECLIPSE_TOTAL_LIMIT - u
+		case 'MAX':
+			return Math.abs(gamma)
+	}
+}
+
+// Umbral and penumbral magnitudes from the shadow-axis distance and enlargement term. Negative values mean the
+// Moon is wholly outside that shadow (kept signed so callers can see how far outside).
+function shadowMagnitudes(shadowDistance: number, u: number): [umbral: number, penumbral: number] {
+	const umbral = (LUNAR_ECLIPSE_UMBRA_LIMIT - u - shadowDistance) / LUNAR_ECLIPSE_MAGNITUDE_DENOMINATOR
+	const penumbral = (LUNAR_ECLIPSE_PENUMBRA_LIMIT + u - shadowDistance) / LUNAR_ECLIPSE_MAGNITUDE_DENOMINATOR
+	return [umbral, penumbral]
+}
+
+// Apparent Moon altitude (radians) at one instant for one observer, from the apparent Moon position and the
+// Greenwich apparent sidereal time. Used by the continuous visibility scan.
+function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider) {
+	const position = getPosition(time)
+	const lst = contactGast(time, position.deltaT ?? 0) + longitude
+	const [, altitude] = equatorialToHorizontal(position.moon.rightAscension, position.moon.declination, latitude, lst)
+	return altitude
+}
+
+// Builds one resolved local event: altitude/azimuth, the P/Z orientation angles, and the per-contact
+// magnitudes.
+function computeLocalEvent(contact: LunarEclipseContact, eclipse: LunarEclipse, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, horizonAltitude: Angle): LocalLunarEclipseEvent {
+	const position = getPosition(contact.time)
+	const gast = contactGast(contact.time, position.deltaT ?? 0)
+	const lst = gast + longitude
+
+	const moonRA = position.moon.rightAscension
+	const moonDec = position.moon.declination
+	const [azimuth, altitude] = equatorialToHorizontal(moonRA, moonDec, latitude, lst)
+
+	// Earth-shadow center = antisolar point. Its position angle on the lunar disk is the table P angle.
+	const shadowRA = position.sun.rightAscension + PI
+	const shadowDec = -position.sun.declination
+	const positionAngle = positionAngleBetween(moonRA, moonDec, shadowRA, shadowDec)
+
+	// Lunar parallactic angle converts the celestial-north P angle into the zenith-oriented Z angle.
+	const hourAngle = normalizePI(lst - moonRA)
+	const q = parallacticAngle(hourAngle, moonDec, latitude)
+	const zenithAngle = normalizeAngle(positionAngle - q)
+
+	const shadowDistance = contactShadowDistance(contact.kind, eclipse.u, eclipse.gamma)
+	const [umbralMagnitude, penumbralMagnitude] = shadowMagnitudes(shadowDistance, eclipse.u)
+
+	return {
+		kind: contact.kind,
+		time: contact.time,
+		jd: contact.jd,
+		observable: altitude >= horizonAltitude,
+		altitude,
+		azimuth,
+		positionAngle,
+		zenithAngle,
+		umbralMagnitude,
+		penumbralMagnitude,
+	}
+}
+
+// Human-readable text for each local visibility classification.
+export function localLunarVisibilityText(kind: LocalLunarEclipseVisibilityKind) {
+	switch (kind) {
+		case 'completelyVisible':
+			return 'Entire eclipse visible'
+		case 'totalVisible':
+			return 'Total phase visible'
+		case 'partialVisible':
+			return 'Partial (umbral) phase visible'
+		case 'penumbralOnlyVisible':
+			return 'Only the penumbral phase visible'
+		case 'geometricOnlyBelowHorizon':
+			return 'Eclipse occurs with the Moon below the horizon'
+		case 'notVisible':
+			return 'Eclipse not visible'
+	}
+}
+
+// Result of the continuous altitude scan across the penumbral interval.
+interface AltitudeScan {
+	// Julian Days of the samples, ascending.
+	readonly jds: number[]
+	// Moon altitudes (radians) at each sample.
+	readonly altitudes: number[]
+	// Sample spacing in days.
+	readonly step: number
+}
+
+// Samples the Moon altitude across the penumbral interval [P1, P4] so the classifier can detect observable
+// stretches between contacts. Returns empty arrays when the interval is degenerate.
+function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, samples: number, reference: Time): AltitudeScan {
+	const jds: number[] = []
+	const altitudes: number[] = []
+	const span = toJd - fromJd
+	if (!(span > 0) || samples < 1) return { jds, altitudes, step: 0 }
+
+	const step = span / samples
+	for (let i = 0; i <= samples; i++) {
+		const jd = fromJd + i * step
+		const time = timeAtJulianDay(reference, jd)
+		jds.push(jd)
+		altitudes.push(moonAltitudeAt(time, longitude, latitude, getPosition))
+	}
+
+	return { jds, altitudes, step }
+}
+
+// Whether the Moon is at or above the horizon at any sample within [fromJd, toJd].
+function anyAboveDuring(scan: AltitudeScan, fromJd: number, toJd: number, horizonAltitude: Angle) {
+	const { jds, altitudes } = scan
+
+	for (let i = 0; i < jds.length; i++) {
+		if (jds[i] < fromJd || jds[i] > toJd) continue
+		if (altitudes[i] >= horizonAltitude) return true
+	}
+
+	return false
+}
+
+// Builds a Time at a Julian Day, preserving the reference time scale and providers.
+function timeAtJulianDay(reference: Time, julianDay: number) {
+	return timeShift(reference, julianDay - reference.day - reference.fraction)
+}
+
+// Computes the full local circumstances of a lunar eclipse for one geographic point.
+//   eclipse: lunar eclipse with its TT contact times, magnitude, u and gamma.
+//   longitude: observer geographic longitude (radians, east-positive).
+//   latitude: observer geodetic latitude (radians).
+//   getSunMoonPosition: apparent Sun/Moon position provider at a dynamical time.
+//   options: horizon altitude and altitude-sampling options.
+export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, longitude: Angle, latitude: Angle, getSunMoonPosition: LunarEclipsePositionProvider, options: LocalLunarEclipseCircumstancesOptions = {}): LocalLunarEclipseCircumstances {
+	const horizonAltitude = options.horizonAltitude ?? 0
+	const samples = options.altitudeSamples ?? 48
+
+	const contacts = lunarEclipseEvents(eclipse)
+	const events: Writable<Partial<Record<LunarEclipseContactKind, LocalLunarEclipseEvent>>> = {}
+
+	for (const contact of contacts) {
+		events[contact.kind] = computeLocalEvent(contact, eclipse, longitude, latitude, getSunMoonPosition, horizonAltitude)
+	}
+
+	const p1 = events.P1
+	const p4 = events.P4
+	const reference = eclipse.maximalTime
+
+	// Continuous altitude scan across the penumbral interval, reused for every phase visibility test.
+	const scan = p1 && p4 ? scanAltitudes(p1.jd, p4.jd, longitude, latitude, getSunMoonPosition, samples, reference) : { jds: [], altitudes: [], step: 0 }
+
+	const hasGeometricEclipse = contacts.length > 0
+	const penumbralVisible = p1 && p4 ? anyAboveDuring(scan, p1.jd, p4.jd, horizonAltitude) : false
+	const hasObservableEclipse = penumbralVisible
+
+	const umbralVisible = events.U1 && events.U4 ? anyAboveDuring(scan, events.U1.jd, events.U4.jd, horizonAltitude) : false
+	const totalVisible = events.U2 && events.U3 ? anyAboveDuring(scan, events.U2.jd, events.U3.jd, horizonAltitude) : false
+	const allContactsObservable = contacts.length > 0 && contacts.every((c) => events[c.kind]!.observable)
+
+	let kind: LocalLunarEclipseVisibilityKind
+	if (!hasGeometricEclipse) kind = 'notVisible'
+	else if (!penumbralVisible) kind = 'geometricOnlyBelowHorizon'
+	else if (allContactsObservable) kind = 'completelyVisible'
+	else if (totalVisible) kind = 'totalVisible'
+	else if (umbralVisible) kind = 'partialVisible'
+	else kind = 'penumbralOnlyVisible'
+
+	// Observable duration: count samples above the horizon, scaled by the sample spacing.
+	let aboveCount = 0
+	for (const altitude of scan.altitudes) if (altitude >= horizonAltitude) aboveCount++
+	const observableDuration = aboveCount * scan.step * DAYSEC
+
+	const [, maximalPenumbralMagnitude] = shadowMagnitudes(Math.abs(eclipse.gamma), eclipse.u)
+
+	const details: LocalLunarEclipseDetails = {
+		maximalUmbralMagnitude: eclipse.type === 'PENUMBRAL' ? null : eclipse.magnitude,
+		maximalPenumbralMagnitude,
+		penumbralPhaseDuration: p1 && p4 ? (p4.jd - p1.jd) * DAYSEC : 0,
+		partialPhaseDuration: events.U1 && events.U4 ? (events.U4.jd - events.U1.jd) * DAYSEC : null,
+		totalPhaseDuration: events.U2 && events.U3 ? (events.U3.jd - events.U2.jd) * DAYSEC : null,
+		observableDuration,
+	}
+
+	return {
+		location: { longitude, latitude },
+		visibility: { kind, text: localLunarVisibilityText(kind), hasGeometricEclipse, hasObservableEclipse },
+		details,
+		events,
+	}
+}
+
+// Local View geometry
+
+// Orientation of the Local View diagram: 'zenith' puts the local zenith up; 'north' puts celestial north up.
+export type LocalLunarViewOrientationMode = 'zenith' | 'north'
+
+// Horizontal handedness: 'eastRight' (default, map-like) puts celestial east to the right; 'eastLeft' mirrors
+// it for the naked-eye / sky-chart convention.
+export type LocalLunarViewHandedness = 'eastRight' | 'eastLeft'
+
+// Options controlling the Local View geometry.
+export interface LocalLunarEclipseViewOptions {
+	// Diagram width in SVG pixels.
+	readonly width: number
+	// Diagram height in SVG pixels.
+	readonly height: number
+	// Contact drawn as the primary (highlighted) state and as the frame reference for the zenith rotation.
+	readonly selectedEvent: LunarEclipseContactKind
+	// Diagram orientation. Only geometry changes; no UI is implied.
+	readonly orientationMode: LocalLunarViewOrientationMode
+	// Horizontal handedness. Defaults to 'eastRight'.
+	readonly handedness?: LocalLunarViewHandedness
+	// Umbra circle radius in SVG pixels; the global scale anchor for the diagram.
+	readonly umbraRadiusPx: number
+	// Whether to draw ghost Moon disks for the non-selected contacts.
+	readonly includeGhostDisks: boolean
+	// Whether to draw the apparent-horizon line and below-horizon band for the selected contact.
+	readonly includeHorizon: boolean
+	// Optional padding (px) for the horizon band polygon.
+	readonly horizonBandPaddingPx?: number
+}
+
+// A circle shape: shadow rings or a Moon disk.
+export interface LocalLunarEclipseSvgCircle {
+	readonly kind: 'circle'
+	// Semantic role.
+	readonly role: 'penumbra' | 'umbra' | 'moonDisk' | 'ghostMoonDisk'
+	// Contact this disk was drawn for (for the Moon disks), so the UI can label it.
+	readonly event?: LunarEclipseContactKind
+	// Center x in SVG pixels.
+	readonly cx: number
+	// Center y in SVG pixels.
+	readonly cy: number
+	// Radius in SVG pixels.
+	readonly r: number
+}
+
+// A straight line: the horizon or a trajectory segment.
+export interface LocalLunarEclipseSvgLine {
+	readonly kind: 'line'
+	readonly role: 'horizonLine'
+	readonly x1: number
+	readonly y1: number
+	readonly x2: number
+	readonly y2: number
+}
+
+// A path: the Moon-center trajectory through the contacts.
+export interface LocalLunarEclipseSvgPath {
+	readonly kind: 'path'
+	readonly role: 'trajectoryPath'
+	// SVG path data string.
+	readonly d: string
+}
+
+// A filled polygon: the below-horizon band.
+export interface LocalLunarEclipseSvgPolygon {
+	readonly kind: 'polygon'
+	readonly role: 'horizonBand'
+	readonly points: readonly Point[]
+}
+
+export type LocalLunarEclipseSvgShape = LocalLunarEclipseSvgCircle | LocalLunarEclipseSvgLine | LocalLunarEclipseSvgPath | LocalLunarEclipseSvgPolygon
+
+// Serializable Local View geometry: plain shapes only, no text and no UI.
+export interface LocalLunarEclipseViewGeometry {
+	// Diagram width in SVG pixels.
+	readonly width: number
+	// Diagram height in SVG pixels.
+	readonly height: number
+	// Orientation frame the geometry was built in.
+	readonly orientationMode: LocalLunarViewOrientationMode
+	// The contact the caller requested as the primary state.
+	readonly requestedEvent: LunarEclipseContactKind
+	// The contact actually drawn as primary: the requested one when available, else MAX, else the first
+	// available contact, or null when no contact exists.
+	readonly selectedEvent: LunarEclipseContactKind | null
+	// Umbra circle radius in SVG pixels.
+	readonly umbraRadiusPx: number
+	// All drawable shapes, in painter order.
+	readonly shapes: readonly LocalLunarEclipseSvgShape[]
+}
+
+// Default Local View options.
+const DEFAULT_LOCAL_LUNAR_VIEW_OPTIONS: LocalLunarEclipseViewOptions = {
+	width: 300,
+	height: 300,
+	selectedEvent: 'MAX',
+	orientationMode: 'zenith',
+	handedness: 'eastRight',
+	umbraRadiusPx: 70,
+	includeGhostDisks: true,
+	includeHorizon: true,
+	horizonBandPaddingPx: 4,
+}
+
+// Chronological contact order used to lay out the trajectory and pick a fallback primary contact.
+const CONTACT_ORDER: readonly LunarEclipseContactKind[] = ['P1', 'U1', 'U2', 'MAX', 'U3', 'U4', 'P4']
+
+// Picks the primary contact: the requested one, else MAX, else the first available.
+function selectPrimaryEvent(events: Partial<Record<LunarEclipseContactKind, LocalLunarEclipseEvent>>, requested: LunarEclipseContactKind) {
+	const requestedEvent = events[requested]
+	if (requestedEvent) return requestedEvent
+	if (events.MAX) return events.MAX
+
+	for (const kind of CONTACT_ORDER) {
+		const event = events[kind]
+		if (event) return event
+	}
+
+	return null
+}
+
+// SVG screen offset (px) of a Moon disk from the shadow center. The Moon sits opposite the shadow-center
+// direction (position angle P + PI) at distance ell. In the zenith frame the celestial-north angle is rotated
+// by the frame parallactic angle q so the zenith is up; in the north frame q is 0.
+//   event: the contact to place.
+//   ell: shadow-axis distance (plane Earth radii).
+//   scale: pixels per plane Earth radius.
+//   frameParallactic: parallactic angle (radians) of the frame's selected event, applied in zenith mode.
+//   orientationMode: diagram orientation.
+//   eastSign: +1 for eastRight, -1 for eastLeft.
+function moonDiskOffset(event: LocalLunarEclipseEvent, ell: number, scale: number, frameParallactic: Angle, orientationMode: LocalLunarViewOrientationMode, eastSign: number): Point {
+	const q = orientationMode === 'zenith' ? frameParallactic : 0
+	const angle = event.positionAngle + PI - q
+	return { x: eastSign * scale * ell * Math.sin(angle), y: -scale * ell * Math.cos(angle) }
+}
+
+// Builds the apparent-horizon line and below-horizon band for the selected contact. The horizon sits at the
+// Moon altitude away from the zenith; its distance from the shadow center is scaled by the mean angular size of
+// one Earth radius at the Moon, which is a schematic approximation (the shadow is tiny next to the altitude).
+function buildHorizonShapes(primary: LocalLunarEclipseEvent, options: LocalLunarEclipseViewOptions, cx: number, cy: number, scale: number, eastSign: number): LocalLunarEclipseSvgShape[] {
+	// Zenith direction in SVG pixels (y grows downward). In the north frame the zenith is rotated from "up" by
+	// the frame parallactic angle; here the zenith frame keeps it straight up, so the rotation is folded into
+	// the disk angles instead and the horizon is drawn straight.
+	const q = options.orientationMode === 'north' ? primary.positionAngle - primary.zenithAngle : 0
+	const zenithX = eastSign * Math.sin(q)
+	const zenithY = -Math.cos(q)
+
+	// Altitude offset (px) from the shadow center along the zenith direction.
+	const offsetPx = clamp((primary.altitude / MEAN_EARTH_RADIUS_ANGULAR_AT_MOON) * scale, -Math.hypot(options.width, options.height) * 2, Math.hypot(options.width, options.height) * 2)
+	const horizonX = cx - offsetPx * zenithX
+	const horizonY = cy - offsetPx * zenithY
+
+	const tangentX = -zenithY
+	const tangentY = zenithX
+	const half = Math.hypot(options.width, options.height)
+	const line: LocalLunarEclipseSvgLine = {
+		kind: 'line',
+		role: 'horizonLine',
+		x1: horizonX - tangentX * half,
+		y1: horizonY - tangentY * half,
+		x2: horizonX + tangentX * half,
+		y2: horizonY + tangentY * half,
+	}
+
+	const padding = options.horizonBandPaddingPx ?? 0
+	const awayX = -zenithX
+	const awayY = -zenithY
+	const near = -padding
+	const far = padding + 4 * half
+	const band: LocalLunarEclipseSvgPolygon = {
+		kind: 'polygon',
+		role: 'horizonBand',
+		points: [
+			{ x: horizonX - tangentX * half + awayX * near, y: horizonY - tangentY * half + awayY * near },
+			{ x: horizonX + tangentX * half + awayX * near, y: horizonY + tangentY * half + awayY * near },
+			{ x: horizonX + tangentX * half + awayX * far, y: horizonY + tangentY * half + awayY * far },
+			{ x: horizonX - tangentX * half + awayX * far, y: horizonY - tangentY * half + awayY * far },
+		],
+	}
+
+	return [band, line]
+}
+
+// Builds the serializable Local View geometry from the resolved circumstances. Emits only geometric shapes: no
+// labels, text or UI. The shadow center is fixed at the diagram center; the Moon disks are placed by their P
+// angle and shadow-axis distance, so the eclipse is read off the disk positions relative to the umbra and
+// penumbra rings.
+//   circumstances: resolved events (from computeLocalLunarEclipseCircumstances) and the eclipse geometry.
+//   eclipse: the lunar eclipse (umbra radius sigma, penumbra radius rho).
+//   options: Local View options.
+export function computeLocalLunarEclipseViewGeometry(circumstances: Pick<LocalLunarEclipseCircumstances, 'events'>, eclipse: LunarEclipse, options: Partial<LocalLunarEclipseViewOptions> = {}): LocalLunarEclipseViewGeometry {
+	const resolved: LocalLunarEclipseViewOptions = { ...DEFAULT_LOCAL_LUNAR_VIEW_OPTIONS, ...options }
+	const events = circumstances.events
+	const cx = resolved.width * 0.5
+	const cy = resolved.height * 0.5
+	const eastSign = resolved.handedness === 'eastLeft' ? -1 : 1
+
+	// Pixels per plane Earth radius, anchored on the umbra radius. Guard a degraded sigma so the rings never
+	// collapse or invert.
+	const umbraRadius = eclipse.sigma > 0 && Number.isFinite(eclipse.sigma) ? eclipse.sigma : LUNAR_ECLIPSE_TOTAL_LIMIT
+	const scale = resolved.umbraRadiusPx / umbraRadius
+	const penumbraRadiusPx = scale * eclipse.rho
+	const moonRadiusPx = scale * MOON_RADIUS_EARTH_RADII
+
+	const primary = selectPrimaryEvent(events, resolved.selectedEvent)
+	const frameParallactic = primary ? primary.positionAngle - primary.zenithAngle : 0
+
+	const shapes: LocalLunarEclipseSvgShape[] = []
+
+	// Below-horizon band first (painted behind), then shadow rings, ghosts, trajectory, primary disk, then the
+	// horizon line on top.
+	if (resolved.includeHorizon && primary) {
+		shapes.push(buildHorizonShapes(primary, resolved, cx, cy, scale, eastSign)[0])
+	}
+
+	shapes.push({ kind: 'circle', role: 'penumbra', cx, cy, r: penumbraRadiusPx })
+	shapes.push({ kind: 'circle', role: 'umbra', cx, cy, r: resolved.umbraRadiusPx })
+
+	// Trajectory through the available contacts, in chronological order.
+	const trajectory: Point[] = []
+	for (const kind of CONTACT_ORDER) {
+		const event = events[kind]
+		if (!event) continue
+		const ell = contactShadowDistance(kind, eclipse.u, eclipse.gamma)
+		const offset = moonDiskOffset(event, ell, scale, frameParallactic, resolved.orientationMode, eastSign)
+		trajectory.push({ x: cx + offset.x, y: cy + offset.y })
+	}
+	if (trajectory.length >= 2) {
+		const tokens: string[] = [`M${formatCoordinate(trajectory[0].x)} ${formatCoordinate(trajectory[0].y)}`]
+		for (let i = 1; i < trajectory.length; i++) tokens.push(`L${formatCoordinate(trajectory[i].x)} ${formatCoordinate(trajectory[i].y)}`)
+		shapes.push({ kind: 'path', role: 'trajectoryPath', d: tokens.join('') })
+	}
+
+	// Ghost Moon disks for the non-selected contacts, drawn before the primary so it sits on top.
+	if (resolved.includeGhostDisks) {
+		for (const kind of CONTACT_ORDER) {
+			const event = events[kind]
+			if (!event || event === primary) continue
+			const ell = contactShadowDistance(kind, eclipse.u, eclipse.gamma)
+			const offset = moonDiskOffset(event, ell, scale, frameParallactic, resolved.orientationMode, eastSign)
+			shapes.push({ kind: 'circle', role: 'ghostMoonDisk', event: kind, cx: cx + offset.x, cy: cy + offset.y, r: moonRadiusPx })
+		}
+	}
+
+	if (primary) {
+		const ell = contactShadowDistance(primary.kind, eclipse.u, eclipse.gamma)
+		const offset = moonDiskOffset(primary, ell, scale, frameParallactic, resolved.orientationMode, eastSign)
+		shapes.push({ kind: 'circle', role: 'moonDisk', event: primary.kind, cx: cx + offset.x, cy: cy + offset.y, r: moonRadiusPx })
+	}
+
+	// Horizon line on top of the disks, so the ground occludes the part of the diagram below it.
+	if (resolved.includeHorizon && primary) {
+		shapes.push(buildHorizonShapes(primary, resolved, cx, cy, scale, eastSign)[1])
+	}
+
+	return {
+		width: resolved.width,
+		height: resolved.height,
+		orientationMode: resolved.orientationMode,
+		requestedEvent: resolved.selectedEvent,
+		selectedEvent: primary ? primary.kind : null,
+		umbraRadiusPx: resolved.umbraRadiusPx,
+		shapes,
+	}
+}
+
+// Formats an SVG coordinate with two decimals, dropping trailing zeros.
+function formatCoordinate(value: number) {
+	return Number(value.toFixed(2)).toString()
+}

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -8,7 +8,7 @@ import { clamp } from './math'
 import type { LunarEclipse } from './moon'
 import { lunarEclipseEvents, type LunarEclipseContact, type LunarEclipseContactKind, MOON_RADIUS_EARTH_RADII } from './moon.eclipse.map'
 import type { SunMoonPosition } from './sun.eclipse.map'
-import { timeShift, tt, type Time } from './time'
+import { timeAtJulianDay, tt, type Time } from './time'
 import type { Writable } from './types'
 
 // Local lunar eclipse circumstances and Local View geometry.
@@ -605,11 +605,6 @@ function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number
 	}
 
 	return true
-}
-
-// Builds a Time at a Julian Day, preserving the reference time scale and providers.
-function timeAtJulianDay(reference: Time, julianDay: number) {
-	return timeShift(reference, julianDay - reference.day - reference.fraction)
 }
 
 // Topocentric Moon altitude (radians) at a Julian Day, preserving the reference time scale and providers.

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -213,8 +213,8 @@ function moonTopocentric(moonRA: Angle, moonDEC: Angle, moonDistance: number, la
 }
 
 // Topocentric apparent Moon altitude (radians) at one instant for one observer. Applies diurnal parallax, then
-// converts to horizontal coordinates. Used by the continuous visibility scan.
-function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider) {
+// converts to horizontal coordinates. Used by the continuous visibility scan and the phase-visibility search.
+export function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider) {
 	const position = getPosition(time)
 	const lst = contactGast(time, position.deltaT ?? 0) + longitude
 	const [topoRA, topoDEC] = moonTopocentric(position.moon.rightAscension, position.moon.declination, position.moon.distance, latitude, lst)
@@ -346,13 +346,61 @@ function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle) {
 	return Math.min(days, jds.at(-1)! - jds[0])
 }
 
-// Whether the Moon is at or above the horizon at any sample within [fromJd, toJd].
-function anyAboveDuring(scan: AltitudeScan, fromJd: number, toJd: number, horizonAltitude: Angle) {
-	const { jds, altitudes } = scan
+// Golden-section iteration cap and minimum interval (days, ~2 s) for the phase-visibility interior search.
+const PHASE_MAX_ITERATIONS = 32
+const PHASE_MIN_SPAN_DAYS = 2 / DAYSEC
+// Reciprocal golden ratio, 1 / phi.
+const INVERSE_GOLDEN_RATIO = (Math.sqrt(5) - 1) / 2
 
-	for (let i = 0; i < jds.length; i++) {
-		if (jds[i] < fromJd || jds[i] > toJd) continue
-		if (altitudes[i] >= horizonAltitude) return true
+// Whether the topocentric Moon altitude reaches the horizon anywhere within [fromJd, toJd].
+//
+// A sample-only test misses a short above-horizon stretch that falls entirely between two fixed samples (a very
+// short total phase, or a grazing high-latitude moonrise/moonset), so this also tests the exact interval
+// endpoints (the phase contacts) and, when every sampled point is below the horizon, searches the interior for
+// the single altitude maximum. The altitude is unimodal over a phase interval (its hour-angle span is well
+// under a full turn, so there is at most one upper transit), so a golden-section search locates that maximum;
+// it returns as soon as any evaluated altitude reaches the horizon.
+//   scan: the precomputed penumbral-interval altitude samples, used only as a cheap interior pre-check.
+//   fromJd, toJd: the phase interval (Julian Days); endpoints are the phase contacts.
+//   altFrom, altTo: topocentric Moon altitudes at the endpoints (already resolved on the contact events).
+//   reference: time-scale reference for building instants from Julian Days.
+function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
+	// Exact phase endpoints first: a short phase whose whole above-horizon stretch is its endpoints is caught here.
+	if (altFrom >= horizonAltitude || altTo >= horizonAltitude) return true
+	if (!(toJd > fromJd)) return false
+
+	// Cheap pre-check: any precomputed sample strictly inside the interval that is already above the horizon.
+	for (let i = 0; i < scan.jds.length; i++) {
+		if (scan.jds[i] <= fromJd || scan.jds[i] >= toJd) continue
+		if (scan.altitudes[i] >= horizonAltitude) return true
+	}
+
+	// Interior maximum search (the altitude is unimodal over the interval): golden-section, early-exit on reach.
+	const altitudeAt = (jd: number) => moonAltitudeAt(timeAtJulianDay(reference, jd), longitude, latitude, getPosition)
+	let lo = fromJd
+	let hi = toJd
+	let c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
+	let d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
+	let fc = altitudeAt(c)
+	let fd = altitudeAt(d)
+	if (fc >= horizonAltitude || fd >= horizonAltitude) return true
+
+	for (let i = 0; i < PHASE_MAX_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
+		if (fc > fd) {
+			hi = d
+			d = c
+			fd = fc
+			c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
+			fc = altitudeAt(c)
+		} else {
+			lo = c
+			c = d
+			fc = fd
+			d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
+			fd = altitudeAt(d)
+		}
+
+		if (fc >= horizonAltitude || fd >= horizonAltitude) return true
 	}
 
 	return false
@@ -384,15 +432,18 @@ export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, lon
 	const p4 = events.P4
 	const reference = eclipse.maximalTime
 
-	// Continuous altitude scan across the penumbral interval, reused for every phase visibility test.
+	// Continuous altitude scan across the penumbral interval, reused for the observable duration and as a cheap
+	// pre-check inside the phase-visibility search.
 	const scan = p1 && p4 ? scanAltitudes(p1.jd, p4.jd, longitude, latitude, getSunMoonPosition, samples, reference) : { jds: [], altitudes: [], step: 0 }
 
 	const hasGeometricEclipse = contacts.length > 0
-	const penumbralVisible = p1 && p4 ? anyAboveDuring(scan, p1.jd, p4.jd, horizonAltitude) : false
+	const penumbralVisible = p1 && p4 ? phaseReachesHorizon(scan, p1.jd, p4.jd, p1.altitude, p4.altitude, longitude, latitude, getSunMoonPosition, horizonAltitude, reference) : false
 	const hasObservableEclipse = penumbralVisible
 
-	const umbralVisible = events.U1 && events.U4 ? anyAboveDuring(scan, events.U1.jd, events.U4.jd, horizonAltitude) : false
-	const totalVisible = events.U2 && events.U3 ? anyAboveDuring(scan, events.U2.jd, events.U3.jd, horizonAltitude) : false
+	// The umbral and total intervals lie inside [P1, P4]: if the Moon never reaches the horizon across the whole
+	// penumbral interval it cannot in a sub-interval, so this guard also avoids the extra search cost there.
+	const umbralVisible = penumbralVisible && events.U1 && events.U4 ? phaseReachesHorizon(scan, events.U1.jd, events.U4.jd, events.U1.altitude, events.U4.altitude, longitude, latitude, getSunMoonPosition, horizonAltitude, reference) : false
+	const totalVisible = penumbralVisible && events.U2 && events.U3 ? phaseReachesHorizon(scan, events.U2.jd, events.U3.jd, events.U2.altitude, events.U3.altitude, longitude, latitude, getSunMoonPosition, horizonAltitude, reference) : false
 	const allContactsObservable = contacts.length > 0 && contacts.every((c) => events[c.kind]!.observable)
 
 	let kind: LocalLunarEclipseVisibilityKind

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -336,30 +336,41 @@ function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude:
 // endpoints are on the same side of the horizon can hide a crossing pair only when an endpoint is within that
 // bound of the horizon.
 const EARTH_ROTATION_RATE_PER_DAY = TAU / 0.99726966
-// Sub-steps used to integrate a suspect interval that may hide a horizon crossing pair.
-const REFINE_SUBSTEPS = 16
 
-// Above-horizon time (days) within one suspect sample interval, by subdividing it and summing the linear
-// horizon-crossing fraction of each sub-step. The interval spans at most one scan step, over which the altitude
-// is unimodal, so a fixed subdivision resolves a brief peak above the horizon (or a brief dip below it) that the
-// coarse endpoints alone miss.
+// Above-horizon time (days) within one suspect sample interval. Both endpoints are on the same side of the horizon
+// (this is only called for same-side intervals), and the interval spans at most one scan step, over which the
+// altitude is unimodal (at most one interior extremum). A hidden above-horizon excursion is therefore either a
+// brief peak above the horizon (both endpoints below) or the whole step minus a brief dip below it (both endpoints
+// above). The interior extremum is bracketed by golden-section and the two horizon roots around it are solved by
+// bisection, so an above-horizon window narrower than any fixed subdivision is still measured exactly (a fixed
+// 16-piece subdivision missed a peak shorter than one sub-step that fell between subdivision points, leaving
+// observableDuration at 0 while phaseReachesHorizon classified the eclipse observable from the same maximum).
 function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, reference: Time) {
-	const dt = (toJd - fromJd) / REFINE_SUBSTEPS
-	let previous = moonAltitudeAt(timeAtJulianDay(reference, fromJd), longitude, latitude, getPosition) - horizonAltitude
-	let days = 0
+	const span = toJd - fromJd
+	if (!(span > 0)) return 0
 
-	for (let k = 1; k <= REFINE_SUBSTEPS; k++) {
-		const current = moonAltitudeAt(timeAtJulianDay(reference, fromJd + k * dt), longitude, latitude, getPosition) - horizonAltitude
-		if (previous >= 0 && current >= 0) days += dt
-		else if (previous < 0 && current < 0) days += 0
-		else {
-			const t = previous / (previous - current)
-			days += (previous >= 0 ? t : 1 - t) * dt
-		}
-		previous = current
+	const altitudeAt = (jd: number) => moonAltitudeAt(timeAtJulianDay(reference, jd), longitude, latitude, getPosition) - horizonAltitude
+	const startsAbove = altitudeAt(fromJd) >= 0
+	const endsAbove = altitudeAt(toJd) >= 0
+
+	// Both endpoints below: the only above-horizon time is a peak that pokes above between them, so seek the
+	// interior maximum. Both endpoints above: the only below-horizon time is a dip, so seek the interior minimum.
+	const seekMaximum = !startsAbove && !endsAbove
+	const extremumJd = goldenSectionExtremum(fromJd, toJd, altitudeAt, seekMaximum)
+
+	if (seekMaximum) {
+		// No peak reaches the horizon: nothing is above. Otherwise the peak is bracketed by a rise and a set root.
+		if (altitudeAt(extremumJd) < 0) return 0
+		const rise = bisectHorizonCrossing(fromJd, extremumJd, altitudeAt)
+		const set = bisectHorizonCrossing(extremumJd, toJd, altitudeAt)
+		return set - rise
 	}
 
-	return days
+	// No dip reaches the horizon: the whole step is above. Otherwise subtract the bracketed below-horizon window.
+	if (altitudeAt(extremumJd) >= 0) return span
+	const set = bisectHorizonCrossing(fromJd, extremumJd, altitudeAt)
+	const rise = bisectHorizonCrossing(extremumJd, toJd, altitudeAt)
+	return span - (rise - set)
 }
 
 // Total time (days) the Moon is at or above the horizon within the scanned interval. Each sample interval
@@ -369,9 +380,10 @@ function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitud
 // A same-side interval can still hide a horizon crossing pair (a brief peak above the horizon, or a brief dip
 // below it). Because the altitude is unimodal over the penumbral interval (its hour-angle span is well under a
 // full turn, so it has at most one interior extremum), such a hidden excursion can only sit at that extremum,
-// i.e. in an interval touching the highest or lowest sample. Those intervals are refined by subdivision when an
-// endpoint is within one step's altitude change of the horizon; this catches a stretch that falls between two
-// coarse samples even when the surrounding samples are monotonic, without scanning every near-horizon interval.
+// i.e. in an interval touching the highest or lowest sample. Those intervals are refined (the interior extremum
+// bracketed and its horizon roots solved) when an endpoint is within one step's altitude change of the horizon;
+// this catches a stretch that falls between two coarse samples even when the surrounding samples are monotonic,
+// without scanning every near-horizon interval.
 // The result is capped at the scanned span so it can never exceed P4 - P1.
 function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, reference: Time) {
 	const { jds, altitudes, step } = scan
@@ -417,6 +429,60 @@ const PHASE_MAX_ITERATIONS = 32
 const PHASE_MIN_SPAN_DAYS = 2 / DAYSEC
 // Reciprocal golden ratio, 1 / phi.
 const INVERSE_GOLDEN_RATIO = 0.61803398874989484820458683436564 // (Math.sqrt(5) - 1) / 2
+// Bisection cap for a horizon-crossing root; combined with the PHASE_MIN_SPAN_DAYS (~2 s) span guard it converges
+// well under one second for any realistic scan step.
+const HORIZON_ROOT_ITERATIONS = 40
+
+// Abscissa of the single interior extremum of a unimodal function f over [lo, hi], by golden-section. seekMaximum
+// selects the maximum; otherwise the minimum. Used to bracket a hidden horizon excursion inside one scan step.
+//   lo, hi: search bounds (Julian Days), lo < hi.
+//   f: unimodal function over [lo, hi].
+//   seekMaximum: true to locate the maximum, false for the minimum.
+function goldenSectionExtremum(lo: number, hi: number, f: (jd: number) => number, seekMaximum: boolean) {
+	let c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
+	let d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
+	let fc = f(c)
+	let fd = f(d)
+
+	for (let i = 0; i < PHASE_MAX_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
+		// Keep the bracket on the side of the better candidate (higher for a maximum, lower for a minimum).
+		if (seekMaximum ? fc > fd : fc < fd) {
+			hi = d
+			d = c
+			fd = fc
+			c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
+			fc = f(c)
+		} else {
+			lo = c
+			c = d
+			fc = fd
+			d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
+			fd = f(d)
+		}
+	}
+
+	return (lo + hi) / 2
+}
+
+// Julian Day of the horizon crossing within [lo, hi] where altitudeAt changes sign, by bisection. Requires
+// altitudeAt(lo) and altitudeAt(hi) to straddle zero (opposite signs); returns the bracket midpoint on convergence.
+//   altitudeAt: topocentric altitude minus the horizon (signed) at a Julian Day.
+function bisectHorizonCrossing(lo: number, hi: number, altitudeAt: (jd: number) => number) {
+	let loBelow = altitudeAt(lo) < 0
+
+	for (let i = 0; i < HORIZON_ROOT_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
+		const mid = (lo + hi) / 2
+		const midBelow = altitudeAt(mid) < 0
+		if (midBelow === loBelow) {
+			lo = mid
+			loBelow = midBelow
+		} else {
+			hi = mid
+		}
+	}
+
+	return (lo + hi) / 2
+}
 
 // Whether the topocentric Moon altitude reaches the horizon anywhere within [fromJd, toJd].
 //

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -322,23 +322,6 @@ const EARTH_ROTATION_RATE_PER_DAY = TAU / 0.99726966
 // Sub-steps used to integrate a suspect interval that may hide a horizon crossing pair.
 const REFINE_SUBSTEPS = 16
 
-// Whether the altitude is monotonic across the window around interval [i, i+1] (its neighbours i-1..i+2). A
-// same-side interval can only hide a horizon crossing pair when it is non-monotonic (an interior extremum pokes
-// across), so this restricts the costly refinement to the at most one turning point of the penumbral scan.
-function isMonotonicWindow(altitudes: number[], i: number) {
-	const lo = Math.max(0, i - 1)
-	const hi = Math.min(altitudes.length - 1, i + 2)
-	let nonDecreasing = true
-	let nonIncreasing = true
-
-	for (let k = lo; k < hi; k++) {
-		if (altitudes[k + 1] > altitudes[k]) nonIncreasing = false
-		if (altitudes[k + 1] < altitudes[k]) nonDecreasing = false
-	}
-
-	return nonDecreasing || nonIncreasing
-}
-
 // Above-horizon time (days) within one suspect sample interval, by subdividing it and summing the linear
 // horizon-crossing fraction of each sub-step. The interval spans at most one scan step, over which the altitude
 // is unimodal, so a fixed subdivision resolves a brief peak above the horizon (or a brief dip below it) that the
@@ -364,14 +347,27 @@ function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitud
 
 // Total time (days) the Moon is at or above the horizon within the scanned interval. Each sample interval
 // contributes its above-horizon fraction: 1 when both endpoints are above, 0 when both are below, and the
-// linearly interpolated horizon-crossing fraction when they straddle the horizon. A same-side interval whose
-// nearer endpoint is within one step's altitude change of the horizon is refined by subdivision, so a short
-// above-horizon stretch that falls between two coarse samples (the same case phaseReachesHorizon catches for
-// the classification) is integrated rather than dropped to zero. The result is capped at the scanned span so it
-// can never exceed P4 - P1.
+// linearly interpolated horizon-crossing fraction when they straddle the horizon.
+//
+// A same-side interval can still hide a horizon crossing pair (a brief peak above the horizon, or a brief dip
+// below it). Because the altitude is unimodal over the penumbral interval (its hour-angle span is well under a
+// full turn, so it has at most one interior extremum), such a hidden excursion can only sit at that extremum,
+// i.e. in an interval touching the highest or lowest sample. Those intervals are refined by subdivision when an
+// endpoint is within one step's altitude change of the horizon; this catches a stretch that falls between two
+// coarse samples even when the surrounding samples are monotonic, without scanning every near-horizon interval.
+// The result is capped at the scanned span so it can never exceed P4 - P1.
 function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, reference: Time) {
 	const { jds, altitudes, step } = scan
 	if (!(step > 0) || altitudes.length < 2) return 0
+
+	// Highest and lowest samples: the single interior extremum (where a hidden crossing pair can sit) lies within
+	// one step of one of them.
+	let highest = 0
+	let lowest = 0
+	for (let i = 1; i < altitudes.length; i++) {
+		if (altitudes[i] > altitudes[highest]) highest = i
+		if (altitudes[i] < altitudes[lowest]) lowest = i
+	}
 
 	// A same-side interval can hide a crossing pair only when an endpoint is within this much of the horizon.
 	const refineMargin = EARTH_ROTATION_RATE_PER_DAY * step
@@ -383,10 +379,11 @@ function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, long
 
 		if (a >= 0 === b >= 0) {
 			// Both endpoints on the same side of the horizon: confidently the whole step (above) or nothing
-			// (below), unless an endpoint is within one step's altitude change of the horizon AND the window is
-			// non-monotonic, so a brief excursion across the horizon could hide between the samples; then
+			// (below), unless this interval touches the extremum sample and an endpoint is within one step's
+			// altitude change of the horizon, so a brief excursion across it could hide between the samples; then
 			// integrate the sub-interval.
-			if (Math.min(Math.abs(a), Math.abs(b)) < refineMargin && !isMonotonicWindow(altitudes, i)) days += aboveHorizonDaysInInterval(jds[i], jds[i + 1], horizonAltitude, longitude, latitude, getPosition, reference)
+			const touchesExtremum = i === highest || i + 1 === highest || i === lowest || i + 1 === lowest
+			if (touchesExtremum && Math.min(Math.abs(a), Math.abs(b)) < refineMargin) days += aboveHorizonDaysInInterval(jds[i], jds[i + 1], horizonAltitude, longitude, latitude, getPosition, reference)
 			else days += a >= 0 ? step : 0
 		} else {
 			// The endpoints straddle the horizon: the crossing is at t = a / (a - b) of the step (a - b != 0).

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -214,8 +214,8 @@ function moonTopocentric(moonRA: Angle, moonDEC: Angle, moonDistance: number, la
 
 // Topocentric apparent Moon altitude (radians) at one instant for one observer. Applies diurnal parallax, then
 // converts to horizontal coordinates. Used by the continuous visibility scan and the phase-visibility search.
-export function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider) {
-	const position = getPosition(time)
+export function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider) {
+	const position = sunMoonPosition(time)
 	const lst = contactGast(time, position.deltaT ?? 0) + longitude
 	const [topoRA, topoDEC] = moonTopocentric(position.moon.rightAscension, position.moon.declination, position.moon.distance, latitude, lst)
 	const [, altitude] = equatorialToHorizontal(topoRA, topoDEC, latitude, lst)
@@ -224,8 +224,8 @@ export function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, ge
 
 // Builds one resolved local event: altitude/azimuth, the P/Z orientation angles, and the per-contact
 // magnitudes.
-function computeLocalEvent(contact: LunarEclipseContact, eclipse: LunarEclipse, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, horizonAltitude: Angle): LocalLunarEclipseEvent {
-	const position = getPosition(contact.time)
+function computeLocalEvent(contact: LunarEclipseContact, eclipse: LunarEclipse, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, horizonAltitude: Angle): LocalLunarEclipseEvent {
+	const position = sunMoonPosition(contact.time)
 	const gast = contactGast(contact.time, position.deltaT ?? 0)
 	const lst = gast + longitude
 
@@ -311,21 +311,28 @@ function normalizeAltitudeSamples(value: number | undefined) {
 	return Math.min(Math.max(Math.floor(value), 1), MAX_ALTITUDE_SAMPLES)
 }
 
+// Normalizes a public horizon-altitude option to a finite angular threshold in radians. Non-finite values fall
+// back to the geometric horizon so NaN/Infinity cannot leak into observability, duration, or SVG geometry.
+function normalizeHorizonAltitude(value: Angle | undefined) {
+	return value !== undefined && Number.isFinite(value) ? value : 0
+}
+
 // Samples the Moon altitude across the penumbral interval [P1, P4] so the classifier can detect observable
 // stretches between contacts. Returns empty arrays when the interval is degenerate. Expects samples to be a
 // finite positive integer (see normalizeAltitudeSamples).
-function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, samples: number, reference: Time): AltitudeScan {
-	const jds: number[] = []
-	const altitudes: number[] = []
+function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, samples: number, reference: Time): AltitudeScan {
 	const span = toJd - fromJd
-	if (!(span > 0) || samples < 1) return { jds, altitudes, step: 0 }
+	if (!(span > 0) || samples < 1) return { jds: [], altitudes: [], step: 0 }
 
 	const step = span / samples
+	const count = samples + 1
+	const jds = new Array<number>(count)
+	const altitudes = new Array<number>(count)
+
 	for (let i = 0; i <= samples; i++) {
 		const jd = fromJd + i * step
-		const time = timeAtJulianDay(reference, jd)
-		jds.push(jd)
-		altitudes.push(moonAltitudeAt(time, longitude, latitude, getPosition))
+		jds[i] = jd
+		altitudes[i] = moonAltitudeAtJulianDay(jd, reference, longitude, latitude, sunMoonPosition)
 	}
 
 	return { jds, altitudes, step }
@@ -345,31 +352,30 @@ const EARTH_ROTATION_RATE_PER_DAY = TAU / 0.99726966
 // bisection, so an above-horizon window narrower than any fixed subdivision is still measured exactly (a fixed
 // 16-piece subdivision missed a peak shorter than one sub-step that fell between subdivision points, leaving
 // observableDuration at 0 while phaseReachesHorizon classified the eclipse observable from the same maximum).
-function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, reference: Time) {
+function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time) {
 	const span = toJd - fromJd
 	if (!(span > 0)) return 0
 
-	const altitudeAt = (jd: number) => moonAltitudeAt(timeAtJulianDay(reference, jd), longitude, latitude, getPosition) - horizonAltitude
-	const startsAbove = altitudeAt(fromJd) >= 0
-	const endsAbove = altitudeAt(toJd) >= 0
+	const startsAbove = altitudeOffsetAtJulianDay(fromJd, horizonAltitude, reference, longitude, latitude, sunMoonPosition) >= 0
+	const endsAbove = altitudeOffsetAtJulianDay(toJd, horizonAltitude, reference, longitude, latitude, sunMoonPosition) >= 0
 
 	// Both endpoints below: the only above-horizon time is a peak that pokes above between them, so seek the
 	// interior maximum. Both endpoints above: the only below-horizon time is a dip, so seek the interior minimum.
 	const seekMaximum = !startsAbove && !endsAbove
-	const extremumJd = goldenSectionExtremum(fromJd, toJd, altitudeAt, seekMaximum)
+	const extremumJd = goldenSectionAltitudeExtremum(fromJd, toJd, longitude, latitude, sunMoonPosition, reference, seekMaximum)
 
 	if (seekMaximum) {
 		// No peak reaches the horizon: nothing is above. Otherwise the peak is bracketed by a rise and a set root.
-		if (altitudeAt(extremumJd) < 0) return 0
-		const rise = bisectHorizonCrossing(fromJd, extremumJd, altitudeAt)
-		const set = bisectHorizonCrossing(extremumJd, toJd, altitudeAt)
+		if (altitudeOffsetAtJulianDay(extremumJd, horizonAltitude, reference, longitude, latitude, sunMoonPosition) < 0) return 0
+		const rise = bisectHorizonCrossing(fromJd, extremumJd, horizonAltitude, longitude, latitude, sunMoonPosition, reference)
+		const set = bisectHorizonCrossing(extremumJd, toJd, horizonAltitude, longitude, latitude, sunMoonPosition, reference)
 		return set - rise
 	}
 
 	// No dip reaches the horizon: the whole step is above. Otherwise subtract the bracketed below-horizon window.
-	if (altitudeAt(extremumJd) >= 0) return span
-	const set = bisectHorizonCrossing(fromJd, extremumJd, altitudeAt)
-	const rise = bisectHorizonCrossing(extremumJd, toJd, altitudeAt)
+	if (altitudeOffsetAtJulianDay(extremumJd, horizonAltitude, reference, longitude, latitude, sunMoonPosition) >= 0) return span
+	const set = bisectHorizonCrossing(fromJd, extremumJd, horizonAltitude, longitude, latitude, sunMoonPosition, reference)
+	const rise = bisectHorizonCrossing(extremumJd, toJd, horizonAltitude, longitude, latitude, sunMoonPosition, reference)
 	return span - (rise - set)
 }
 
@@ -385,7 +391,7 @@ function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitud
 // this catches a stretch that falls between two coarse samples even when the surrounding samples are monotonic,
 // without scanning every near-horizon interval.
 // The result is capped at the scanned span so it can never exceed P4 - P1.
-function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, reference: Time) {
+function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time) {
 	const { jds, altitudes, step } = scan
 	if (!(step > 0) || altitudes.length < 2) return 0
 
@@ -412,7 +418,7 @@ function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, long
 			// altitude change of the horizon, so a brief excursion across it could hide between the samples; then
 			// integrate the sub-interval.
 			const touchesExtremum = i === highest || i + 1 === highest || i === lowest || i + 1 === lowest
-			if (touchesExtremum && Math.min(Math.abs(a), Math.abs(b)) < refineMargin) days += aboveHorizonDaysInInterval(jds[i], jds[i + 1], horizonAltitude, longitude, latitude, getPosition, reference)
+			if (touchesExtremum && Math.min(Math.abs(a), Math.abs(b)) < refineMargin) days += aboveHorizonDaysInInterval(jds[i], jds[i + 1], horizonAltitude, longitude, latitude, sunMoonPosition, reference)
 			else days += a >= 0 ? step : 0
 		} else {
 			// The endpoints straddle the horizon: the crossing is at t = a / (a - b) of the step (a - b != 0).
@@ -433,16 +439,18 @@ const INVERSE_GOLDEN_RATIO = 0.61803398874989484820458683436564 // (Math.sqrt(5)
 // well under one second for any realistic scan step.
 const HORIZON_ROOT_ITERATIONS = 40
 
-// Abscissa of the single interior extremum of a unimodal function f over [lo, hi], by golden-section. seekMaximum
-// selects the maximum; otherwise the minimum. Used to bracket a hidden horizon excursion inside one scan step.
+// Abscissa of the single interior extremum of the topocentric Moon altitude over [lo, hi], by golden-section.
+// seekMaximum selects the maximum; otherwise the minimum. Used to bracket hidden horizon excursions without
+// allocating a per-call altitude closure in the refinement path.
 //   lo, hi: search bounds (Julian Days), lo < hi.
-//   f: unimodal function over [lo, hi].
+//   longitude, latitude: observer position in radians, east-positive longitude and geodetic latitude.
+//   reference: time-scale reference for building instants from Julian Days.
 //   seekMaximum: true to locate the maximum, false for the minimum.
-function goldenSectionExtremum(lo: number, hi: number, f: (jd: number) => number, seekMaximum: boolean) {
+function goldenSectionAltitudeExtremum(lo: number, hi: number, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time, seekMaximum: boolean) {
 	let c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
 	let d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
-	let fc = f(c)
-	let fd = f(d)
+	let fc = moonAltitudeAtJulianDay(c, reference, longitude, latitude, sunMoonPosition)
+	let fd = moonAltitudeAtJulianDay(d, reference, longitude, latitude, sunMoonPosition)
 
 	for (let i = 0; i < PHASE_MAX_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
 		// Keep the bracket on the side of the better candidate (higher for a maximum, lower for a minimum).
@@ -451,13 +459,13 @@ function goldenSectionExtremum(lo: number, hi: number, f: (jd: number) => number
 			d = c
 			fd = fc
 			c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
-			fc = f(c)
+			fc = moonAltitudeAtJulianDay(c, reference, longitude, latitude, sunMoonPosition)
 		} else {
 			lo = c
 			c = d
 			fc = fd
 			d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
-			fd = f(d)
+			fd = moonAltitudeAtJulianDay(d, reference, longitude, latitude, sunMoonPosition)
 		}
 	}
 
@@ -466,13 +474,13 @@ function goldenSectionExtremum(lo: number, hi: number, f: (jd: number) => number
 
 // Julian Day of the horizon crossing within [lo, hi] where altitudeAt changes sign, by bisection. Requires
 // altitudeAt(lo) and altitudeAt(hi) to straddle zero (opposite signs); returns the bracket midpoint on convergence.
-//   altitudeAt: topocentric altitude minus the horizon (signed) at a Julian Day.
-function bisectHorizonCrossing(lo: number, hi: number, altitudeAt: (jd: number) => number) {
-	let loBelow = altitudeAt(lo) < 0
+//   horizonAltitude: topocentric horizon threshold in radians.
+function bisectHorizonCrossing(lo: number, hi: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time) {
+	let loBelow = altitudeOffsetAtJulianDay(lo, horizonAltitude, reference, longitude, latitude, sunMoonPosition) < 0
 
 	for (let i = 0; i < HORIZON_ROOT_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
 		const mid = (lo + hi) / 2
-		const midBelow = altitudeAt(mid) < 0
+		const midBelow = altitudeOffsetAtJulianDay(mid, horizonAltitude, reference, longitude, latitude, sunMoonPosition) < 0
 		if (midBelow === loBelow) {
 			lo = mid
 			loBelow = midBelow
@@ -496,7 +504,7 @@ function bisectHorizonCrossing(lo: number, hi: number, altitudeAt: (jd: number) 
 //   fromJd, toJd: the phase interval (Julian Days); endpoints are the phase contacts.
 //   altFrom, altTo: topocentric Moon altitudes at the endpoints (already resolved on the contact events).
 //   reference: time-scale reference for building instants from Julian Days.
-function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
+function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
 	// Exact phase endpoints first: a short phase whose whole above-horizon stretch is its endpoints is caught here.
 	if (altFrom >= horizonAltitude || altTo >= horizonAltitude) return true
 	if (!(toJd > fromJd)) return false
@@ -508,13 +516,12 @@ function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, a
 	}
 
 	// Interior maximum search (the altitude is unimodal over the interval): golden-section, early-exit on reach.
-	const altitudeAt = (jd: number) => moonAltitudeAt(timeAtJulianDay(reference, jd), longitude, latitude, getPosition)
 	let lo = fromJd
 	let hi = toJd
 	let c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
 	let d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
-	let fc = altitudeAt(c)
-	let fd = altitudeAt(d)
+	let fc = moonAltitudeAtJulianDay(c, reference, longitude, latitude, sunMoonPosition)
+	let fd = moonAltitudeAtJulianDay(d, reference, longitude, latitude, sunMoonPosition)
 	if (fc >= horizonAltitude || fd >= horizonAltitude) return true
 
 	for (let i = 0; i < PHASE_MAX_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
@@ -523,13 +530,13 @@ function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, a
 			d = c
 			fd = fc
 			c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
-			fc = altitudeAt(c)
+			fc = moonAltitudeAtJulianDay(c, reference, longitude, latitude, sunMoonPosition)
 		} else {
 			lo = c
 			c = d
 			fc = fd
 			d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
-			fd = altitudeAt(d)
+			fd = moonAltitudeAtJulianDay(d, reference, longitude, latitude, sunMoonPosition)
 		}
 
 		if (fc >= horizonAltitude || fd >= horizonAltitude) return true
@@ -548,7 +555,7 @@ function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, a
 // returns false as soon as any evaluated altitude is below the horizon.
 //   scan: precomputed penumbral-interval samples, used to reject an obvious below-horizon sample and to bracket.
 //   altFrom, altTo: topocentric Moon altitudes at the endpoints (already resolved on the contact events).
-function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
+function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
 	if (altFrom < horizonAltitude || altTo < horizonAltitude) return false
 	if (!(toJd > fromJd)) return true
 
@@ -573,11 +580,10 @@ function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number
 	}
 
 	// Golden-section minimum search, early-exit on a below-horizon point.
-	const altitudeAt = (jd: number) => moonAltitudeAt(timeAtJulianDay(reference, jd), longitude, latitude, getPosition)
 	let c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
 	let d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
-	let fc = altitudeAt(c)
-	let fd = altitudeAt(d)
+	let fc = moonAltitudeAtJulianDay(c, reference, longitude, latitude, sunMoonPosition)
+	let fd = moonAltitudeAtJulianDay(d, reference, longitude, latitude, sunMoonPosition)
 	if (fc < horizonAltitude || fd < horizonAltitude) return false
 
 	for (let i = 0; i < PHASE_MAX_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
@@ -586,13 +592,13 @@ function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number
 			d = c
 			fd = fc
 			c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
-			fc = altitudeAt(c)
+			fc = moonAltitudeAtJulianDay(c, reference, longitude, latitude, sunMoonPosition)
 		} else {
 			lo = c
 			c = d
 			fc = fd
 			d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
-			fd = altitudeAt(d)
+			fd = moonAltitudeAtJulianDay(d, reference, longitude, latitude, sunMoonPosition)
 		}
 
 		if (fc < horizonAltitude || fd < horizonAltitude) return false
@@ -606,6 +612,20 @@ function timeAtJulianDay(reference: Time, julianDay: number) {
 	return timeShift(reference, julianDay - reference.day - reference.fraction)
 }
 
+// Topocentric Moon altitude (radians) at a Julian Day, preserving the reference time scale and providers.
+//   julianDay: sample instant as a Julian Day.
+//   reference: time-scale reference used to construct the sample Time.
+//   longitude, latitude: observer position in radians, east-positive longitude and geodetic latitude.
+function moonAltitudeAtJulianDay(julianDay: number, reference: Time, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider) {
+	return moonAltitudeAt(timeAtJulianDay(reference, julianDay), longitude, latitude, sunMoonPosition)
+}
+
+// Signed topocentric Moon altitude relative to a horizon threshold at a Julian Day. Positive means observable.
+//   horizonAltitude: observer's horizon threshold in radians.
+function altitudeOffsetAtJulianDay(julianDay: number, horizonAltitude: Angle, reference: Time, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider) {
+	return moonAltitudeAtJulianDay(julianDay, reference, longitude, latitude, sunMoonPosition) - horizonAltitude
+}
+
 // Computes the full local circumstances of a lunar eclipse for one geographic point.
 //   eclipse: lunar eclipse with its TT contact times, magnitude, u and gamma.
 //   longitude: observer geographic longitude (radians, east-positive).
@@ -613,7 +633,7 @@ function timeAtJulianDay(reference: Time, julianDay: number) {
 //   getSunMoonPosition: apparent Sun/Moon position provider at a dynamical time.
 //   options: horizon altitude and altitude-sampling options.
 export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, longitude: Angle, latitude: Angle, getSunMoonPosition: LunarEclipsePositionProvider, options: LocalLunarEclipseCircumstancesOptions = {}): LocalLunarEclipseCircumstances {
-	const horizonAltitude = options.horizonAltitude ?? 0
+	const horizonAltitude = normalizeHorizonAltitude(options.horizonAltitude)
 	const samples = normalizeAltitudeSamples(options.altitudeSamples)
 
 	const contacts = lunarEclipseEvents(eclipse)
@@ -845,14 +865,15 @@ function buildHorizonShapes(primary: LocalLunarEclipseEvent, options: LocalLunar
 	// Altitude offset (px) from the disk center along the zenith direction, measured from the CONFIGURED horizon
 	// (not true altitude 0) so the line matches the observable flag for a raised/obstructed horizon: the disk
 	// sits above the line exactly when altitude >= horizonAltitude.
-	const horizonAltitude = options.horizonAltitude ?? 0
-	const offsetPx = clamp(((primary.altitude - horizonAltitude) / MEAN_EARTH_RADIUS_ANGULAR_AT_MOON) * scale, -Math.hypot(options.width, options.height) * 2, Math.hypot(options.width, options.height) * 2)
+	const horizonAltitude = normalizeHorizonAltitude(options.horizonAltitude)
+	const half = Math.hypot(options.width, options.height)
+	const maxOffsetPx = half * 2
+	const offsetPx = clamp(((primary.altitude - horizonAltitude) / MEAN_EARTH_RADIUS_ANGULAR_AT_MOON) * scale, -maxOffsetPx, maxOffsetPx)
 	const horizonX = diskCx - offsetPx * zenithX
 	const horizonY = diskCy - offsetPx * zenithY
 
 	const tangentX = -zenithY
 	const tangentY = zenithX
-	const half = Math.hypot(options.width, options.height)
 	const line: LocalLunarEclipseSvgLine = {
 		kind: 'line',
 		role: 'horizonLine',
@@ -907,20 +928,21 @@ export function computeLocalLunarEclipseViewGeometry(circumstances: Pick<LocalLu
 
 	// Selected disk center: the horizon must be anchored here (not at the shadow center) so the band agrees with
 	// the contact's observable flag despite the disk's own zenith-direction offset from the shadow center.
-	let primaryDiskCenter: Point = { x: cx, y: cy }
+	let primaryDiskX = cx
+	let primaryDiskY = cy
 	if (primary) {
 		const ell = contactShadowDistance(primary.kind, eclipse.u, eclipse.gamma)
 		const offset = moonDiskOffset(eventShadowCenterAngle(primary, eclipse.type), ell, scale, frameParallactic, resolved.orientationMode, eastSign)
-		primaryDiskCenter = { x: cx + offset.x, y: cy + offset.y }
+		primaryDiskX = cx + offset.x
+		primaryDiskY = cy + offset.y
 	}
 
 	const shapes: LocalLunarEclipseSvgShape[] = []
+	const horizonShapes = resolved.includeHorizon && primary ? buildHorizonShapes(primary, resolved, primaryDiskX, primaryDiskY, scale, eastSign) : undefined
 
 	// Below-horizon band first (painted behind), then shadow rings, ghosts, trajectory, primary disk, then the
 	// horizon line on top.
-	if (resolved.includeHorizon && primary) {
-		shapes.push(buildHorizonShapes(primary, resolved, primaryDiskCenter.x, primaryDiskCenter.y, scale, eastSign)[0])
-	}
+	if (horizonShapes) shapes.push(horizonShapes[0])
 
 	shapes.push({ kind: 'circle', role: 'penumbra', cx, cy, r: penumbraRadiusPx })
 	shapes.push({ kind: 'circle', role: 'umbra', cx, cy, r: resolved.umbraRadiusPx })
@@ -952,13 +974,11 @@ export function computeLocalLunarEclipseViewGeometry(circumstances: Pick<LocalLu
 	}
 
 	if (primary) {
-		shapes.push({ kind: 'circle', role: 'moonDisk', event: primary.kind, cx: primaryDiskCenter.x, cy: primaryDiskCenter.y, r: moonRadiusPx })
+		shapes.push({ kind: 'circle', role: 'moonDisk', event: primary.kind, cx: primaryDiskX, cy: primaryDiskY, r: moonRadiusPx })
 	}
 
 	// Horizon line on top of the disks, so the ground occludes the part of the diagram below it.
-	if (resolved.includeHorizon && primary) {
-		shapes.push(buildHorizonShapes(primary, resolved, primaryDiskCenter.x, primaryDiskCenter.y, scale, eastSign)[1])
-	}
+	if (horizonShapes) shapes.push(horizonShapes[1])
 
 	return {
 		width: resolved.width,

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -6,7 +6,7 @@ import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
 import { clamp } from './math'
 import type { LunarEclipse } from './moon'
-import { lunarEclipseEvents, type LunarEclipseContact, type LunarEclipseContactKind } from './moon.eclipse.map'
+import { lunarEclipseEvents, type LunarEclipseContact, type LunarEclipseContactKind, MOON_RADIUS_EARTH_RADII } from './moon.eclipse.map'
 import type { SunMoonPosition } from './sun.eclipse.map'
 import { timeShift, tt, type Time } from './time'
 import type { Writable } from './types'
@@ -33,8 +33,6 @@ const LUNAR_ECLIPSE_TOTAL_LIMIT = 0.4678
 const LUNAR_ECLIPSE_PENUMBRA_LIMIT = 1.5573
 // Magnitude denominator: twice the lunar plane radius (the Moon spans 0..1 magnitude over 2 * 0.2725).
 const LUNAR_ECLIPSE_MAGNITUDE_DENOMINATOR = 0.545
-// Lunar radius in plane Earth radii (half the magnitude denominator); constant in the Meeus model.
-const MOON_RADIUS_EARTH_RADII = 0.2725
 // Mean angular size (radians) of one Earth equatorial radius seen from the Moon (mean distance ~60.27 Earth
 // radii). Used only to scale the schematic Local View horizon offset; not a precise per-event value.
 const MEAN_EARTH_RADIUS_ANGULAR_AT_MOON: Angle = Math.asin(1 / 60.27)

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -51,7 +51,8 @@ export interface LocalLunarEclipseCircumstancesOptions {
 	readonly horizonAltitude?: Angle
 	// Number of altitude samples across the penumbral interval for the continuous visibility check. The check
 	// detects observable stretches even when every contact is below the horizon (e.g. moonrise mid-eclipse).
-	// Default 48 (~7 min spacing for a 6 h eclipse), which resolves any lunar phase comfortably.
+	// Default 48 (~7 min spacing for a 6 h eclipse), which resolves any lunar phase comfortably. Normalized to a
+	// finite positive integer (fractional values floored, non-finite values replaced by the default, capped).
 	readonly altitudeSamples?: number
 }
 
@@ -295,8 +296,24 @@ interface AltitudeScan {
 	readonly step: number
 }
 
+// Default number of altitude samples across the penumbral interval for the continuous visibility scan.
+const DEFAULT_ALTITUDE_SAMPLES = 48
+// Safety ceiling on the requested sample count, so a pathological value cannot make the scan effectively
+// unbounded (each sample is one apparent-position evaluation).
+const MAX_ALTITUDE_SAMPLES = 100000
+
+// Normalizes the public altitudeSamples option to a finite positive integer in [1, MAX_ALTITUDE_SAMPLES]. A
+// fractional value is floored (48.5 would otherwise make scanAltitudes stop one step short of P4 and under-report
+// the observable duration); a non-finite or undefined value uses the default (Infinity would otherwise loop
+// forever, NaN would skip the scan entirely).
+function normalizeAltitudeSamples(value: number | undefined) {
+	if (value === undefined || !Number.isFinite(value)) return DEFAULT_ALTITUDE_SAMPLES
+	return Math.min(Math.max(Math.floor(value), 1), MAX_ALTITUDE_SAMPLES)
+}
+
 // Samples the Moon altitude across the penumbral interval [P1, P4] so the classifier can detect observable
-// stretches between contacts. Returns empty arrays when the interval is degenerate.
+// stretches between contacts. Returns empty arrays when the interval is degenerate. Expects samples to be a
+// finite positive integer (see normalizeAltitudeSamples).
 function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider, samples: number, reference: Time): AltitudeScan {
 	const jds: number[] = []
 	const altitudes: number[] = []
@@ -531,7 +548,7 @@ function timeAtJulianDay(reference: Time, julianDay: number) {
 //   options: horizon altitude and altitude-sampling options.
 export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, longitude: Angle, latitude: Angle, getSunMoonPosition: LunarEclipsePositionProvider, options: LocalLunarEclipseCircumstancesOptions = {}): LocalLunarEclipseCircumstances {
 	const horizonAltitude = options.horizonAltitude ?? 0
-	const samples = options.altitudeSamples ?? 48
+	const samples = normalizeAltitudeSamples(options.altitudeSamples)
 
 	const contacts = lunarEclipseEvents(eclipse)
 	const events: Writable<Partial<Record<LunarEclipseContactKind, LocalLunarEclipseEvent>>> = {}

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -572,6 +572,11 @@ export interface LocalLunarEclipseViewOptions {
 	readonly includeHorizon: boolean
 	// Optional padding (px) for the horizon band polygon.
 	readonly horizonBandPaddingPx?: number
+	// Apparent-horizon altitude (radians) the diagram is drawn against: the horizon line is placed at this
+	// altitude, so a Moon disk is drawn above it exactly when altitude >= horizonAltitude (matching the event's
+	// observable flag). Pass the same value used for the circumstances so an obstructed horizon (e.g. 10 deg)
+	// stays consistent with observability. Default 0 (the true horizon).
+	readonly horizonAltitude?: Angle
 }
 
 // A circle shape: shadow rings or a Moon disk.
@@ -646,6 +651,7 @@ const DEFAULT_LOCAL_LUNAR_VIEW_OPTIONS: LocalLunarEclipseViewOptions = {
 	includeGhostDisks: true,
 	includeHorizon: true,
 	horizonBandPaddingPx: 4,
+	horizonAltitude: 0,
 }
 
 // Chronological contact order used to lay out the trajectory and pick a fallback primary contact.
@@ -699,8 +705,11 @@ function buildHorizonShapes(primary: LocalLunarEclipseEvent, options: LocalLunar
 	const zenithX = eastSign * Math.sin(q)
 	const zenithY = -Math.cos(q)
 
-	// Altitude offset (px) from the shadow center along the zenith direction.
-	const offsetPx = clamp((primary.altitude / MEAN_EARTH_RADIUS_ANGULAR_AT_MOON) * scale, -Math.hypot(options.width, options.height) * 2, Math.hypot(options.width, options.height) * 2)
+	// Altitude offset (px) from the shadow center along the zenith direction, measured from the CONFIGURED
+	// horizon (not true altitude 0) so the line matches the observable flag for a raised/obstructed horizon: the
+	// Moon sits above the line exactly when altitude >= horizonAltitude.
+	const horizonAltitude = options.horizonAltitude ?? 0
+	const offsetPx = clamp(((primary.altitude - horizonAltitude) / MEAN_EARTH_RADIUS_ANGULAR_AT_MOON) * scale, -Math.hypot(options.width, options.height) * 2, Math.hypot(options.width, options.height) * 2)
 	const horizonX = cx - offsetPx * zenithX
 	const horizonY = cy - offsetPx * zenithY
 

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -6,9 +6,9 @@ import type { SunMoonProvider } from './eclipse'
 import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
 import { clamp } from './math'
-import type { LunarEclipse } from './moon'
+import { nearestLunarEclipse, type LunarEclipse } from './moon'
 import { lunarEclipseEvents, type LunarEclipseContact, type LunarEclipseContactKind, MOON_RADIUS_EARTH_RADII } from './moon.eclipse.map'
-import { timeAtJulianDay, tt, type Time } from './time'
+import { timeAtJulianDay, toJulianDay, tt, type Time } from './time'
 import type { Writable } from './types'
 
 // Local lunar eclipse circumstances and Local View geometry.
@@ -686,6 +686,54 @@ export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, lon
 		details,
 		events,
 	}
+}
+
+// One eclipse in a listLocalLunarEclipses result.
+export interface LocalLunarEclipseListEntry {
+	// The eclipse as returned by nearestLunarEclipse (global circumstances: contact times, type, gamma, magnitude).
+	readonly eclipse: LunarEclipse
+	// Full local circumstances at the location (visibility, magnitudes, durations, per-contact events), already
+	// computed during the visibility filter so the caller never recomputes them.
+	readonly circumstances: LocalLunarEclipseCircumstances
+}
+
+// Lists the lunar eclipses whose maximal time falls in (startTime, endTime] that are observable from the location.
+//
+// A lunar eclipse is global - it happens on the Moon, so every observer shares its contact times - and the only
+// locality is whether the Moon is above the configured horizon during the eclipse. Eclipses are enumerated with
+// nearestLunarEclipse, walking forward one eclipse per step (the Meeus series is cheap), and each candidate's full
+// local circumstances are computed once; an eclipse is kept when hasObservableEclipse is true (the Moon reaches the
+// horizon during the penumbral interval, including a moonrise/moonset mid-eclipse). The computed circumstances are
+// returned so a caller never recomputes them; an eclipse that stays below the horizon at this location is omitted.
+//
+// longitude is east-positive radians, latitude geodetic radians; options set the horizon altitude and altitude
+// sampling (see computeLocalLunarEclipseCircumstances). Results are ordered earliest-first. previousMaxJd guards
+// against a non-advancing series so the loop can never spin.
+export function listLocalLunarEclipses(longitude: Angle, latitude: Angle, startTime: Time, endTime: Time, sunMoonPosition: SunMoonProvider, options: LocalLunarEclipseCircumstancesOptions = {}): LocalLunarEclipseListEntry[] {
+	const result: LocalLunarEclipseListEntry[] = []
+
+	const startJd = toJulianDay(startTime)
+	const endJd = toJulianDay(endTime)
+	if (!Number.isFinite(startJd) || !Number.isFinite(endJd) || endJd < startJd) return result
+
+	// nearestLunarEclipse(t, true) returns the first eclipse strictly after t, so seeding the cursor with the
+	// previous maximalTime advances exactly one eclipse per step.
+	let cursor = startTime
+	let previousMaxJd = -Infinity
+
+	while (true) {
+		const eclipse = nearestLunarEclipse(cursor, true)
+		const maxJd = toJulianDay(eclipse.maximalTime)
+		if (!Number.isFinite(maxJd) || maxJd <= previousMaxJd || maxJd > endJd) break
+
+		const circumstances = computeLocalLunarEclipseCircumstances(eclipse, longitude, latitude, sunMoonPosition, options)
+		if (circumstances.visibility.hasObservableEclipse) result.push({ eclipse, circumstances })
+
+		previousMaxJd = maxJd
+		cursor = eclipse.maximalTime
+	}
+
+	return result
 }
 
 // Local View geometry

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -1,6 +1,6 @@
 import { type Angle, normalizeAngle, normalizePI } from './angle'
 import { parallacticAngle } from './astrometry'
-import { DAYSEC, PI } from './constants'
+import { DAYSEC, PI, WGS84_FLATTENING } from './constants'
 import { equatorialToHorizontal } from './coordinate'
 import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
@@ -38,6 +38,8 @@ const MOON_RADIUS_EARTH_RADII = 0.2725
 // Mean angular size (radians) of one Earth equatorial radius seen from the Moon (mean distance ~60.27 Earth
 // radii). Used only to scale the schematic Local View horizon offset; not a precise per-event value.
 const MEAN_EARTH_RADIUS_ANGULAR_AT_MOON: Angle = Math.asin(1 / 60.27)
+// Earth polar/equatorial radius ratio (1 - flattening).
+const F = 1 - WGS84_FLATTENING
 
 // Coarse local visibility classification of a lunar eclipse for one observer.
 export type LocalLunarEclipseVisibilityKind = 'notVisible' | 'penumbralOnlyVisible' | 'partialVisible' | 'totalVisible' | 'completelyVisible' | 'geometricOnlyBelowHorizon'
@@ -63,11 +65,11 @@ export interface LocalLunarEclipseEvent {
 	readonly time: Time
 	// Julian Day of the contact.
 	readonly jd: number
-	// Whether the Moon is at or above the configured horizon at the contact.
+	// Whether the Moon is at or above the configured horizon at the contact (topocentric center altitude).
 	readonly observable: boolean
-	// Apparent Moon altitude (radians) at the contact for this observer.
+	// Topocentric apparent Moon altitude (radians) at the contact for this observer (diurnal parallax applied).
 	readonly altitude: Angle
-	// Apparent Moon azimuth (radians) at the contact, measured from North through East, in [0, TAU).
+	// Topocentric apparent Moon azimuth (radians) at the contact, measured from North through East, in [0, TAU).
 	readonly azimuth: Angle
 	// Position angle of the Earth-shadow center on the lunar disk, from celestial north toward east, in
 	// [0, TAU). This is the P angle of the contact tables.
@@ -176,12 +178,38 @@ function shadowMagnitudes(shadowDistance: number, u: number): [umbral: number, p
 	return [umbral, penumbral]
 }
 
-// Apparent Moon altitude (radians) at one instant for one observer, from the apparent Moon position and the
-// Greenwich apparent sidereal time. Used by the continuous visibility scan.
+// Topocentric Moon equatorial coordinates (radians) corrected for diurnal parallax. The geocentric apparent
+// Moon direction is shifted by the observer's geocentric position before re-deriving right ascension and
+// declination. Omitting this (~0.95 deg horizontal parallax) would overstate the altitude near the horizon by
+// up to one parallax, marking sub-horizon locations as observable, and would bias the Alt/Az and zenith angle.
+//   moonRA, moonDEC: geocentric apparent Moon right ascension/declination (radians).
+//   moonDistance: geocentric Moon distance in Earth equatorial radii (position.moon.distance).
+//   latitude: observer geodetic latitude (radians).
+//   lst: local apparent sidereal time (radians) = GAST + longitude.
+//   returns: [topocentric right ascension, topocentric declination] in radians.
+function moonTopocentric(moonRA: Angle, moonDEC: Angle, moonDistance: number, latitude: Angle, lst: Angle): [ra: Angle, dec: Angle] {
+	// Observer geocentric coordinates (Earth equatorial radii), reduced for Earth flattening (F = b / a). The
+	// observer's zenith points to right ascension = lst, geocentric declination = phi'.
+	const u = Math.atan(F * Math.tan(latitude))
+	const rhoSinPhi = F * Math.sin(u)
+	const rhoCosPhi = Math.cos(u)
+
+	const cosD = Math.cos(moonDEC)
+	const x = moonDistance * cosD * Math.cos(moonRA) - rhoCosPhi * Math.cos(lst)
+	const y = moonDistance * cosD * Math.sin(moonRA) - rhoCosPhi * Math.sin(lst)
+	const z = moonDistance * Math.sin(moonDEC) - rhoSinPhi
+	const r = Math.hypot(x, y, z)
+
+	return [Math.atan2(y, x), Math.asin(clamp(z / r, -1, 1))]
+}
+
+// Topocentric apparent Moon altitude (radians) at one instant for one observer. Applies diurnal parallax, then
+// converts to horizontal coordinates. Used by the continuous visibility scan.
 function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, getPosition: LunarEclipsePositionProvider) {
 	const position = getPosition(time)
 	const lst = contactGast(time, position.deltaT ?? 0) + longitude
-	const [, altitude] = equatorialToHorizontal(position.moon.rightAscension, position.moon.declination, latitude, lst)
+	const [topoRA, topoDEC] = moonTopocentric(position.moon.rightAscension, position.moon.declination, position.moon.distance, latitude, lst)
+	const [, altitude] = equatorialToHorizontal(topoRA, topoDEC, latitude, lst)
 	return altitude
 }
 
@@ -193,17 +221,22 @@ function computeLocalEvent(contact: LunarEclipseContact, eclipse: LunarEclipse, 
 	const lst = gast + longitude
 
 	const moonRA = position.moon.rightAscension
-	const moonDec = position.moon.declination
-	const [azimuth, altitude] = equatorialToHorizontal(moonRA, moonDec, latitude, lst)
+	const moonDEC = position.moon.declination
+
+	// Topocentric (parallax-corrected) Moon position drives the observer-dependent quantities: altitude,
+	// azimuth and the parallactic angle. The shadow-disk position angle P stays geocentric (the conventional
+	// table value): parallax shifts the Moon and the shadow, which lies at the Moon's distance, almost equally.
+	const [topoRA, topoDEC] = moonTopocentric(moonRA, moonDEC, position.moon.distance, latitude, lst)
+	const [azimuth, altitude] = equatorialToHorizontal(topoRA, topoDEC, latitude, lst)
 
 	// Earth-shadow center = antisolar point. Its position angle on the lunar disk is the table P angle.
 	const shadowRA = position.sun.rightAscension + PI
-	const shadowDec = -position.sun.declination
-	const positionAngle = positionAngleBetween(moonRA, moonDec, shadowRA, shadowDec)
+	const shadowDEC = -position.sun.declination
+	const positionAngle = positionAngleBetween(moonRA, moonDEC, shadowRA, shadowDEC)
 
 	// Lunar parallactic angle converts the celestial-north P angle into the zenith-oriented Z angle.
-	const hourAngle = normalizePI(lst - moonRA)
-	const q = parallacticAngle(hourAngle, moonDec, latitude)
+	const hourAngle = normalizePI(lst - topoRA)
+	const q = parallacticAngle(hourAngle, topoDEC, latitude)
 	const zenithAngle = normalizeAngle(positionAngle - q)
 
 	const shadowDistance = contactShadowDistance(contact.kind, eclipse.u, eclipse.gamma)

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -35,7 +35,7 @@ const LUNAR_ECLIPSE_PENUMBRA_LIMIT = 1.5573
 const LUNAR_ECLIPSE_MAGNITUDE_DENOMINATOR = 0.545
 // Mean angular size (radians) of one Earth equatorial radius seen from the Moon (mean distance ~60.27 Earth
 // radii). Used only to scale the schematic Local View horizon offset; not a precise per-event value.
-const MEAN_EARTH_RADIUS_ANGULAR_AT_MOON: Angle = Math.asin(1 / 60.27)
+const MEAN_EARTH_RADIUS_ANGULAR_AT_MOON: Angle = 0.01659276403036854845767088434102 // Math.asin(1 / 60.27)
 // Earth polar/equatorial radius ratio (1 - flattening).
 const F = 1 - WGS84_FLATTENING
 
@@ -402,7 +402,7 @@ function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, long
 const PHASE_MAX_ITERATIONS = 32
 const PHASE_MIN_SPAN_DAYS = 2 / DAYSEC
 // Reciprocal golden ratio, 1 / phi.
-const INVERSE_GOLDEN_RATIO = (Math.sqrt(5) - 1) / 2
+const INVERSE_GOLDEN_RATIO = 0.61803398874989484820458683436564 // (Math.sqrt(5) - 1) / 2
 
 // Whether the topocentric Moon altitude reaches the horizon anywhere within [fromJd, toJd].
 //

--- a/src/moon.eclipse.local.ts
+++ b/src/moon.eclipse.local.ts
@@ -2,12 +2,12 @@ import { type Angle, normalizeAngle, normalizePI } from './angle'
 import { parallacticAngle } from './astrometry'
 import { DAYSEC, PI, TAU, WGS84_FLATTENING } from './constants'
 import { equatorialToHorizontal } from './coordinate'
+import type { SunMoonProvider } from './eclipse'
 import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
 import { clamp } from './math'
 import type { LunarEclipse } from './moon'
 import { lunarEclipseEvents, type LunarEclipseContact, type LunarEclipseContactKind, MOON_RADIUS_EARTH_RADII } from './moon.eclipse.map'
-import type { SunMoonPosition } from './sun.eclipse.map'
 import { timeAtJulianDay, tt, type Time } from './time'
 import type { Writable } from './types'
 
@@ -41,9 +41,6 @@ const F = 1 - WGS84_FLATTENING
 
 // Coarse local visibility classification of a lunar eclipse for one observer.
 export type LocalLunarEclipseVisibilityKind = 'notVisible' | 'penumbralOnlyVisible' | 'partialVisible' | 'totalVisible' | 'completelyVisible' | 'geometricOnlyBelowHorizon'
-
-// Apparent Sun/Moon position provider at a dynamical time (TT/TDB), as produced by computeSunMoonPositionAt.
-export type LunarEclipsePositionProvider = (time: Time) => SunMoonPosition
 
 // Options controlling the local circumstances computation.
 export interface LocalLunarEclipseCircumstancesOptions {
@@ -214,7 +211,7 @@ function moonTopocentric(moonRA: Angle, moonDEC: Angle, moonDistance: number, la
 
 // Topocentric apparent Moon altitude (radians) at one instant for one observer. Applies diurnal parallax, then
 // converts to horizontal coordinates. Used by the continuous visibility scan and the phase-visibility search.
-export function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider) {
+export function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider) {
 	const position = sunMoonPosition(time)
 	const lst = contactGast(time, position.deltaT ?? 0) + longitude
 	const [topoRA, topoDEC] = moonTopocentric(position.moon.rightAscension, position.moon.declination, position.moon.distance, latitude, lst)
@@ -224,7 +221,7 @@ export function moonAltitudeAt(time: Time, longitude: Angle, latitude: Angle, su
 
 // Builds one resolved local event: altitude/azimuth, the P/Z orientation angles, and the per-contact
 // magnitudes.
-function computeLocalEvent(contact: LunarEclipseContact, eclipse: LunarEclipse, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, horizonAltitude: Angle): LocalLunarEclipseEvent {
+function computeLocalEvent(contact: LunarEclipseContact, eclipse: LunarEclipse, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, horizonAltitude: Angle): LocalLunarEclipseEvent {
 	const position = sunMoonPosition(contact.time)
 	const gast = contactGast(contact.time, position.deltaT ?? 0)
 	const lst = gast + longitude
@@ -320,7 +317,7 @@ function normalizeHorizonAltitude(value: Angle | undefined) {
 // Samples the Moon altitude across the penumbral interval [P1, P4] so the classifier can detect observable
 // stretches between contacts. Returns empty arrays when the interval is degenerate. Expects samples to be a
 // finite positive integer (see normalizeAltitudeSamples).
-function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, samples: number, reference: Time): AltitudeScan {
+function scanAltitudes(fromJd: number, toJd: number, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, samples: number, reference: Time): AltitudeScan {
 	const span = toJd - fromJd
 	if (!(span > 0) || samples < 1) return { jds: [], altitudes: [], step: 0 }
 
@@ -352,7 +349,7 @@ const EARTH_ROTATION_RATE_PER_DAY = TAU / 0.99726966
 // bisection, so an above-horizon window narrower than any fixed subdivision is still measured exactly (a fixed
 // 16-piece subdivision missed a peak shorter than one sub-step that fell between subdivision points, leaving
 // observableDuration at 0 while phaseReachesHorizon classified the eclipse observable from the same maximum).
-function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time) {
+function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, reference: Time) {
 	const span = toJd - fromJd
 	if (!(span > 0)) return 0
 
@@ -391,7 +388,7 @@ function aboveHorizonDaysInInterval(fromJd: number, toJd: number, horizonAltitud
 // this catches a stretch that falls between two coarse samples even when the surrounding samples are monotonic,
 // without scanning every near-horizon interval.
 // The result is capped at the scanned span so it can never exceed P4 - P1.
-function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time) {
+function observableDaysFromScan(scan: AltitudeScan, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, reference: Time) {
 	const { jds, altitudes, step } = scan
 	if (!(step > 0) || altitudes.length < 2) return 0
 
@@ -446,7 +443,7 @@ const HORIZON_ROOT_ITERATIONS = 40
 //   longitude, latitude: observer position in radians, east-positive longitude and geodetic latitude.
 //   reference: time-scale reference for building instants from Julian Days.
 //   seekMaximum: true to locate the maximum, false for the minimum.
-function goldenSectionAltitudeExtremum(lo: number, hi: number, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time, seekMaximum: boolean) {
+function goldenSectionAltitudeExtremum(lo: number, hi: number, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, reference: Time, seekMaximum: boolean) {
 	let c = hi - INVERSE_GOLDEN_RATIO * (hi - lo)
 	let d = lo + INVERSE_GOLDEN_RATIO * (hi - lo)
 	let fc = moonAltitudeAtJulianDay(c, reference, longitude, latitude, sunMoonPosition)
@@ -475,7 +472,7 @@ function goldenSectionAltitudeExtremum(lo: number, hi: number, longitude: Angle,
 // Julian Day of the horizon crossing within [lo, hi] where altitudeAt changes sign, by bisection. Requires
 // altitudeAt(lo) and altitudeAt(hi) to straddle zero (opposite signs); returns the bracket midpoint on convergence.
 //   horizonAltitude: topocentric horizon threshold in radians.
-function bisectHorizonCrossing(lo: number, hi: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, reference: Time) {
+function bisectHorizonCrossing(lo: number, hi: number, horizonAltitude: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, reference: Time) {
 	let loBelow = altitudeOffsetAtJulianDay(lo, horizonAltitude, reference, longitude, latitude, sunMoonPosition) < 0
 
 	for (let i = 0; i < HORIZON_ROOT_ITERATIONS && hi - lo > PHASE_MIN_SPAN_DAYS; i++) {
@@ -504,7 +501,7 @@ function bisectHorizonCrossing(lo: number, hi: number, horizonAltitude: Angle, l
 //   fromJd, toJd: the phase interval (Julian Days); endpoints are the phase contacts.
 //   altFrom, altTo: topocentric Moon altitudes at the endpoints (already resolved on the contact events).
 //   reference: time-scale reference for building instants from Julian Days.
-function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
+function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, horizonAltitude: Angle, reference: Time) {
 	// Exact phase endpoints first: a short phase whose whole above-horizon stretch is its endpoints is caught here.
 	if (altFrom >= horizonAltitude || altTo >= horizonAltitude) return true
 	if (!(toJd > fromJd)) return false
@@ -555,7 +552,7 @@ function phaseReachesHorizon(scan: AltitudeScan, fromJd: number, toJd: number, a
 // returns false as soon as any evaluated altitude is below the horizon.
 //   scan: precomputed penumbral-interval samples, used to reject an obvious below-horizon sample and to bracket.
 //   altFrom, altTo: topocentric Moon altitudes at the endpoints (already resolved on the contact events).
-function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider, horizonAltitude: Angle, reference: Time) {
+function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number, altFrom: Angle, altTo: Angle, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider, horizonAltitude: Angle, reference: Time) {
 	if (altFrom < horizonAltitude || altTo < horizonAltitude) return false
 	if (!(toJd > fromJd)) return true
 
@@ -611,13 +608,13 @@ function phaseStaysAboveHorizon(scan: AltitudeScan, fromJd: number, toJd: number
 //   julianDay: sample instant as a Julian Day.
 //   reference: time-scale reference used to construct the sample Time.
 //   longitude, latitude: observer position in radians, east-positive longitude and geodetic latitude.
-function moonAltitudeAtJulianDay(julianDay: number, reference: Time, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider) {
+function moonAltitudeAtJulianDay(julianDay: number, reference: Time, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider) {
 	return moonAltitudeAt(timeAtJulianDay(reference, julianDay), longitude, latitude, sunMoonPosition)
 }
 
 // Signed topocentric Moon altitude relative to a horizon threshold at a Julian Day. Positive means observable.
 //   horizonAltitude: observer's horizon threshold in radians.
-function altitudeOffsetAtJulianDay(julianDay: number, horizonAltitude: Angle, reference: Time, longitude: Angle, latitude: Angle, sunMoonPosition: LunarEclipsePositionProvider) {
+function altitudeOffsetAtJulianDay(julianDay: number, horizonAltitude: Angle, reference: Time, longitude: Angle, latitude: Angle, sunMoonPosition: SunMoonProvider) {
 	return moonAltitudeAtJulianDay(julianDay, reference, longitude, latitude, sunMoonPosition) - horizonAltitude
 }
 
@@ -627,7 +624,7 @@ function altitudeOffsetAtJulianDay(julianDay: number, horizonAltitude: Angle, re
 //   latitude: observer geodetic latitude (radians).
 //   getSunMoonPosition: apparent Sun/Moon position provider at a dynamical time.
 //   options: horizon altitude and altitude-sampling options.
-export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, longitude: Angle, latitude: Angle, getSunMoonPosition: LunarEclipsePositionProvider, options: LocalLunarEclipseCircumstancesOptions = {}): LocalLunarEclipseCircumstances {
+export function computeLocalLunarEclipseCircumstances(eclipse: LunarEclipse, longitude: Angle, latitude: Angle, getSunMoonPosition: SunMoonProvider, options: LocalLunarEclipseCircumstancesOptions = {}): LocalLunarEclipseCircumstances {
 	const horizonAltitude = normalizeHorizonAltitude(options.horizonAltitude)
 	const samples = normalizeAltitudeSamples(options.altitudeSamples)
 

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -4,7 +4,7 @@ import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
 import { clamp } from './math'
 import type { LunarEclipse } from './moon'
-import type { Projection } from './projection'
+import type { CylindricalProjection, ProjectionOptions, RaAxisDirection } from './projection'
 import { geoPolylinesToSvgPathData, normalizeLongitude, pointsToSvgPathData, splitPolygonAtAntimeridian, type GeoBranch, type GeoCurve, type GeoPoint, type SolarEclipseMapSvgProjectionOptions, type SunMoonPosition } from './sun.eclipse.map'
 import { tt, type Time, toJulianDay } from './time'
 import type { Writable } from './types'
@@ -181,6 +181,12 @@ export interface LunarEclipseMapSvgPaths {
 	readonly sublunarPoints: LunarEclipseMapPoints
 }
 
+const DEFAULT_LUNAR_ECLIPSE_MAP_SVG_OPTIONS: LunarEclipseMapSvgOptions = {
+	fill: false,
+	fillRegion: 'belowHorizon',
+	precision: 2,
+}
+
 // Maps each contact kind to the LunarEclipse time field that holds its instant. A field left at the default
 // minimal time (day 0) signals that contact does not exist for this eclipse.
 const CONTACT_TIME_FIELDS = {
@@ -353,7 +359,7 @@ export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPos
 }
 
 // Serializes one optional contact curve into SVG path data, splitting at the antimeridian during projection.
-function curveToSvgPath(curve: GeoCurve | undefined, projection: Projection, options: SolarEclipseMapSvgProjectionOptions) {
+function curveToSvgPath(curve: GeoCurve | undefined, projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions) {
 	return curve && curve.length > 0 ? geoPolylinesToSvgPathData(curve, projection, options) : ''
 }
 
@@ -375,33 +381,39 @@ function ringEnclosesPole(ring: GeoBranch) {
 
 // Projects a closed geographic ring into pixel polygon pieces, splitting at the antimeridian first so each
 // piece is a self-contained drawable ring.
-function projectRingPieces(ring: GeoBranch, projection: Projection, options: SolarEclipseMapSvgProjectionOptions): Point[][] {
+function projectRingPieces(ring: GeoBranch, projection: CylindricalProjection, options: ProjectionOptions) {
 	const pieces: Point[][] = []
 
 	for (const sub of splitPolygonAtAntimeridian(ring)) {
 		const piece: Point[] = []
+
 		for (const point of sub) {
 			const projected = projection.project(point.x, point.y, undefined, options)
-			if (projected) piece.push({ x: projected.x, y: projected.y })
+			if (projected) piece.push(projected)
 		}
+
 		if (piece.length >= 3) pieces.push(piece)
 	}
 
 	return pieces
 }
 
+const WORLD_RECT_BORDERS = [
+	[-PI, -PIOVERTWO],
+	[PI, -PIOVERTWO],
+	[PI, PIOVERTWO],
+	[-PI, PIOVERTWO],
+] as const
+
 // Projects the four geographic corners of the full map (the +-PI longitude, +-90 deg latitude rectangle).
-function projectedWorldRect(projection: Projection, options: SolarEclipseMapSvgProjectionOptions): Point[] {
+function projectedWorldRect(projection: CylindricalProjection, options: ProjectionOptions) {
 	const rect: Point[] = []
-	for (const [lon, lat] of [
-		[-PI, -PIOVERTWO],
-		[PI, -PIOVERTWO],
-		[PI, PIOVERTWO],
-		[-PI, PIOVERTWO],
-	] as const) {
+
+	for (const [lon, lat] of WORLD_RECT_BORDERS) {
 		const projected = projection.project(lon, lat, undefined, options)
-		if (projected) rect.push({ x: projected.x, y: projected.y })
+		projected && rect.push(projected)
 	}
+
 	return rect
 }
 
@@ -409,25 +421,26 @@ function projectedWorldRect(projection: Projection, options: SolarEclipseMapSvgP
 // once), so the points are sorted into a left-to-right profile and closed along a map pole edge: the enclosed
 // pole for the 'aboveHorizon' cap, the opposite pole for its 'belowHorizon' complement. The result is one
 // simple polygon.
-function polarCapFillPath(ring: GeoBranch, declination: Angle, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+function polarCapFillPath(ring: GeoBranch, declination: Angle, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, options: ProjectionOptions) {
 	const capPoleLat = declination >= 0 ? PIOVERTWO : -PIOVERTWO
 	const edgeLat = region === 'aboveHorizon' ? capPoleLat : -capPoleLat
 
 	// Sort the boundary into a left-to-right profile, dropping the duplicated closing vertex.
 	const sorted = ring.slice(0, ring.length - 1).sort((a, b) => a.x - b.x)
-
 	const polygon: Point[] = []
+
 	for (const point of sorted) {
 		const projected = projection.project(point.x, point.y, undefined, options)
-		if (projected) polygon.push({ x: projected.x, y: projected.y })
+		if (projected) polygon.push(projected)
 	}
+
 	if (polygon.length < 2) return ''
 
 	// Close along the pole edge: from the rightmost boundary point to the +PI corner, across to the -PI corner.
 	const right = projection.project(PI, edgeLat, undefined, options)
 	const left = projection.project(-PI, edgeLat, undefined, options)
-	if (right) polygon.push({ x: right.x, y: right.y })
-	if (left) polygon.push({ x: left.x, y: left.y })
+	if (right) polygon.push(right)
+	if (left) polygon.push(left)
 	if (polygon.length < 3) return ''
 
 	return pointsToSvgPathData([polygon], true, precision)
@@ -442,7 +455,7 @@ function polarCapFillPath(ring: GeoBranch, declination: Angle, projection: Proje
 // ring punched out as a hole, which (like the ring's own antimeridian pieces) fills correctly under fill-rule
 // "evenodd": a point inside the ring is covered by the rectangle and a ring piece (even -> not filled), a point
 // outside only by the rectangle (odd -> filled).
-function nonPolarCapFillPath(ring: GeoBranch, projection: Projection, region: LunarEclipseFillRegion, capExceedsHemisphere: boolean, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+function nonPolarCapFillPath(ring: GeoBranch, projection: CylindricalProjection, region: LunarEclipseFillRegion, capExceedsHemisphere: boolean, precision: number, options: ProjectionOptions) {
 	const ringPieces = projectRingPieces(ring, projection, options)
 	if (ringPieces.length === 0) return ''
 
@@ -457,40 +470,81 @@ function nonPolarCapFillPath(ring: GeoBranch, projection: Projection, region: Lu
 	return pointsToSvgPathData([rect, ...ringPieces], true, precision)
 }
 
+// Recenters a geographic ring's longitudes on the projection's central meridian, mapping each into the signed
+// wrapped offset in (-PI, PI] (east-positive). Latitudes and jd are preserved. After recentering, the projection's
+// antimeridian seam and its +-PI map edges sit at +-PI in the ring's own longitudes, so the fill's raw-longitude
+// split, left-to-right sort and pole-edge close operate in the actual map frame rather than in geographic
+// longitude. A zero central meridian with an east axis is the identity and returns the input ring unchanged
+// (no allocation), preserving the common-case behavior exactly.
+//   ring: closed geographic ring (first vertex repeated as last), longitudes east-positive in [-PI, PI].
+//   centralMeridian: projection central meridian (radians): the geographic longitude drawn at the map center.
+//   direction: 'east' when longitude increases to the right (the usual map), 'west' otherwise.
+function recenterRing(ring: GeoBranch, centralMeridian: Angle, direction: RaAxisDirection): GeoBranch {
+	if (centralMeridian === 0 && direction === 'east') return ring
+
+	const out: GeoBranch = new Array(ring.length)
+	for (let i = 0; i < ring.length; i++) {
+		const point = ring[i]
+		const delta = direction === 'west' ? centralMeridian - point.x : point.x - centralMeridian
+		out[i] = { x: normalizeLongitude(delta), y: point.y, jd: point.jd }
+	}
+	return out
+}
+
+// Serialize the recentered geometry in a central-meridian-neutral frame: recenterRing already shifted every
+// longitude by the central meridian, so projecting must NOT subtract it again. Without this override project()
+// re-applies the projection's central meridian (a double shift) and the +-PI pole-edge corners and complement
+// rectangle collapse onto the map center, inverting the fill. Scale, false origin and y-axis still come from
+// the projection. The fill contract assumes a 'pi'-wrap full-longitude cylindrical map.
+const POLAR_CAP_FILL_PROJECTION_OPTIONS: ProjectionOptions = { centralMeridian: 0, raAxisDirection: 'east', longitudeWrapMode: 'pi' }
+
 // Closes one contact's horizon curve into a fillable region polygon and serializes it. The visibility cap either
 // encloses a geographic pole (closed along the pole edge, correct whatever its size) or encloses neither pole; in
 // the latter case the cap radius distinguishes the usual sub-hemisphere cap from a larger-than-hemisphere cap
 // (whose ring is the antipodal below-horizon hole), so the correct side is filled in every case. The geographic
 // geometry is not mutated; the closing happens here.
+//
+// The ring is first recentered into the projection's wrapped-longitude frame and the closing is done with the
+// central meridian neutralized to 0 and an east axis, so the +-PI raw-longitude seam, the +-PI map edges (the
+// pole-edge corners and the complement rectangle) and the left-to-right ordering coincide with the actual map for
+// any cylindrical central meridian. Without this a non-zero central meridian would order and close the cap in the
+// geographic frame and fill the side opposite the open curve. The fill contract assumes a 'pi'-wrap cylindrical
+// full-longitude projection, so the wrapped serialization forces that mode.
 //   event: the map event for the contact (declination selects the enclosed pole; horizon and distance set the
 //   cap radius), or undefined.
 //   curve: the contact's horizon curve (a single closed ring as its first branch), or undefined.
 //   region: which side of the curve to fill.
 //   precision: SVG coordinate precision.
 //   options: projection polyline options shared with the open-curve serialization.
-function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurve | undefined, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurve | undefined, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number): string {
 	if (!curve || curve.length === 0) return ''
 
 	const ring = curve[0]
 	if (ring.length < 4) return ''
 
-	if (ringEnclosesPole(ring)) return polarCapFillPath(ring, event?.declination ?? 0, projection, region, precision, options)
+	// Resolve the projection's central meridian and longitude axis, then recenter the ring so its antimeridian
+	// seam and +-PI map edges land at +-PI in the ring's own longitudes.
+	const centralMeridian = projection.options?.centralMeridian ?? 0
+	const direction: RaAxisDirection = projection.options?.raAxisDirection ?? 'east'
+	const wrappedRing = recenterRing(ring, centralMeridian, direction)
+
+	if (ringEnclosesPole(wrappedRing)) return polarCapFillPath(wrappedRing, event?.declination ?? 0, projection, region, precision, POLAR_CAP_FILL_PROJECTION_OPTIONS)
 
 	const capExceedsHemisphere = event ? capRadius(event.horizonAltitude, event.distance) > PIOVERTWO : false
-	return nonPolarCapFillPath(ring, projection, region, capExceedsHemisphere, precision, options)
+	return nonPolarCapFillPath(wrappedRing, projection, region, capExceedsHemisphere, precision, POLAR_CAP_FILL_PROJECTION_OPTIONS)
 }
 
 // Projects the lunar eclipse map geometry and serializes each contact's horizon curve into an SVG path data
 // string, plus the projected sublunar points. Antimeridian wraps are split into separate subpaths at
 // projection time only; the geometry itself is never mutated. When options.fill is set, also returns closed
 // region polygons per contact (see contactFillPath).
-export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, projection: Projection, options: LunarEclipseMapSvgOptions = {}): LunarEclipseMapSvgPaths {
+export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, projection: CylindricalProjection, options: LunarEclipseMapSvgOptions = DEFAULT_LUNAR_ECLIPSE_MAP_SVG_OPTIONS): LunarEclipseMapSvgPaths {
 	const { moonRiseSet } = geometry.lines
-	const sublunarPoints: Writable<LunarEclipseMapPoints> = {}
+	const sublunarPoints: Writable<LunarEclipseMapPoints> = Object.create(null)
 
 	for (const event of geometry.events) {
-		const projected = projection.project(event.sublunar.x, event.sublunar.y, undefined, options)
-		if (projected) sublunarPoints[event.kind] = { x: projected.x, y: projected.y }
+		const projected = projection.project(event.sublunar.x, event.sublunar.y)
+		if (projected) sublunarPoints[event.kind] = projected
 	}
 
 	if (options.fill) {
@@ -499,19 +553,19 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 
 		// The event per contact drives the fill topology (declination for the enclosed pole, horizon and distance
 		// for the cap radius). Absent contacts have no event and no curve, so contactFillPath returns ''.
-		const eventByKind: Partial<Record<LunarEclipseContactKind, LunarEclipseMapEvent>> = {}
-		for (const event of geometry.events) eventByKind[event.kind] = event
+		const events: Partial<Record<LunarEclipseContactKind, LunarEclipseMapEvent>> = Object.create(null)
+		for (const event of geometry.events) events[event.kind] = event
 
 		return {
 			sublunarPoints,
 			moonRiseSet: {
-				P1: contactFillPath(eventByKind.P1, moonRiseSet.P1, projection, region, precision, options),
-				U1: contactFillPath(eventByKind.U1, moonRiseSet.U1, projection, region, precision, options),
-				U2: contactFillPath(eventByKind.U2, moonRiseSet.U2, projection, region, precision, options),
-				MAX: contactFillPath(eventByKind.MAX, moonRiseSet.MAX, projection, region, precision, options),
-				U3: contactFillPath(eventByKind.U3, moonRiseSet.U3, projection, region, precision, options),
-				U4: contactFillPath(eventByKind.U4, moonRiseSet.U4, projection, region, precision, options),
-				P4: contactFillPath(eventByKind.P4, moonRiseSet.P4, projection, region, precision, options),
+				P1: contactFillPath(events.P1, moonRiseSet.P1, projection, region, precision),
+				U1: contactFillPath(events.U1, moonRiseSet.U1, projection, region, precision),
+				U2: contactFillPath(events.U2, moonRiseSet.U2, projection, region, precision),
+				MAX: contactFillPath(events.MAX, moonRiseSet.MAX, projection, region, precision),
+				U3: contactFillPath(events.U3, moonRiseSet.U3, projection, region, precision),
+				U4: contactFillPath(events.U4, moonRiseSet.U4, projection, region, precision),
+				P4: contactFillPath(events.P4, moonRiseSet.P4, projection, region, precision),
 			},
 		}
 	} else {

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -1,11 +1,12 @@
 import type { Angle } from './angle'
 import { DAYSEC, DEG2RAD, PI, PIOVERTWO, TAU } from './constants'
+import { geoPolylinesToSvgPathData, normalizeLongitude, pointsToSvgPathData, splitPolygonAtAntimeridian, type EclipseGeoBranch, type EclipseGeoCurve, type EclipseGeoPoint, type SunMoonProvider } from './eclipse'
 import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
 import { clamp } from './math'
 import type { LunarEclipse } from './moon'
 import type { CylindricalProjection, ProjectionOptions, RaAxisDirection } from './projection'
-import { geoPolylinesToSvgPathData, normalizeLongitude, pointsToSvgPathData, splitPolygonAtAntimeridian, type GeoBranch, type GeoCurve, type GeoPoint, type SolarEclipseMapSvgProjectionOptions, type SunMoonPosition } from './sun.eclipse.map'
+import type { SolarEclipseMapSvgProjectionOptions } from './sun.eclipse.map'
 import { tt, type Time, toJulianDay } from './time'
 import type { Writable } from './types'
 
@@ -101,20 +102,20 @@ export interface LunarEclipseMapEvent extends LunarEclipseContact {
 	// Effective visibility-horizon altitude (radians) used to draw this contact's curve.
 	readonly horizonAltitude: Angle
 	// Sublunar point: where the Moon is at the local zenith (latitude = declination, longitude = RA - GAST).
-	readonly sublunar: GeoPoint
+	readonly sublunar: EclipseGeoPoint
 }
 
 // Per-contact moon rise/set (horizon) curves. Each curve is the small circle where the observer's topocentric
 // Moon altitude equals the contact's visibility horizon; it is kept unsplit (one closed branch) and
 // projection-agnostic, the antimeridian split happening only at serialization time.
 export interface LunarEclipseContactCurves {
-	readonly P1?: GeoCurve
-	readonly U1?: GeoCurve
-	readonly U2?: GeoCurve
-	readonly MAX?: GeoCurve
-	readonly U3?: GeoCurve
-	readonly U4?: GeoCurve
-	readonly P4?: GeoCurve
+	readonly P1?: EclipseGeoCurve
+	readonly U1?: EclipseGeoCurve
+	readonly U2?: EclipseGeoCurve
+	readonly MAX?: EclipseGeoCurve
+	readonly U3?: EclipseGeoCurve
+	readonly U4?: EclipseGeoCurve
+	readonly P4?: EclipseGeoCurve
 }
 
 // Projection-agnostic lunar eclipse map geometry: the contact events and their horizon curves.
@@ -292,7 +293,7 @@ function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, distan
 	// zero) cannot derive a non-finite or unsafe array length and throw a RangeError from new Array(...).
 	const bearingStep = maxAngularStep / Math.max(sinRho, 0.05)
 	const count = Math.min(Math.max(24, Math.ceil(TAU / bearingStep)), MAX_HORIZON_CIRCLE_POINTS)
-	const points: GeoBranch = new Array(count + 1)
+	const points: EclipseGeoBranch = new Array(count + 1)
 
 	for (let i = 0; i <= count; i++) {
 		const theta = (i % count) * (TAU / count)
@@ -312,7 +313,7 @@ function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, distan
 // (from the Moon distance), not a mean, so a near-perigee eclipse marks the upper limb on the right boundary.
 //   baseHorizon: distance-independent horizon altitude (configured horizon minus refraction).
 //   limbVisibility: 'center' marks the Moon center on the horizon; 'upperLimb' marks the upper limb.
-function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Time) => SunMoonPosition, baseHorizon: Angle, limbVisibility: LunarLimbVisibility): LunarEclipseMapEvent {
+function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: SunMoonProvider, baseHorizon: Angle, limbVisibility: LunarLimbVisibility): LunarEclipseMapEvent {
 	const position = sunMoonPosition(contact.time)
 	const gast = contactGast(contact.time, position.deltaT ?? 0)
 	const rightAscension = position.moon.rightAscension
@@ -337,7 +338,7 @@ function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Tim
 //   eclipse: lunar eclipse with its TT contact times.
 //   sunMoonPosition: apparent Sun/Moon position provider at a dynamical time (see computeSunMoonPositionAt).
 //   options: curve sampling and visibility-horizon options.
-export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPosition: (time: Time) => SunMoonPosition, options: LunarEclipseMapGeometryOptions = {}): LunarEclipseMapGeometry {
+export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPosition: SunMoonProvider, options: LunarEclipseMapGeometryOptions = {}): LunarEclipseMapGeometry {
 	const maxAngularStep = options.maxAngularStep !== undefined && Number.isFinite(options.maxAngularStep) && options.maxAngularStep > 0 ? options.maxAngularStep : DEFAULT_MAX_ANGULAR_STEP
 	const horizonAltitude = options.horizonAltitude !== undefined && Number.isFinite(options.horizonAltitude) ? options.horizonAltitude : 0
 	const baseHorizon = baseHorizonAltitude(horizonAltitude, options.refraction ?? false)
@@ -357,14 +358,14 @@ export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPos
 }
 
 // Serializes one optional contact curve into SVG path data, splitting at the antimeridian during projection.
-function curveToSvgPath(curve: GeoCurve | undefined, projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions) {
-	return curve && curve.length > 0 ? geoPolylinesToSvgPathData(curve, projection, options) : ''
+function curveToSvgPath(curve: EclipseGeoCurve | undefined, projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions) {
+	return curve && curve.length > 0 ? geoPolylinesToSvgPathData(curve, projection, options.precision, options.projectionOptions) : ''
 }
 
 // Whether the horizon ring encircles a geographic pole, from its total signed longitude winding: a cap that
 // contains a pole sweeps all longitudes (winding ~ +-TAU), while a cap that contains neither pole (a
 // near-equatorial eclipse, |declination| below the lunar parallax) is a bounded loop (winding ~ 0).
-function ringEnclosesPole(ring: GeoBranch) {
+function ringEnclosesPole(ring: EclipseGeoBranch) {
 	let winding = 0
 
 	for (let i = 1; i < ring.length; i++) {
@@ -379,7 +380,7 @@ function ringEnclosesPole(ring: GeoBranch) {
 
 // Projects a closed geographic ring into pixel polygon pieces, splitting at the antimeridian first so each
 // piece is a self-contained drawable ring.
-function projectRingPieces(ring: GeoBranch, projection: CylindricalProjection, options: ProjectionOptions) {
+function projectRingPieces(ring: EclipseGeoBranch, projection: CylindricalProjection, options: ProjectionOptions) {
 	const pieces: Point[][] = []
 
 	for (const sub of splitPolygonAtAntimeridian(ring)) {
@@ -419,7 +420,7 @@ function projectedWorldRect(projection: CylindricalProjection, options: Projecti
 // once), so the points are sorted into a left-to-right profile and closed along a map pole edge: the enclosed
 // pole for the 'aboveHorizon' cap, the opposite pole for its 'belowHorizon' complement. The result is one
 // simple polygon.
-function polarCapFillPath(ring: GeoBranch, declination: Angle, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, options: ProjectionOptions) {
+function polarCapFillPath(ring: EclipseGeoBranch, declination: Angle, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, options: ProjectionOptions) {
 	const capPoleLat = declination >= 0 ? PIOVERTWO : -PIOVERTWO
 	const edgeLat = region === 'aboveHorizon' ? capPoleLat : -capPoleLat
 
@@ -453,7 +454,7 @@ function polarCapFillPath(ring: GeoBranch, declination: Angle, projection: Cylin
 // ring punched out as a hole, which (like the ring's own antimeridian pieces) fills correctly under fill-rule
 // "evenodd": a point inside the ring is covered by the rectangle and a ring piece (even -> not filled), a point
 // outside only by the rectangle (odd -> filled).
-function nonPolarCapFillPath(ring: GeoBranch, projection: CylindricalProjection, region: LunarEclipseFillRegion, capExceedsHemisphere: boolean, precision: number, options: ProjectionOptions) {
+function nonPolarCapFillPath(ring: EclipseGeoBranch, projection: CylindricalProjection, region: LunarEclipseFillRegion, capExceedsHemisphere: boolean, precision: number, options: ProjectionOptions) {
 	const ringPieces = projectRingPieces(ring, projection, options)
 	if (ringPieces.length === 0) return ''
 
@@ -477,15 +478,17 @@ function nonPolarCapFillPath(ring: GeoBranch, projection: CylindricalProjection,
 //   ring: closed geographic ring (first vertex repeated as last), longitudes east-positive in [-PI, PI].
 //   centralMeridian: projection central meridian (radians): the geographic longitude drawn at the map center.
 //   direction: 'east' when longitude increases to the right (the usual map), 'west' otherwise.
-function recenterRing(ring: GeoBranch, centralMeridian: Angle, direction: RaAxisDirection): GeoBranch {
+function recenterRing(ring: EclipseGeoBranch, centralMeridian: Angle, direction: RaAxisDirection): EclipseGeoBranch {
 	if (centralMeridian === 0 && direction === 'east') return ring
 
-	const out: GeoBranch = new Array(ring.length)
+	const out: EclipseGeoBranch = new Array(ring.length)
+
 	for (let i = 0; i < ring.length; i++) {
 		const point = ring[i]
 		const delta = direction === 'west' ? centralMeridian - point.x : point.x - centralMeridian
 		out[i] = { x: normalizeLongitude(delta), y: point.y, jd: point.jd }
 	}
+
 	return out
 }
 
@@ -514,7 +517,7 @@ const POLAR_CAP_FILL_PROJECTION_OPTIONS: ProjectionOptions = { centralMeridian: 
 //   region: which side of the curve to fill.
 //   precision: SVG coordinate precision.
 //   projectionOptions: projection options with the ring's central-meridian-neutral frame already applied.
-function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurve | undefined, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, projectionOptions: ProjectionOptions) {
+function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: EclipseGeoCurve | undefined, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, projectionOptions: ProjectionOptions) {
 	if (!curve || curve.length === 0) return ''
 
 	const ring = curve[0]

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -197,9 +197,11 @@ const CONTACT_SEQUENCE = {
 	TOTAL: ['P1', 'U1', 'U2', 'MAX', 'U3', 'U4', 'P4'],
 } as const satisfies Record<LunarEclipse['type'], readonly LunarEclipseContactKind[]>
 
-// Whether a Time refers to an existing contact: the absent contacts keep the default minimal time (day 0).
+// Whether a Time refers to an existing contact. Absent contacts keep the default minimal time (Julian Day 0, i.e.
+// day 0 and fraction 0), so the test is for that exact sentinel rather than a positive day: real contacts before
+// JD 0 (ancient eclipses) have negative days and must not be dropped.
 function isExistingContactTime(time: Time) {
-	return time.day > 0
+	return !(time.day === 0 && time.fraction === 0)
 }
 
 // Resolves the ordered contact sequence of an eclipse from its type and existing contact times. Absent

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -54,6 +54,12 @@ const MEAN_MOON_SEMIDIAMETER: Angle = 0.259 * DEG2RAD
 // Default angular spacing (radians, 1 deg) between neighboring horizon-curve points.
 const DEFAULT_MAX_ANGULAR_STEP: Angle = DEG2RAD
 
+// Hard ceiling on the number of points per horizon circle. A pathologically small but finite maxAngularStep
+// (e.g. a unit-conversion typo, or Number.MIN_VALUE) passes the finite-positive option check yet would derive a
+// count that overflows the maximum safe array length and throw a RangeError from new Array(...). Capping keeps
+// geometry generation robust; the ceiling is far above any useful map resolution (~0.0036 deg spacing).
+const MAX_HORIZON_CIRCLE_POINTS = 100000
+
 // Visibility criterion for the horizon curve.
 //   'center': the Moon's center is on the horizon h0 (the conventional reference-map choice);
 //   'upperLimb': the horizon is lowered by the Moon's semidiameter so the curve marks where the upper limb
@@ -275,9 +281,11 @@ function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, distan
 	const cosRho = Math.cos(rho)
 
 	// Bearing step so the along-circle spacing (~sinRho * dTheta) stays within maxAngularStep; clamped so a
-	// degenerate tiny circle (h0 near PI/2) still produces a bounded number of samples.
+	// degenerate tiny circle (h0 near PI/2) still produces a bounded number of samples. The count is also capped
+	// at MAX_HORIZON_CIRCLE_POINTS so an extremely small maxAngularStep (which makes bearingStep underflow toward
+	// zero) cannot derive a non-finite or unsafe array length and throw a RangeError from new Array(...).
 	const bearingStep = maxAngularStep / Math.max(sinRho, 0.05)
-	const count = Math.max(24, Math.ceil(TAU / bearingStep))
+	const count = Math.min(Math.max(24, Math.ceil(TAU / bearingStep)), MAX_HORIZON_CIRCLE_POINTS)
 	const points: GeoBranch = new Array(count + 1)
 
 	for (let i = 0; i <= count; i++) {

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -528,10 +528,11 @@ function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurv
 	const direction: RaAxisDirection = projection.options?.raAxisDirection ?? 'east'
 	const wrappedRing = recenterRing(ring, centralMeridian, direction)
 
-	if (ringEnclosesPole(wrappedRing)) return polarCapFillPath(wrappedRing, event?.declination ?? 0, projection, region, precision, POLAR_CAP_FILL_PROJECTION_OPTIONS)
+	const wrappedOptions: ProjectionOptions = { ...projection.options, ...POLAR_CAP_FILL_PROJECTION_OPTIONS }
+	if (ringEnclosesPole(wrappedRing)) return polarCapFillPath(wrappedRing, event?.declination ?? 0, projection, region, precision, wrappedOptions)
 
 	const capExceedsHemisphere = event ? capRadius(event.horizonAltitude, event.distance) > PIOVERTWO : false
-	return nonPolarCapFillPath(wrappedRing, projection, region, capExceedsHemisphere, precision, POLAR_CAP_FILL_PROJECTION_OPTIONS)
+	return nonPolarCapFillPath(wrappedRing, projection, region, capExceedsHemisphere, precision, wrappedOptions)
 }
 
 // Projects the lunar eclipse map geometry and serializes each contact's horizon curve into an SVG path data

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -5,7 +5,7 @@ import type { Point } from './geometry'
 import { clamp } from './math'
 import type { LunarEclipse } from './moon'
 import type { Projection } from './projection'
-import { geoPolylinesToSvgPathData, normalizeLongitude, pointsToSvgPathData, type GeoBranch, type GeoCurve, type GeoPoint, type SolarEclipseMapSvgProjectionOptions, type SunMoonPosition } from './sun.eclipse.map'
+import { geoPolylinesToSvgPathData, normalizeLongitude, pointsToSvgPathData, splitPolygonAtAntimeridian, type GeoBranch, type GeoCurve, type GeoPoint, type SolarEclipseMapSvgProjectionOptions, type SunMoonPosition } from './sun.eclipse.map'
 import { tt, type Time, toJulianDay } from './time'
 import type { Writable } from './types'
 
@@ -142,18 +142,20 @@ export interface LunarEclipseContactPaths {
 }
 
 // Which side of a contact's horizon curve a fill polygon covers.
-//   'aboveHorizon': the visibility cap (where the Moon is up), closed against the enclosed pole;
-//   'belowHorizon': the complementary region (where the Moon is down), closed against the opposite pole.
+//   'aboveHorizon': the visibility cap, where the Moon is up;
+//   'belowHorizon': the complementary region, where the Moon is down.
 export type LunarEclipseFillRegion = 'aboveHorizon' | 'belowHorizon'
 
 // Options for serializing the lunar eclipse map to SVG, extending the shared projection/polyline options.
 export interface LunarEclipseMapSvgOptions extends SolarEclipseMapSvgProjectionOptions {
-	// When true, also emit closed region polygons (moonRiseSetFill) per contact, suitable for filling or
-	// gradients. Each polygon is the horizon curve closed against a map pole edge.
+	// When true, replace each contact's open horizon curve with a closed region polygon, suitable for filling or
+	// gradients. Render these paths with fill-rule "evenodd": a near-equatorial cap's complement is emitted as
+	// the map rectangle with the cap punched out (two subpaths), which only fills correctly under evenodd.
 	//
 	// This assumes a cylindrical, full-longitude projection (e.g. PlateCarree) able to represent the +-90 deg
-	// latitude edges: the visibility cap of a near-90 deg horizon circle always encloses a geographic pole, so
-	// the region is closed along that pole's map edge rather than across the map interior.
+	// latitude edges. When the visibility cap encloses a geographic pole (the usual case) the region is closed
+	// along that pole's map edge; when it encloses neither pole (|declination| below the lunar parallax, i.e. a
+	// near-equatorial eclipse) the cap ring is filled directly instead.
 	readonly fill?: boolean
 	// Which side of each horizon curve to fill. Default 'belowHorizon' (the not-visible region, for shading).
 	readonly fillRegion?: LunarEclipseFillRegion
@@ -319,26 +321,59 @@ function curveToSvgPath(curve: GeoCurve | undefined, projection: Projection, opt
 	return curve && curve.length > 0 ? geoPolylinesToSvgPathData(curve, projection, options) : ''
 }
 
-// Closes one contact's horizon curve into a fillable region polygon and serializes it.
-//
-// A near-90 deg horizon circle's visibility cap always encloses the geographic pole in the Moon's hemisphere
-// (north when declination >= 0, south otherwise), so the boundary is single-valued in longitude: each meridian
-// crosses it once. The boundary points are therefore sorted by longitude into a left-to-right profile and the
-// polygon is closed along a map pole edge (at +-PI longitude and +-90 deg latitude): the enclosed pole for the
-// 'aboveHorizon' cap, the opposite pole for its 'belowHorizon' complement. The geographic geometry is not
-// mutated; the closing happens here, at serialization time.
-//   declination: Moon declination at the contact (radians), selecting the enclosed pole.
-//   curve: the contact's horizon curve (a single closed ring as its first branch), or undefined.
-//   region: which side of the curve to fill.
-//   precision: SVG coordinate precision.
-//   options: projection polyline options shared with the open-curve serialization.
-function contactFillPath(declination: Angle, curve: GeoCurve | undefined, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
-	if (!curve || curve.length === 0) return ''
+// Whether the horizon ring encircles a geographic pole, from its total signed longitude winding: a cap that
+// contains a pole sweeps all longitudes (winding ~ +-TAU), while a cap that contains neither pole (a
+// near-equatorial eclipse, |declination| below the lunar parallax) is a bounded loop (winding ~ 0).
+function ringEnclosesPole(ring: GeoBranch) {
+	let winding = 0
 
-	const ring = curve[0]
-	if (ring.length < 4) return ''
+	for (let i = 1; i < ring.length; i++) {
+		let delta = ring[i].x - ring[i - 1].x
+		if (delta > PI) delta -= TAU
+		else if (delta < -PI) delta += TAU
+		winding += delta
+	}
 
-	// Latitude of the closing pole edge: the enclosed pole for the cap, the opposite pole for its complement.
+	return Math.abs(winding) > PI
+}
+
+// Projects a closed geographic ring into pixel polygon pieces, splitting at the antimeridian first so each
+// piece is a self-contained drawable ring.
+function projectRingPieces(ring: GeoBranch, projection: Projection, options: SolarEclipseMapSvgProjectionOptions): Point[][] {
+	const pieces: Point[][] = []
+
+	for (const sub of splitPolygonAtAntimeridian(ring)) {
+		const piece: Point[] = []
+		for (const point of sub) {
+			const projected = projection.project(point.x, point.y, undefined, options)
+			if (projected) piece.push({ x: projected.x, y: projected.y })
+		}
+		if (piece.length >= 3) pieces.push(piece)
+	}
+
+	return pieces
+}
+
+// Projects the four geographic corners of the full map (the +-PI longitude, +-90 deg latitude rectangle).
+function projectedWorldRect(projection: Projection, options: SolarEclipseMapSvgProjectionOptions): Point[] {
+	const rect: Point[] = []
+	for (const [lon, lat] of [
+		[-PI, -PIOVERTWO],
+		[PI, -PIOVERTWO],
+		[PI, PIOVERTWO],
+		[-PI, PIOVERTWO],
+	] as const) {
+		const projected = projection.project(lon, lat, undefined, options)
+		if (projected) rect.push({ x: projected.x, y: projected.y })
+	}
+	return rect
+}
+
+// Fill polygon for a POLE-ENCLOSING cap. The boundary is single-valued in longitude (each meridian crosses it
+// once), so the points are sorted into a left-to-right profile and closed along a map pole edge: the enclosed
+// pole for the 'aboveHorizon' cap, the opposite pole for its 'belowHorizon' complement. The result is one
+// simple polygon.
+function polarCapFillPath(ring: GeoBranch, declination: Angle, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
 	const capPoleLat = declination >= 0 ? PIOVERTWO : -PIOVERTWO
 	const edgeLat = region === 'aboveHorizon' ? capPoleLat : -capPoleLat
 
@@ -346,12 +381,10 @@ function contactFillPath(declination: Angle, curve: GeoCurve | undefined, projec
 	const sorted = ring.slice(0, ring.length - 1).sort((a, b) => a.x - b.x)
 
 	const polygon: Point[] = []
-
 	for (const point of sorted) {
 		const projected = projection.project(point.x, point.y, undefined, options)
 		if (projected) polygon.push({ x: projected.x, y: projected.y })
 	}
-
 	if (polygon.length < 2) return ''
 
 	// Close along the pole edge: from the rightmost boundary point to the +PI corner, across to the -PI corner.
@@ -362,6 +395,41 @@ function contactFillPath(declination: Angle, curve: GeoCurve | undefined, projec
 	if (polygon.length < 3) return ''
 
 	return pointsToSvgPathData([polygon], true, precision)
+}
+
+// Fill polygon for a cap that encloses NEITHER pole (a near-equatorial eclipse). The cap is the bounded ring
+// itself, so 'aboveHorizon' is just the projected ring; 'belowHorizon' (the complement, which contains both
+// poles) is the map rectangle with the cap punched out as a hole. Both rely on fill-rule "evenodd": for
+// 'belowHorizon' a point inside the cap is covered by the rectangle and a cap piece (even -> not filled), and a
+// point outside is covered only by the rectangle (odd -> filled).
+function nonPolarCapFillPath(ring: GeoBranch, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+	const capPieces = projectRingPieces(ring, projection, options)
+	if (capPieces.length === 0) return ''
+
+	if (region === 'aboveHorizon') return pointsToSvgPathData(capPieces, true, precision)
+
+	const rect = projectedWorldRect(projection, options)
+	if (rect.length < 3) return ''
+	return pointsToSvgPathData([rect, ...capPieces], true, precision)
+}
+
+// Closes one contact's horizon curve into a fillable region polygon and serializes it. The visibility cap
+// either encloses a geographic pole (closed along the pole edge) or encloses neither pole for a near-equatorial
+// eclipse (filled as the bounded ring, or its complement); the topology is read from the ring's winding so the
+// correct side is filled in both cases. The geographic geometry is not mutated; the closing happens here.
+//   declination: Moon declination at the contact (radians), selecting the enclosed pole for a polar cap.
+//   curve: the contact's horizon curve (a single closed ring as its first branch), or undefined.
+//   region: which side of the curve to fill.
+//   precision: SVG coordinate precision.
+//   options: projection polyline options shared with the open-curve serialization.
+function contactFillPath(declination: Angle, curve: GeoCurve | undefined, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+	if (!curve || curve.length === 0) return ''
+
+	const ring = curve[0]
+	if (ring.length < 4) return ''
+
+	if (ringEnclosesPole(ring)) return polarCapFillPath(ring, declination, projection, region, precision, options)
+	return nonPolarCapFillPath(ring, projection, region, precision, options)
 }
 
 // Projects the lunar eclipse map geometry and serializes each contact's horizon curve into an SVG path data

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -1,0 +1,309 @@
+import type { Angle } from './angle'
+import { DAYSEC, DEG2RAD, PIOVERTWO, TAU } from './constants'
+import { eraGst06a } from './erfa'
+import type { Point } from './geometry'
+import { clamp } from './math'
+import type { LunarEclipse } from './moon'
+import type { Projection } from './projection'
+import { geoPolylinesToSvgPathData, normalizeLongitude, type GeoBranch, type GeoCurve, type GeoPoint, type SolarEclipseMapSvgProjectionOptions, type SunMoonPosition } from './sun.eclipse.map'
+import { tt, type Time, toJulianDay } from './time'
+import type { Writable } from './types'
+
+// Lunar eclipse map geometry engine.
+//
+// Unlike a solar eclipse, the lunar event happens ON the Moon, not on the Earth's surface, so the terrestrial
+// map does not represent the umbra/penumbra sweeping the ground. Instead, each global curve marks WHERE THE
+// MOON IS ON THE HORIZON at a given contact instant (P1, U1, U2, MAX, U3, U4, P4): the boundary between the
+// hemisphere that sees the Moon above the horizon and the hemisphere that does not. The physical umbra and
+// penumbra geometry belongs to the Moon's plane and is exposed by the local view, not by this global map.
+//
+// Geometry of one contact curve: the locus where the apparent Moon altitude equals a chosen visibility
+// horizon h0 is a small circle on the sphere centered at the sublunar point (the place where the Moon is at
+// the zenith) at angular radius (PI/2 - h0). The sublunar point is at latitude = declination and longitude =
+// rightAscension - GAST. This is computed by a direct bearing sweep, which is robust at high declination and
+// near the poles, where a longitude scan would be double-valued or undefined.
+//
+// Unit conventions:
+//   - angles (right ascension, declination, longitude, latitude, altitudes) in radians;
+//   - longitude is east-positive in [-PI, PI], latitude is geodetic in [-PI/2, PI/2];
+//   - times are Time (the LunarEclipse contact times are TT) or Julian Day.
+
+// The seven possible lunar eclipse contacts, in chronological order around maximum.
+export type LunarEclipseContactKind = 'P1' | 'U1' | 'U2' | 'MAX' | 'U3' | 'U4' | 'P4'
+
+// Atmospheric refraction lift at the geometric horizon (radians, ~34'). Applied to h0 when refraction is on so
+// the curve marks where the Moon is seen on the apparent horizon rather than the true horizon.
+const HORIZON_REFRACTION: Angle = (34 / 60) * DEG2RAD
+
+// Mean lunar semidiameter (radians) used as a fallback upper-limb lift when no distance is available. The
+// Moon's geocentric semidiameter is ~0.259 deg on average; the sublunar-point altitude criterion uses the
+// geocentric direction, so a mean value is sufficient for the visibility horizon.
+const MEAN_MOON_SEMIDIAMETER: Angle = 0.259 * DEG2RAD
+
+// Default angular spacing (radians, 1 deg) between neighboring horizon-curve points.
+const DEFAULT_MAX_ANGULAR_STEP: Angle = DEG2RAD
+
+// Visibility criterion for the horizon curve.
+//   'center': the Moon's center is on the horizon h0 (the conventional reference-map choice);
+//   'upperLimb': the horizon is lowered by the Moon's semidiameter so the curve marks where the upper limb
+//   first appears.
+export type LunarLimbVisibility = 'center' | 'upperLimb'
+
+// Options controlling the lunar eclipse map geometry.
+export interface LunarEclipseMapGeometryOptions {
+	// Maximum geodesic spacing (radians) between neighboring horizon-curve points. Default 1 deg.
+	readonly maxAngularStep?: Angle
+	// Altitude (radians) of the visibility horizon for the Moon center. Default 0 (geometric horizon).
+	readonly horizonAltitude?: Angle
+	// Whether to lower the horizon by the standard atmospheric refraction (~34'). Default false.
+	readonly refraction?: boolean
+	// Whether to mark the center on the horizon or the upper limb. Default 'center'.
+	readonly limbVisibility?: LunarLimbVisibility
+}
+
+// One contact in the lunar eclipse sequence, with its instant.
+export interface LunarEclipseContact {
+	// Which contact this is.
+	readonly kind: LunarEclipseContactKind
+	// Instant of the contact (TT, taken from the LunarEclipse).
+	readonly time: Time
+	// Julian Day of the contact.
+	readonly jd: number
+}
+
+// One contact enriched with the apparent Moon position and the sublunar point, used to draw the global map.
+export interface LunarEclipseMapEvent extends LunarEclipseContact {
+	// Apparent geocentric Moon right ascension (radians) at the contact.
+	readonly rightAscension: Angle
+	// Apparent geocentric Moon declination (radians) at the contact.
+	readonly declination: Angle
+	// Greenwich apparent sidereal time (radians) at the contact.
+	readonly gast: Angle
+	// Effective visibility-horizon altitude (radians) used to draw this contact's curve.
+	readonly horizonAltitude: Angle
+	// Sublunar point: where the Moon is at the local zenith (latitude = declination, longitude = RA - GAST).
+	readonly sublunar: GeoPoint
+}
+
+// Per-contact moon rise/set (horizon) curves. Each curve is the small circle where the Moon altitude equals
+// the contact's visibility horizon; it is kept unsplit (one closed branch) and projection-agnostic, the
+// antimeridian split happening only at serialization time.
+export interface LunarEclipseContactCurves {
+	readonly P1?: GeoCurve
+	readonly U1?: GeoCurve
+	readonly U2?: GeoCurve
+	readonly MAX?: GeoCurve
+	readonly U3?: GeoCurve
+	readonly U4?: GeoCurve
+	readonly P4?: GeoCurve
+}
+
+// Projection-agnostic lunar eclipse map geometry: the contact events and their horizon curves.
+export interface LunarEclipseMapGeometry {
+	// The eclipse this geometry was built from.
+	readonly eclipse: LunarEclipse
+	// Contact events in chronological order, with apparent Moon positions and sublunar points.
+	readonly events: readonly LunarEclipseMapEvent[]
+	// Drawable geographic curves.
+	readonly lines: {
+		// Moon rise/set (horizon) curves, one per existing contact.
+		readonly moonRiseSet: LunarEclipseContactCurves
+	}
+}
+
+// Projected sublunar points (pixel coordinates) per contact.
+export interface LunarEclipseMapPoints {
+	readonly P1?: Point
+	readonly U1?: Point
+	readonly U2?: Point
+	readonly MAX?: Point
+	readonly U3?: Point
+	readonly U4?: Point
+	readonly P4?: Point
+}
+
+// SVG path data strings per contact horizon curve, plus projected sublunar points.
+export interface LunarEclipseMapSvgPaths {
+	// Horizon-curve path data per contact (empty string when the contact does not exist).
+	readonly moonRiseSet: {
+		readonly P1: string
+		readonly U1: string
+		readonly U2: string
+		readonly MAX: string
+		readonly U3: string
+		readonly U4: string
+		readonly P4: string
+	}
+	// Projected sublunar points, when present.
+	readonly sublunarPoints: LunarEclipseMapPoints
+}
+
+// Maps each contact kind to the LunarEclipse time field that holds its instant. A field left at the default
+// minimal time (day 0) signals that contact does not exist for this eclipse.
+const CONTACT_TIME_FIELDS = {
+	P1: 'firstContactPenumbraTime',
+	U1: 'firstContactUmbraTime',
+	U2: 'totalBeginTime',
+	MAX: 'maximalTime',
+	U3: 'totalEndTime',
+	U4: 'lastContactUmbraTime',
+	P4: 'lastContactPenumbraTime',
+} as const satisfies Record<LunarEclipseContactKind, keyof LunarEclipse>
+
+// The contact sequence per eclipse type, in chronological order.
+//   PENUMBRAL: P1, MAX, P4;
+//   PARTIAL: P1, U1, MAX, U4, P4;
+//   TOTAL: P1, U1, U2, MAX, U3, U4, P4.
+const CONTACT_SEQUENCE = {
+	PENUMBRAL: ['P1', 'MAX', 'P4'],
+	PARTIAL: ['P1', 'U1', 'MAX', 'U4', 'P4'],
+	TOTAL: ['P1', 'U1', 'U2', 'MAX', 'U3', 'U4', 'P4'],
+} as const satisfies Record<LunarEclipse['type'], readonly LunarEclipseContactKind[]>
+
+// Whether a Time refers to an existing contact: the absent contacts keep the default minimal time (day 0).
+function isExistingContactTime(time: Time) {
+	return time.day > 0
+}
+
+// Resolves the ordered contact sequence of an eclipse from its type and existing contact times. Absent
+// contacts (default minimal time) are filtered out, so a malformed eclipse never yields a zero-time contact.
+//   eclipse: lunar eclipse with its TT contact times.
+//   returns: contacts in chronological order, each with its instant and Julian Day.
+export function lunarEclipseEvents(eclipse: LunarEclipse): LunarEclipseContact[] {
+	const contacts: LunarEclipseContact[] = []
+
+	for (const kind of CONTACT_SEQUENCE[eclipse.type]) {
+		const time = eclipse[CONTACT_TIME_FIELDS[kind]]
+		if (!isExistingContactTime(time)) continue
+		contacts.push({ kind, time, jd: toJulianDay(time) })
+	}
+
+	return contacts
+}
+
+// Greenwich apparent sidereal time (radians) at a contact, consistent with the apparent Moon position. The
+// UT1 fraction is derived from the dynamical time and the sample's Delta T, matching the solar eclipse
+// engine's mu construction.
+//   time: contact instant in a dynamical scale (TT/TDB).
+//   deltaT: Delta T (TT - UT1) in seconds for the sample, defaulting to 0 when unavailable.
+function contactGast(time: Time, deltaT: number) {
+	const ttTime = tt(time)
+	const ut1Fraction = ttTime.fraction - deltaT / DAYSEC
+	return eraGst06a(ttTime.day, ut1Fraction, ttTime.day, ttTime.fraction)
+}
+
+// Effective visibility-horizon altitude (radians) for the Moon center, combining the configured horizon, the
+// optional refraction lift, and the optional upper-limb lowering by the Moon semidiameter.
+function effectiveHorizonAltitude(horizonAltitude: Angle, refraction: boolean, limbVisibility: LunarLimbVisibility) {
+	let h0 = horizonAltitude
+	if (refraction) h0 -= HORIZON_REFRACTION
+	if (limbVisibility === 'upperLimb') h0 -= MEAN_MOON_SEMIDIAMETER
+	return h0
+}
+
+// Generates the small circle where the Moon altitude equals h0, centered at the sublunar point. The circle has
+// spherical radius (PI/2 - h0); points are swept by bearing so spacing stays near maxAngularStep along the
+// circle and the curve is well behaved at high declination and near the poles. The returned branch is closed
+// (first point repeated) and projection-agnostic; the antimeridian split happens at serialization time.
+//   sublunarLat: latitude of the sublunar point (= Moon declination), radians.
+//   sublunarLon: longitude of the sublunar point (= RA - GAST), radians, east-positive.
+//   h0: visibility-horizon altitude, radians.
+//   jd: Julian Day stamped on every point of the curve.
+//   maxAngularStep: target geodesic spacing between neighboring points, radians.
+function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, jd: number, maxAngularStep: Angle) {
+	const rho = PIOVERTWO - h0
+	const sinClat = Math.sin(sublunarLat)
+	const cosClat = Math.cos(sublunarLat)
+	const sinRho = Math.sin(rho)
+	const cosRho = Math.cos(rho)
+
+	// Bearing step so the along-circle spacing (~sinRho * dTheta) stays within maxAngularStep; clamped so a
+	// degenerate tiny circle (h0 near PI/2) still produces a bounded number of samples.
+	const bearingStep = maxAngularStep / Math.max(sinRho, 0.05)
+	const count = Math.max(24, Math.ceil(TAU / bearingStep))
+	const points: GeoBranch = new Array(count + 1)
+
+	for (let i = 0; i <= count; i++) {
+		const theta = (i % count) * (TAU / count)
+		const cosTheta = Math.cos(theta)
+		const sinTheta = Math.sin(theta)
+		const sinLat = sinClat * cosRho + cosClat * sinRho * cosTheta
+		const lat = Math.asin(clamp(sinLat, -1, 1))
+		const lon = sublunarLon + Math.atan2(sinTheta * sinRho * cosClat, cosRho - sinClat * sinLat)
+		points[i] = { x: normalizeLongitude(lon), y: lat, jd }
+	}
+
+	return points
+}
+
+// Builds one map event from a contact: computes the apparent Moon position, GAST, the effective horizon and
+// the sublunar point.
+function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Time) => SunMoonPosition, h0: Angle): LunarEclipseMapEvent {
+	const position = sunMoonPosition(contact.time)
+	const gast = contactGast(contact.time, position.deltaT ?? 0)
+	const rightAscension = position.moon.rightAscension
+	const declination = position.moon.declination
+	const sublunarLon = normalizeLongitude(rightAscension - gast)
+
+	return {
+		...contact,
+		rightAscension,
+		declination,
+		gast,
+		horizonAltitude: h0,
+		sublunar: { x: sublunarLon, y: declination, jd: contact.jd },
+	}
+}
+
+// Computes the projection-agnostic lunar eclipse map geometry: the contact events and their moon rise/set
+// horizon curves.
+//   eclipse: lunar eclipse with its TT contact times.
+//   sunMoonPosition: apparent Sun/Moon position provider at a dynamical time (see computeSunMoonPositionAt).
+//   options: curve sampling and visibility-horizon options.
+export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPosition: (time: Time) => SunMoonPosition, options: LunarEclipseMapGeometryOptions = {}): LunarEclipseMapGeometry {
+	const maxAngularStep = options.maxAngularStep ?? DEFAULT_MAX_ANGULAR_STEP
+	const h0 = effectiveHorizonAltitude(options.horizonAltitude ?? 0, options.refraction ?? false, options.limbVisibility ?? 'center')
+
+	const contacts = lunarEclipseEvents(eclipse)
+	const events: LunarEclipseMapEvent[] = new Array(contacts.length)
+	const moonRiseSet: Writable<LunarEclipseContactCurves> = {}
+
+	for (let i = 0; i < contacts.length; i++) {
+		const event = buildMapEvent(contacts[i], sunMoonPosition, h0)
+		events[i] = event
+		moonRiseSet[event.kind] = [horizonCircle(event.declination, event.sublunar.x, h0, event.jd, maxAngularStep)]
+	}
+
+	return { eclipse, events, lines: { moonRiseSet } }
+}
+
+// Serializes one optional contact curve into SVG path data, splitting at the antimeridian during projection.
+function curveToSvgPath(curve: GeoCurve | undefined, projection: Projection, options: SolarEclipseMapSvgProjectionOptions) {
+	return curve && curve.length > 0 ? geoPolylinesToSvgPathData(curve, projection, options) : ''
+}
+
+// Projects the lunar eclipse map geometry and serializes each contact's horizon curve into an SVG path data
+// string, plus the projected sublunar points. Antimeridian wraps are split into separate subpaths at
+// projection time only; the geometry itself is never mutated.
+export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, projection: Projection, options: SolarEclipseMapSvgProjectionOptions = {}): LunarEclipseMapSvgPaths {
+	const { moonRiseSet } = geometry.lines
+	const sublunarPoints: Writable<LunarEclipseMapPoints> = {}
+
+	for (const event of geometry.events) {
+		const projected = projection.project(event.sublunar.x, event.sublunar.y, undefined, options)
+		if (projected) sublunarPoints[event.kind] = { x: projected.x, y: projected.y }
+	}
+
+	return {
+		moonRiseSet: {
+			P1: curveToSvgPath(moonRiseSet.P1, projection, options),
+			U1: curveToSvgPath(moonRiseSet.U1, projection, options),
+			U2: curveToSvgPath(moonRiseSet.U2, projection, options),
+			MAX: curveToSvgPath(moonRiseSet.MAX, projection, options),
+			U3: curveToSvgPath(moonRiseSet.U3, projection, options),
+			U4: curveToSvgPath(moonRiseSet.U4, projection, options),
+			P4: curveToSvgPath(moonRiseSet.P4, projection, options),
+		},
+		sublunarPoints,
+	}
+}

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -1,11 +1,11 @@
 import type { Angle } from './angle'
-import { DAYSEC, DEG2RAD, PIOVERTWO, TAU } from './constants'
+import { DAYSEC, DEG2RAD, PI, PIOVERTWO, TAU } from './constants'
 import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
 import { clamp } from './math'
 import type { LunarEclipse } from './moon'
 import type { Projection } from './projection'
-import { geoPolylinesToSvgPathData, normalizeLongitude, type GeoBranch, type GeoCurve, type GeoPoint, type SolarEclipseMapSvgProjectionOptions, type SunMoonPosition } from './sun.eclipse.map'
+import { geoPolylinesToSvgPathData, normalizeLongitude, pointsToSvgPathData, type GeoBranch, type GeoCurve, type GeoPoint, type SolarEclipseMapSvgProjectionOptions, type SunMoonPosition } from './sun.eclipse.map'
 import { tt, type Time, toJulianDay } from './time'
 import type { Writable } from './types'
 
@@ -122,18 +122,40 @@ export interface LunarEclipseMapPoints {
 	readonly P4?: Point
 }
 
+// One SVG path data string per contact (empty string when the contact does not exist).
+export interface LunarEclipseContactPaths {
+	readonly P1: string
+	readonly U1: string
+	readonly U2: string
+	readonly MAX: string
+	readonly U3: string
+	readonly U4: string
+	readonly P4: string
+}
+
+// Which side of a contact's horizon curve a fill polygon covers.
+//   'aboveHorizon': the visibility cap (where the Moon is up), closed against the enclosed pole;
+//   'belowHorizon': the complementary region (where the Moon is down), closed against the opposite pole.
+export type LunarEclipseFillRegion = 'aboveHorizon' | 'belowHorizon'
+
+// Options for serializing the lunar eclipse map to SVG, extending the shared projection/polyline options.
+export interface LunarEclipseMapSvgOptions extends SolarEclipseMapSvgProjectionOptions {
+	// When true, also emit closed region polygons (moonRiseSetFill) per contact, suitable for filling or
+	// gradients. Each polygon is the horizon curve closed against a map pole edge.
+	//
+	// This assumes a cylindrical, full-longitude projection (e.g. PlateCarree) able to represent the +-90 deg
+	// latitude edges: the visibility cap of a near-90 deg horizon circle always encloses a geographic pole, so
+	// the region is closed along that pole's map edge rather than across the map interior.
+	readonly fill?: boolean
+	// Which side of each horizon curve to fill. Default 'belowHorizon' (the not-visible region, for shading).
+	readonly fillRegion?: LunarEclipseFillRegion
+}
+
 // SVG path data strings per contact horizon curve, plus projected sublunar points.
 export interface LunarEclipseMapSvgPaths {
-	// Horizon-curve path data per contact (empty string when the contact does not exist).
-	readonly moonRiseSet: {
-		readonly P1: string
-		readonly U1: string
-		readonly U2: string
-		readonly MAX: string
-		readonly U3: string
-		readonly U4: string
-		readonly P4: string
-	}
+	// When fill=false, open horizon-curve path data per contact, split at the antimeridian.
+	// When fill=true, closed region-polygon path data per contact, present only when the fill option is set.
+	readonly moonRiseSet: LunarEclipseContactPaths
 	// Projected sublunar points, when present.
 	readonly sublunarPoints: LunarEclipseMapPoints
 }
@@ -265,7 +287,7 @@ export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPos
 	const h0 = effectiveHorizonAltitude(options.horizonAltitude ?? 0, options.refraction ?? false, options.limbVisibility ?? 'center')
 
 	const contacts = lunarEclipseEvents(eclipse)
-	const events: LunarEclipseMapEvent[] = new Array(contacts.length)
+	const events = new Array<LunarEclipseMapEvent>(contacts.length)
 	const moonRiseSet: Writable<LunarEclipseContactCurves> = {}
 
 	for (let i = 0; i < contacts.length; i++) {
@@ -282,10 +304,56 @@ function curveToSvgPath(curve: GeoCurve | undefined, projection: Projection, opt
 	return curve && curve.length > 0 ? geoPolylinesToSvgPathData(curve, projection, options) : ''
 }
 
+// Closes one contact's horizon curve into a fillable region polygon and serializes it.
+//
+// A near-90 deg horizon circle's visibility cap always encloses the geographic pole in the Moon's hemisphere
+// (north when declination >= 0, south otherwise), so the boundary is single-valued in longitude: each meridian
+// crosses it once. The boundary points are therefore sorted by longitude into a left-to-right profile and the
+// polygon is closed along a map pole edge (at +-PI longitude and +-90 deg latitude): the enclosed pole for the
+// 'aboveHorizon' cap, the opposite pole for its 'belowHorizon' complement. The geographic geometry is not
+// mutated; the closing happens here, at serialization time.
+//   declination: Moon declination at the contact (radians), selecting the enclosed pole.
+//   curve: the contact's horizon curve (a single closed ring as its first branch), or undefined.
+//   region: which side of the curve to fill.
+//   precision: SVG coordinate precision.
+//   options: projection polyline options shared with the open-curve serialization.
+function contactFillPath(declination: Angle, curve: GeoCurve | undefined, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+	if (!curve || curve.length === 0) return ''
+
+	const ring = curve[0]
+	if (ring.length < 4) return ''
+
+	// Latitude of the closing pole edge: the enclosed pole for the cap, the opposite pole for its complement.
+	const capPoleLat = declination >= 0 ? PIOVERTWO : -PIOVERTWO
+	const edgeLat = region === 'aboveHorizon' ? capPoleLat : -capPoleLat
+
+	// Sort the boundary into a left-to-right profile, dropping the duplicated closing vertex.
+	const sorted = ring.slice(0, ring.length - 1).sort((a, b) => a.x - b.x)
+
+	const polygon: Point[] = []
+
+	for (const point of sorted) {
+		const projected = projection.project(point.x, point.y, undefined, options)
+		if (projected) polygon.push({ x: projected.x, y: projected.y })
+	}
+
+	if (polygon.length < 2) return ''
+
+	// Close along the pole edge: from the rightmost boundary point to the +PI corner, across to the -PI corner.
+	const right = projection.project(PI, edgeLat, undefined, options)
+	const left = projection.project(-PI, edgeLat, undefined, options)
+	if (right) polygon.push({ x: right.x, y: right.y })
+	if (left) polygon.push({ x: left.x, y: left.y })
+	if (polygon.length < 3) return ''
+
+	return pointsToSvgPathData([polygon], true, precision)
+}
+
 // Projects the lunar eclipse map geometry and serializes each contact's horizon curve into an SVG path data
 // string, plus the projected sublunar points. Antimeridian wraps are split into separate subpaths at
-// projection time only; the geometry itself is never mutated.
-export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, projection: Projection, options: SolarEclipseMapSvgProjectionOptions = {}): LunarEclipseMapSvgPaths {
+// projection time only; the geometry itself is never mutated. When options.fill is set, also returns closed
+// region polygons per contact (see contactFillPath).
+export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, projection: Projection, options: LunarEclipseMapSvgOptions = {}): LunarEclipseMapSvgPaths {
 	const { moonRiseSet } = geometry.lines
 	const sublunarPoints: Writable<LunarEclipseMapPoints> = {}
 
@@ -294,16 +362,38 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 		if (projected) sublunarPoints[event.kind] = { x: projected.x, y: projected.y }
 	}
 
-	return {
-		moonRiseSet: {
-			P1: curveToSvgPath(moonRiseSet.P1, projection, options),
-			U1: curveToSvgPath(moonRiseSet.U1, projection, options),
-			U2: curveToSvgPath(moonRiseSet.U2, projection, options),
-			MAX: curveToSvgPath(moonRiseSet.MAX, projection, options),
-			U3: curveToSvgPath(moonRiseSet.U3, projection, options),
-			U4: curveToSvgPath(moonRiseSet.U4, projection, options),
-			P4: curveToSvgPath(moonRiseSet.P4, projection, options),
-		},
-		sublunarPoints,
+	if (options.fill) {
+		const region = options.fillRegion ?? 'belowHorizon'
+		const precision = options.precision ?? 2
+
+		// Declination per contact drives the enclosed pole; fall back to 0 (north) for an absent contact.
+		const declination: Partial<Record<LunarEclipseContactKind, Angle>> = {}
+		for (const event of geometry.events) declination[event.kind] = event.declination
+
+		return {
+			sublunarPoints,
+			moonRiseSet: {
+				P1: contactFillPath(declination.P1 ?? 0, moonRiseSet.P1, projection, region, precision, options),
+				U1: contactFillPath(declination.U1 ?? 0, moonRiseSet.U1, projection, region, precision, options),
+				U2: contactFillPath(declination.U2 ?? 0, moonRiseSet.U2, projection, region, precision, options),
+				MAX: contactFillPath(declination.MAX ?? 0, moonRiseSet.MAX, projection, region, precision, options),
+				U3: contactFillPath(declination.U3 ?? 0, moonRiseSet.U3, projection, region, precision, options),
+				U4: contactFillPath(declination.U4 ?? 0, moonRiseSet.U4, projection, region, precision, options),
+				P4: contactFillPath(declination.P4 ?? 0, moonRiseSet.P4, projection, region, precision, options),
+			},
+		}
+	} else {
+		return {
+			sublunarPoints,
+			moonRiseSet: {
+				P1: curveToSvgPath(moonRiseSet.P1, projection, options),
+				U1: curveToSvgPath(moonRiseSet.U1, projection, options),
+				U2: curveToSvgPath(moonRiseSet.U2, projection, options),
+				MAX: curveToSvgPath(moonRiseSet.MAX, projection, options),
+				U3: curveToSvgPath(moonRiseSet.U3, projection, options),
+				U4: curveToSvgPath(moonRiseSet.U4, projection, options),
+				P4: curveToSvgPath(moonRiseSet.P4, projection, options),
+			},
+		}
 	}
 }

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -517,16 +517,17 @@ const POLAR_CAP_FILL_PROJECTION_OPTIONS: ProjectionOptions = { centralMeridian: 
 //   region: which side of the curve to fill.
 //   precision: SVG coordinate precision.
 //   projectionOptions: projection options with the ring's central-meridian-neutral frame already applied.
-function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: EclipseGeoCurve | undefined, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, projectionOptions: ProjectionOptions) {
+//   centralMeridian: effective central meridian (radians) the open curves and sublunar points are projected with
+//   (call-time options.projectionOptions first, then the projection's own options); recenters the ring into it.
+//   direction: effective longitude axis ('east'/'west'), resolved the same way, so the fill follows the curves.
+function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: EclipseGeoCurve | undefined, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, projectionOptions: ProjectionOptions, centralMeridian: Angle, direction: RaAxisDirection) {
 	if (!curve || curve.length === 0) return ''
 
 	const ring = curve[0]
 	if (ring.length < 4) return ''
 
-	// Resolve the projection's central meridian and longitude axis, then recenter the ring so its antimeridian
-	// seam and +-PI map edges land at +-PI in the ring's own longitudes.
-	const centralMeridian = projection.options?.centralMeridian ?? 0
-	const direction: RaAxisDirection = projection.options?.raAxisDirection ?? 'east'
+	// Recenter the ring so its antimeridian seam and +-PI map edges land at +-PI in the ring's own longitudes,
+	// using the SAME effective central meridian and axis the open curves and sublunar points are projected with.
 	const wrappedRing = recenterRing(ring, centralMeridian, direction)
 
 	if (ringEnclosesPole(wrappedRing)) return polarCapFillPath(wrappedRing, event?.declination ?? 0, projection, region, precision, projectionOptions)
@@ -544,14 +545,21 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 	const sublunarPoints: Writable<LunarEclipseMapPoints> = Object.create(null)
 
 	for (const event of geometry.events) {
-		const projected = projection.project(event.sublunar.x, event.sublunar.y, undefined, projection.options)
+		const projected = projection.project(event.sublunar.x, event.sublunar.y, undefined, options.projectionOptions)
 		if (projected) sublunarPoints[event.kind] = projected
 	}
 
 	if (options.fill) {
 		const region = options.fillRegion ?? 'belowHorizon'
 		const precision = options.precision ?? 2
-		const projectionOptions: ProjectionOptions = { ...projection.options, ...POLAR_CAP_FILL_PROJECTION_OPTIONS }
+		const projectionOptions: ProjectionOptions = { ...options.projectionOptions, ...POLAR_CAP_FILL_PROJECTION_OPTIONS }
+
+		// Effective central meridian and longitude axis: call-time projection options first, then the projection's
+		// own options, then the defaults - the same resolution project() uses for the open curves and sublunar
+		// points, so the recentered fill follows them (reading only projection.options here left the fill at the
+		// projection's central meridian while the curves shifted with options.projectionOptions).
+		const centralMeridian = options.projectionOptions?.centralMeridian ?? projection.options?.centralMeridian ?? 0
+		const direction: RaAxisDirection = options.projectionOptions?.raAxisDirection ?? projection.options?.raAxisDirection ?? 'east'
 
 		// The event per contact drives the fill topology (declination for the enclosed pole, horizon and distance
 		// for the cap radius). Absent contacts have no event and no curve, so contactFillPath returns ''.
@@ -561,13 +569,13 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 		return {
 			sublunarPoints,
 			moonRiseSet: {
-				P1: contactFillPath(events.P1, moonRiseSet.P1, projection, region, precision, projectionOptions),
-				U1: contactFillPath(events.U1, moonRiseSet.U1, projection, region, precision, projectionOptions),
-				U2: contactFillPath(events.U2, moonRiseSet.U2, projection, region, precision, projectionOptions),
-				MAX: contactFillPath(events.MAX, moonRiseSet.MAX, projection, region, precision, projectionOptions),
-				U3: contactFillPath(events.U3, moonRiseSet.U3, projection, region, precision, projectionOptions),
-				U4: contactFillPath(events.U4, moonRiseSet.U4, projection, region, precision, projectionOptions),
-				P4: contactFillPath(events.P4, moonRiseSet.P4, projection, region, precision, projectionOptions),
+				P1: contactFillPath(events.P1, moonRiseSet.P1, projection, region, precision, projectionOptions, centralMeridian, direction),
+				U1: contactFillPath(events.U1, moonRiseSet.U1, projection, region, precision, projectionOptions, centralMeridian, direction),
+				U2: contactFillPath(events.U2, moonRiseSet.U2, projection, region, precision, projectionOptions, centralMeridian, direction),
+				MAX: contactFillPath(events.MAX, moonRiseSet.MAX, projection, region, precision, projectionOptions, centralMeridian, direction),
+				U3: contactFillPath(events.U3, moonRiseSet.U3, projection, region, precision, projectionOptions, centralMeridian, direction),
+				U4: contactFillPath(events.U4, moonRiseSet.U4, projection, region, precision, projectionOptions, centralMeridian, direction),
+				P4: contactFillPath(events.P4, moonRiseSet.P4, projection, region, precision, projectionOptions, centralMeridian, direction),
 			},
 		}
 	} else {

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -41,9 +41,14 @@ export type LunarEclipseContactKind = 'P1' | 'U1' | 'U2' | 'MAX' | 'U3' | 'U4' |
 // the curve marks where the Moon is seen on the apparent horizon rather than the true horizon.
 const HORIZON_REFRACTION: Angle = (34 / 60) * DEG2RAD
 
-// Mean lunar semidiameter (radians) used as a fallback upper-limb lift when no distance is available. The
-// Moon's geocentric semidiameter is ~0.259 deg on average; the sublunar-point altitude criterion uses the
-// geocentric direction, so a mean value is sufficient for the visibility horizon.
+// Mean lunar radius as a fraction of the Earth's equatorial radius (the IAU k factor for the apparent disk).
+// The apparent lunar semidiameter at geocentric Moon distance d (Earth equatorial radii) is
+// asin(MOON_RADIUS_EARTH_RADII / d): ~0.259 deg at the mean distance, ~0.279 deg near perigee. This is the
+// physical disk radius, distinct from the Meeus shadow-plane lunar radius used by the local magnitudes.
+export const MOON_RADIUS_EARTH_RADII = 0.2725076
+
+// Mean lunar semidiameter (radians, ~0.259 deg), used only as the upper-limb fallback when the Moon distance is
+// unusable. With a usable distance the per-event semidiameter asin(MOON_RADIUS_EARTH_RADII / distance) is used.
 const MEAN_MOON_SEMIDIAMETER: Angle = 0.259 * DEG2RAD
 
 // Default angular spacing (radians, 1 deg) between neighboring horizon-curve points.
@@ -224,13 +229,17 @@ function contactGast(time: Time, deltaT: number) {
 	return eraGst06a(ttTime.day, ut1Fraction, ttTime.day, ttTime.fraction)
 }
 
-// Effective visibility-horizon altitude (radians) for the Moon center, combining the configured horizon, the
-// optional refraction lift, and the optional upper-limb lowering by the Moon semidiameter.
-function effectiveHorizonAltitude(horizonAltitude: Angle, refraction: boolean, limbVisibility: LunarLimbVisibility) {
-	let h0 = horizonAltitude
-	if (refraction) h0 -= HORIZON_REFRACTION
-	if (limbVisibility === 'upperLimb') h0 -= MEAN_MOON_SEMIDIAMETER
-	return h0
+// Distance-independent base visibility-horizon altitude (radians): the configured horizon lowered by the
+// standard atmospheric refraction when enabled. The distance-dependent upper-limb lowering is applied per event
+// (see buildMapEvent), because the apparent semidiameter varies by ~0.02 deg between apogee and perigee.
+function baseHorizonAltitude(horizonAltitude: Angle, refraction: boolean) {
+	return refraction ? horizonAltitude - HORIZON_REFRACTION : horizonAltitude
+}
+
+// Apparent lunar semidiameter (radians) from the geocentric Moon distance in Earth equatorial radii. Falls back
+// to the mean value when the distance is unusable (non-finite, or not larger than the Moon radius).
+function moonSemidiameter(distance: number): Angle {
+	return distance > MOON_RADIUS_EARTH_RADII && Number.isFinite(distance) ? Math.asin(MOON_RADIUS_EARTH_RADII / distance) : MEAN_MOON_SEMIDIAMETER
 }
 
 // Generates the small circle where the observer's TOPOCENTRIC Moon altitude equals h0, centered at the sublunar
@@ -275,20 +284,25 @@ function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, distan
 }
 
 // Builds one map event from a contact: computes the apparent Moon position, GAST, the effective horizon and
-// the sublunar point.
-function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Time) => SunMoonPosition, h0: Angle): LunarEclipseMapEvent {
+// the sublunar point. For 'upperLimb' the base horizon is lowered by this event's actual apparent semidiameter
+// (from the Moon distance), not a mean, so a near-perigee eclipse marks the upper limb on the right boundary.
+//   baseHorizon: distance-independent horizon altitude (configured horizon minus refraction).
+//   limbVisibility: 'center' marks the Moon center on the horizon; 'upperLimb' marks the upper limb.
+function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Time) => SunMoonPosition, baseHorizon: Angle, limbVisibility: LunarLimbVisibility): LunarEclipseMapEvent {
 	const position = sunMoonPosition(contact.time)
 	const gast = contactGast(contact.time, position.deltaT ?? 0)
 	const rightAscension = position.moon.rightAscension
 	const declination = position.moon.declination
+	const distance = position.moon.distance
 	const sublunarLon = normalizeLongitude(rightAscension - gast)
+	const h0 = limbVisibility === 'upperLimb' ? baseHorizon - moonSemidiameter(distance) : baseHorizon
 
 	return {
 		...contact,
 		rightAscension,
 		declination,
 		gast,
-		distance: position.moon.distance,
+		distance,
 		horizonAltitude: h0,
 		sublunar: { x: sublunarLon, y: declination, jd: contact.jd },
 	}
@@ -301,16 +315,17 @@ function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Tim
 //   options: curve sampling and visibility-horizon options.
 export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPosition: (time: Time) => SunMoonPosition, options: LunarEclipseMapGeometryOptions = {}): LunarEclipseMapGeometry {
 	const maxAngularStep = options.maxAngularStep ?? DEFAULT_MAX_ANGULAR_STEP
-	const h0 = effectiveHorizonAltitude(options.horizonAltitude ?? 0, options.refraction ?? false, options.limbVisibility ?? 'center')
+	const baseHorizon = baseHorizonAltitude(options.horizonAltitude ?? 0, options.refraction ?? false)
+	const limbVisibility = options.limbVisibility ?? 'center'
 
 	const contacts = lunarEclipseEvents(eclipse)
 	const events = new Array<LunarEclipseMapEvent>(contacts.length)
 	const moonRiseSet: Writable<LunarEclipseContactCurves> = {}
 
 	for (let i = 0; i < contacts.length; i++) {
-		const event = buildMapEvent(contacts[i], sunMoonPosition, h0)
+		const event = buildMapEvent(contacts[i], sunMoonPosition, baseHorizon, limbVisibility)
 		events[i] = event
-		moonRiseSet[event.kind] = [horizonCircle(event.declination, event.sublunar.x, h0, event.distance, event.jd, maxAngularStep)]
+		moonRiseSet[event.kind] = [horizonCircle(event.declination, event.sublunar.x, event.horizonAltitude, event.distance, event.jd, maxAngularStep)]
 	}
 
 	return { eclipse, events, lines: { moonRiseSet } }

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -339,8 +339,8 @@ function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Tim
 //   options: curve sampling and visibility-horizon options.
 export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPosition: (time: Time) => SunMoonPosition, options: LunarEclipseMapGeometryOptions = {}): LunarEclipseMapGeometry {
 	const maxAngularStep = options.maxAngularStep !== undefined && Number.isFinite(options.maxAngularStep) && options.maxAngularStep > 0 ? options.maxAngularStep : DEFAULT_MAX_ANGULAR_STEP
-	const horizonAltitude = options.horizonAltitude !== undefined && Number.isFinite(options.horizonAltitude) && options.horizonAltitude > 0 ? options.horizonAltitude : 0
-	const baseHorizon = baseHorizonAltitude(horizonAltitude ?? 0, options.refraction ?? false)
+	const horizonAltitude = options.horizonAltitude !== undefined && Number.isFinite(options.horizonAltitude) ? options.horizonAltitude : 0
+	const baseHorizon = baseHorizonAltitude(horizonAltitude, options.refraction ?? false)
 	const limbVisibility = options.limbVisibility ?? 'center'
 
 	const contacts = lunarEclipseEvents(eclipse)
@@ -513,8 +513,8 @@ const POLAR_CAP_FILL_PROJECTION_OPTIONS: ProjectionOptions = { centralMeridian: 
 //   curve: the contact's horizon curve (a single closed ring as its first branch), or undefined.
 //   region: which side of the curve to fill.
 //   precision: SVG coordinate precision.
-//   options: projection polyline options shared with the open-curve serialization.
-function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurve | undefined, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number): string {
+//   projectionOptions: projection options with the ring's central-meridian-neutral frame already applied.
+function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurve | undefined, projection: CylindricalProjection, region: LunarEclipseFillRegion, precision: number, projectionOptions: ProjectionOptions) {
 	if (!curve || curve.length === 0) return ''
 
 	const ring = curve[0]
@@ -526,11 +526,10 @@ function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurv
 	const direction: RaAxisDirection = projection.options?.raAxisDirection ?? 'east'
 	const wrappedRing = recenterRing(ring, centralMeridian, direction)
 
-	const wrappedOptions: ProjectionOptions = { ...projection.options, ...POLAR_CAP_FILL_PROJECTION_OPTIONS }
-	if (ringEnclosesPole(wrappedRing)) return polarCapFillPath(wrappedRing, event?.declination ?? 0, projection, region, precision, wrappedOptions)
+	if (ringEnclosesPole(wrappedRing)) return polarCapFillPath(wrappedRing, event?.declination ?? 0, projection, region, precision, projectionOptions)
 
 	const capExceedsHemisphere = event ? capRadius(event.horizonAltitude, event.distance) > PIOVERTWO : false
-	return nonPolarCapFillPath(wrappedRing, projection, region, capExceedsHemisphere, precision, wrappedOptions)
+	return nonPolarCapFillPath(wrappedRing, projection, region, capExceedsHemisphere, precision, projectionOptions)
 }
 
 // Projects the lunar eclipse map geometry and serializes each contact's horizon curve into an SVG path data
@@ -549,6 +548,7 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 	if (options.fill) {
 		const region = options.fillRegion ?? 'belowHorizon'
 		const precision = options.precision ?? 2
+		const projectionOptions: ProjectionOptions = { ...projection.options, ...POLAR_CAP_FILL_PROJECTION_OPTIONS }
 
 		// The event per contact drives the fill topology (declination for the enclosed pole, horizon and distance
 		// for the cap radius). Absent contacts have no event and no curve, so contactFillPath returns ''.
@@ -558,13 +558,13 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 		return {
 			sublunarPoints,
 			moonRiseSet: {
-				P1: contactFillPath(events.P1, moonRiseSet.P1, projection, region, precision),
-				U1: contactFillPath(events.U1, moonRiseSet.U1, projection, region, precision),
-				U2: contactFillPath(events.U2, moonRiseSet.U2, projection, region, precision),
-				MAX: contactFillPath(events.MAX, moonRiseSet.MAX, projection, region, precision),
-				U3: contactFillPath(events.U3, moonRiseSet.U3, projection, region, precision),
-				U4: contactFillPath(events.U4, moonRiseSet.U4, projection, region, precision),
-				P4: contactFillPath(events.P4, moonRiseSet.P4, projection, region, precision),
+				P1: contactFillPath(events.P1, moonRiseSet.P1, projection, region, precision, projectionOptions),
+				U1: contactFillPath(events.U1, moonRiseSet.U1, projection, region, precision, projectionOptions),
+				U2: contactFillPath(events.U2, moonRiseSet.U2, projection, region, precision, projectionOptions),
+				MAX: contactFillPath(events.MAX, moonRiseSet.MAX, projection, region, precision, projectionOptions),
+				U3: contactFillPath(events.U3, moonRiseSet.U3, projection, region, precision, projectionOptions),
+				U4: contactFillPath(events.U4, moonRiseSet.U4, projection, region, precision, projectionOptions),
+				P4: contactFillPath(events.P4, moonRiseSet.P4, projection, region, precision, projectionOptions),
 			},
 		}
 	} else {

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -314,7 +314,10 @@ function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Tim
 //   sunMoonPosition: apparent Sun/Moon position provider at a dynamical time (see computeSunMoonPositionAt).
 //   options: curve sampling and visibility-horizon options.
 export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPosition: (time: Time) => SunMoonPosition, options: LunarEclipseMapGeometryOptions = {}): LunarEclipseMapGeometry {
-	const maxAngularStep = options.maxAngularStep ?? DEFAULT_MAX_ANGULAR_STEP
+	// Use the requested spacing only when it is a finite positive angle; otherwise fall back to the default, so an
+	// invalid maxAngularStep (0, negative, NaN or Infinity) can never make a curve's sample count non-finite and
+	// throw a RangeError from new Array(...) before any geometry is returned.
+	const maxAngularStep = options.maxAngularStep !== undefined && Number.isFinite(options.maxAngularStep) && options.maxAngularStep > 0 ? options.maxAngularStep : DEFAULT_MAX_ANGULAR_STEP
 	const baseHorizon = baseHorizonAltitude(options.horizonAltitude ?? 0, options.refraction ?? false)
 	const limbVisibility = options.limbVisibility ?? 'center'
 

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -416,6 +416,10 @@ function projectedWorldRect(projection: CylindricalProjection, options: Projecti
 	return rect
 }
 
+function ringPointComparatorByX(a: EclipseGeoPoint, b: EclipseGeoPoint) {
+	return a.x - b.x
+}
+
 // Fill polygon for a POLE-ENCLOSING cap. The boundary is single-valued in longitude (each meridian crosses it
 // once), so the points are sorted into a left-to-right profile and closed along a map pole edge: the enclosed
 // pole for the 'aboveHorizon' cap, the opposite pole for its 'belowHorizon' complement. The result is one
@@ -425,7 +429,7 @@ function polarCapFillPath(ring: EclipseGeoBranch, declination: Angle, projection
 	const edgeLat = region === 'aboveHorizon' ? capPoleLat : -capPoleLat
 
 	// Sort the boundary into a left-to-right profile, dropping the duplicated closing vertex.
-	const sorted = ring.slice(0, ring.length - 1).sort((a, b) => a.x - b.x)
+	const sorted = ring.slice(0, ring.length - 1).sort(ringPointComparatorByX)
 	const polygon: Point[] = []
 
 	for (const point of sorted) {

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -17,11 +17,17 @@ import type { Writable } from './types'
 // hemisphere that sees the Moon above the horizon and the hemisphere that does not. The physical umbra and
 // penumbra geometry belongs to the Moon's plane and is exposed by the local view, not by this global map.
 //
-// Geometry of one contact curve: the locus where the apparent Moon altitude equals a chosen visibility
-// horizon h0 is a small circle on the sphere centered at the sublunar point (the place where the Moon is at
-// the zenith) at angular radius (PI/2 - h0). The sublunar point is at latitude = declination and longitude =
-// rightAscension - GAST. This is computed by a direct bearing sweep, which is robust at high declination and
-// near the poles, where a longitude scan would be double-valued or undefined.
+// Geometry of one contact curve: rise/set is a TOPOCENTRIC condition, so the curve is the locus where the
+// observer's topocentric Moon altitude equals a chosen visibility horizon h0. That locus is still a small
+// circle on the sphere centered at the sublunar point (the place where the Moon is at the zenith), but its
+// geocentric angular radius is (PI/2 - h0 - p), where p = asin(cos(h0) / d) is the lunar parallax in altitude
+// at zenith distance (90 deg - h0) and d is the Moon distance in Earth equatorial radii. Folding the parallax
+// into the radius keeps the topocentric center on the horizon h0; using the bare geocentric radius (PI/2 - h0)
+// would leave every point about one horizontal parallax (~0.95 deg) above the rise/set boundary it should mark.
+// The reduction uses a spherical observer (geocentric radius 1 equatorial Earth radius); the residual flattening
+// term is well under the curve resolution. The sublunar point is at latitude = declination and longitude =
+// rightAscension - GAST. The circle is swept by bearing, which is robust at high declination and near the poles,
+// where a longitude scan would be double-valued or undefined.
 //
 // Unit conventions:
 //   - angles (right ascension, declination, longitude, latitude, altitudes) in radians;
@@ -79,15 +85,17 @@ export interface LunarEclipseMapEvent extends LunarEclipseContact {
 	readonly declination: Angle
 	// Greenwich apparent sidereal time (radians) at the contact.
 	readonly gast: Angle
+	// Apparent geocentric Moon distance in Earth equatorial radii, used for the parallax-reduced curve radius.
+	readonly distance: number
 	// Effective visibility-horizon altitude (radians) used to draw this contact's curve.
 	readonly horizonAltitude: Angle
 	// Sublunar point: where the Moon is at the local zenith (latitude = declination, longitude = RA - GAST).
 	readonly sublunar: GeoPoint
 }
 
-// Per-contact moon rise/set (horizon) curves. Each curve is the small circle where the Moon altitude equals
-// the contact's visibility horizon; it is kept unsplit (one closed branch) and projection-agnostic, the
-// antimeridian split happening only at serialization time.
+// Per-contact moon rise/set (horizon) curves. Each curve is the small circle where the observer's topocentric
+// Moon altitude equals the contact's visibility horizon; it is kept unsplit (one closed branch) and
+// projection-agnostic, the antimeridian split happening only at serialization time.
 export interface LunarEclipseContactCurves {
 	readonly P1?: GeoCurve
 	readonly U1?: GeoCurve
@@ -223,17 +231,23 @@ function effectiveHorizonAltitude(horizonAltitude: Angle, refraction: boolean, l
 	return h0
 }
 
-// Generates the small circle where the Moon altitude equals h0, centered at the sublunar point. The circle has
-// spherical radius (PI/2 - h0); points are swept by bearing so spacing stays near maxAngularStep along the
-// circle and the curve is well behaved at high declination and near the poles. The returned branch is closed
-// (first point repeated) and projection-agnostic; the antimeridian split happens at serialization time.
+// Generates the small circle where the observer's TOPOCENTRIC Moon altitude equals h0, centered at the sublunar
+// point. The geocentric angular radius is (PI/2 - h0 - p), where p = asin(cos(h0) / distance) is the parallax in
+// altitude that pushes the Moon down for a surface observer; this keeps the topocentric center on the horizon h0
+// rather than ~one horizontal parallax above it. Points are swept by bearing so spacing stays near maxAngularStep
+// along the circle and the curve is well behaved at high declination and near the poles. The returned branch is
+// closed (first point repeated) and projection-agnostic; the antimeridian split happens at serialization time.
 //   sublunarLat: latitude of the sublunar point (= Moon declination), radians.
 //   sublunarLon: longitude of the sublunar point (= RA - GAST), radians, east-positive.
-//   h0: visibility-horizon altitude, radians.
+//   h0: topocentric visibility-horizon altitude, radians.
+//   distance: apparent geocentric Moon distance in Earth equatorial radii (sets the parallax reduction).
 //   jd: Julian Day stamped on every point of the curve.
 //   maxAngularStep: target geodesic spacing between neighboring points, radians.
-function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, jd: number, maxAngularStep: Angle) {
-	const rho = PIOVERTWO - h0
+function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, distance: number, jd: number, maxAngularStep: Angle) {
+	// Lunar parallax in altitude at zenith distance (90 deg - h0): sin(p) = cos(h0) / d for a spherical observer.
+	// A degraded distance (non-finite or <= 1) falls back to the geocentric circle.
+	const parallax = distance > 1 && Number.isFinite(distance) ? Math.asin(clamp(Math.cos(h0) / distance, -1, 1)) : 0
+	const rho = PIOVERTWO - h0 - parallax
 	const sinClat = Math.sin(sublunarLat)
 	const cosClat = Math.cos(sublunarLat)
 	const sinRho = Math.sin(rho)
@@ -272,6 +286,7 @@ function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Tim
 		rightAscension,
 		declination,
 		gast,
+		distance: position.moon.distance,
 		horizonAltitude: h0,
 		sublunar: { x: sublunarLon, y: declination, jd: contact.jd },
 	}
@@ -293,7 +308,7 @@ export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPos
 	for (let i = 0; i < contacts.length; i++) {
 		const event = buildMapEvent(contacts[i], sunMoonPosition, h0)
 		events[i] = event
-		moonRiseSet[event.kind] = [horizonCircle(event.declination, event.sublunar.x, h0, event.jd, maxAngularStep)]
+		moonRiseSet[event.kind] = [horizonCircle(event.declination, event.sublunar.x, h0, event.distance, event.jd, maxAngularStep)]
 	}
 
 	return { eclipse, events, lines: { moonRiseSet } }

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -338,11 +338,9 @@ function buildMapEvent(contact: LunarEclipseContact, sunMoonPosition: (time: Tim
 //   sunMoonPosition: apparent Sun/Moon position provider at a dynamical time (see computeSunMoonPositionAt).
 //   options: curve sampling and visibility-horizon options.
 export function computeLunarEclipseMapGeometry(eclipse: LunarEclipse, sunMoonPosition: (time: Time) => SunMoonPosition, options: LunarEclipseMapGeometryOptions = {}): LunarEclipseMapGeometry {
-	// Use the requested spacing only when it is a finite positive angle; otherwise fall back to the default, so an
-	// invalid maxAngularStep (0, negative, NaN or Infinity) can never make a curve's sample count non-finite and
-	// throw a RangeError from new Array(...) before any geometry is returned.
 	const maxAngularStep = options.maxAngularStep !== undefined && Number.isFinite(options.maxAngularStep) && options.maxAngularStep > 0 ? options.maxAngularStep : DEFAULT_MAX_ANGULAR_STEP
-	const baseHorizon = baseHorizonAltitude(options.horizonAltitude ?? 0, options.refraction ?? false)
+	const horizonAltitude = options.horizonAltitude !== undefined && Number.isFinite(options.horizonAltitude) && options.horizonAltitude > 0 ? options.horizonAltitude : 0
+	const baseHorizon = baseHorizonAltitude(horizonAltitude ?? 0, options.refraction ?? false)
 	const limbVisibility = options.limbVisibility ?? 'center'
 
 	const contacts = lunarEclipseEvents(eclipse)

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -544,7 +544,7 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 	const sublunarPoints: Writable<LunarEclipseMapPoints> = Object.create(null)
 
 	for (const event of geometry.events) {
-		const projected = projection.project(event.sublunar.x, event.sublunar.y)
+		const projected = projection.project(event.sublunar.x, event.sublunar.y, undefined, projection.options)
 		if (projected) sublunarPoints[event.kind] = projected
 	}
 

--- a/src/moon.eclipse.map.ts
+++ b/src/moon.eclipse.map.ts
@@ -244,6 +244,17 @@ function moonSemidiameter(distance: number): Angle {
 	return distance > MOON_RADIUS_EARTH_RADII && Number.isFinite(distance) ? Math.asin(MOON_RADIUS_EARTH_RADII / distance) : MEAN_MOON_SEMIDIAMETER
 }
 
+// Geocentric angular radius (radians) of the topocentric horizon circle: PI/2 - h0 - p, where p =
+// asin(cos(h0) / distance) is the lunar parallax in altitude (a degraded distance falls back to no parallax).
+// It exceeds PI/2 (a visibility cap larger than a hemisphere, enclosing the sublunar point and both poles) when
+// h0 is below the negative parallax, e.g. a sufficiently negative configured horizon.
+//   h0: topocentric visibility-horizon altitude (radians).
+//   distance: apparent geocentric Moon distance in Earth equatorial radii.
+function capRadius(h0: Angle, distance: number): Angle {
+	const parallax = distance > 1 && Number.isFinite(distance) ? Math.asin(clamp(Math.cos(h0) / distance, -1, 1)) : 0
+	return PIOVERTWO - h0 - parallax
+}
+
 // Generates the small circle where the observer's TOPOCENTRIC Moon altitude equals h0, centered at the sublunar
 // point. The geocentric angular radius is (PI/2 - h0 - p), where p = asin(cos(h0) / distance) is the parallax in
 // altitude that pushes the Moon down for a surface observer; this keeps the topocentric center on the horizon h0
@@ -257,10 +268,7 @@ function moonSemidiameter(distance: number): Angle {
 //   jd: Julian Day stamped on every point of the curve.
 //   maxAngularStep: target geodesic spacing between neighboring points, radians.
 function horizonCircle(sublunarLat: Angle, sublunarLon: Angle, h0: Angle, distance: number, jd: number, maxAngularStep: Angle) {
-	// Lunar parallax in altitude at zenith distance (90 deg - h0): sin(p) = cos(h0) / d for a spherical observer.
-	// A degraded distance (non-finite or <= 1) falls back to the geocentric circle.
-	const parallax = distance > 1 && Number.isFinite(distance) ? Math.asin(clamp(Math.cos(h0) / distance, -1, 1)) : 0
-	const rho = PIOVERTWO - h0 - parallax
+	const rho = capRadius(h0, distance)
 	const sinClat = Math.sin(sublunarLat)
 	const cosClat = Math.cos(sublunarLat)
 	const sinRho = Math.sin(rho)
@@ -417,39 +425,51 @@ function polarCapFillPath(ring: GeoBranch, declination: Angle, projection: Proje
 	return pointsToSvgPathData([polygon], true, precision)
 }
 
-// Fill polygon for a cap that encloses NEITHER pole (a near-equatorial eclipse). The cap is the bounded ring
-// itself, so 'aboveHorizon' is just the projected ring; 'belowHorizon' (the complement, which contains both
-// poles) is the map rectangle with the cap punched out as a hole. Both rely on fill-rule "evenodd": for
-// 'belowHorizon' a point inside the cap is covered by the rectangle and a cap piece (even -> not filled), and a
-// point outside is covered only by the rectangle (odd -> filled).
-function nonPolarCapFillPath(ring: GeoBranch, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
-	const capPieces = projectRingPieces(ring, projection, options)
-	if (capPieces.length === 0) return ''
+// Fill polygon for a horizon ring that encloses NEITHER pole. Two topologies share this branch:
+//   - the usual near-equatorial cap, a bounded ring smaller than a hemisphere around the sublunar point, so the
+//     ring bounds the 'aboveHorizon' region;
+//   - a cap larger than a hemisphere (a sufficiently negative horizon), where the above-horizon region contains
+//     the sublunar point AND both poles and the bounded ring is instead the small antipodal 'belowHorizon' hole.
+// The capExceedsHemisphere flag selects which side the ring bounds; the other side is the map rectangle with the
+// ring punched out as a hole, which (like the ring's own antimeridian pieces) fills correctly under fill-rule
+// "evenodd": a point inside the ring is covered by the rectangle and a ring piece (even -> not filled), a point
+// outside only by the rectangle (odd -> filled).
+function nonPolarCapFillPath(ring: GeoBranch, projection: Projection, region: LunarEclipseFillRegion, capExceedsHemisphere: boolean, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+	const ringPieces = projectRingPieces(ring, projection, options)
+	if (ringPieces.length === 0) return ''
 
-	if (region === 'aboveHorizon') return pointsToSvgPathData(capPieces, true, precision)
+	// The ring bounds the above-horizon region for a sub-hemisphere cap, and the below-horizon region otherwise;
+	// fill it directly when the side it bounds is the requested side, else fill the complement.
+	const ringIsAbove = !capExceedsHemisphere
+	const wantAbove = region === 'aboveHorizon'
+	if (ringIsAbove === wantAbove) return pointsToSvgPathData(ringPieces, true, precision)
 
 	const rect = projectedWorldRect(projection, options)
 	if (rect.length < 3) return ''
-	return pointsToSvgPathData([rect, ...capPieces], true, precision)
+	return pointsToSvgPathData([rect, ...ringPieces], true, precision)
 }
 
-// Closes one contact's horizon curve into a fillable region polygon and serializes it. The visibility cap
-// either encloses a geographic pole (closed along the pole edge) or encloses neither pole for a near-equatorial
-// eclipse (filled as the bounded ring, or its complement); the topology is read from the ring's winding so the
-// correct side is filled in both cases. The geographic geometry is not mutated; the closing happens here.
-//   declination: Moon declination at the contact (radians), selecting the enclosed pole for a polar cap.
+// Closes one contact's horizon curve into a fillable region polygon and serializes it. The visibility cap either
+// encloses a geographic pole (closed along the pole edge, correct whatever its size) or encloses neither pole; in
+// the latter case the cap radius distinguishes the usual sub-hemisphere cap from a larger-than-hemisphere cap
+// (whose ring is the antipodal below-horizon hole), so the correct side is filled in every case. The geographic
+// geometry is not mutated; the closing happens here.
+//   event: the map event for the contact (declination selects the enclosed pole; horizon and distance set the
+//   cap radius), or undefined.
 //   curve: the contact's horizon curve (a single closed ring as its first branch), or undefined.
 //   region: which side of the curve to fill.
 //   precision: SVG coordinate precision.
 //   options: projection polyline options shared with the open-curve serialization.
-function contactFillPath(declination: Angle, curve: GeoCurve | undefined, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
+function contactFillPath(event: LunarEclipseMapEvent | undefined, curve: GeoCurve | undefined, projection: Projection, region: LunarEclipseFillRegion, precision: number, options: SolarEclipseMapSvgProjectionOptions): string {
 	if (!curve || curve.length === 0) return ''
 
 	const ring = curve[0]
 	if (ring.length < 4) return ''
 
-	if (ringEnclosesPole(ring)) return polarCapFillPath(ring, declination, projection, region, precision, options)
-	return nonPolarCapFillPath(ring, projection, region, precision, options)
+	if (ringEnclosesPole(ring)) return polarCapFillPath(ring, event?.declination ?? 0, projection, region, precision, options)
+
+	const capExceedsHemisphere = event ? capRadius(event.horizonAltitude, event.distance) > PIOVERTWO : false
+	return nonPolarCapFillPath(ring, projection, region, capExceedsHemisphere, precision, options)
 }
 
 // Projects the lunar eclipse map geometry and serializes each contact's horizon curve into an SVG path data
@@ -469,20 +489,21 @@ export function lunarEclipseMapToSvgPaths(geometry: LunarEclipseMapGeometry, pro
 		const region = options.fillRegion ?? 'belowHorizon'
 		const precision = options.precision ?? 2
 
-		// Declination per contact drives the enclosed pole; fall back to 0 (north) for an absent contact.
-		const declination: Partial<Record<LunarEclipseContactKind, Angle>> = {}
-		for (const event of geometry.events) declination[event.kind] = event.declination
+		// The event per contact drives the fill topology (declination for the enclosed pole, horizon and distance
+		// for the cap radius). Absent contacts have no event and no curve, so contactFillPath returns ''.
+		const eventByKind: Partial<Record<LunarEclipseContactKind, LunarEclipseMapEvent>> = {}
+		for (const event of geometry.events) eventByKind[event.kind] = event
 
 		return {
 			sublunarPoints,
 			moonRiseSet: {
-				P1: contactFillPath(declination.P1 ?? 0, moonRiseSet.P1, projection, region, precision, options),
-				U1: contactFillPath(declination.U1 ?? 0, moonRiseSet.U1, projection, region, precision, options),
-				U2: contactFillPath(declination.U2 ?? 0, moonRiseSet.U2, projection, region, precision, options),
-				MAX: contactFillPath(declination.MAX ?? 0, moonRiseSet.MAX, projection, region, precision, options),
-				U3: contactFillPath(declination.U3 ?? 0, moonRiseSet.U3, projection, region, precision, options),
-				U4: contactFillPath(declination.U4 ?? 0, moonRiseSet.U4, projection, region, precision, options),
-				P4: contactFillPath(declination.P4 ?? 0, moonRiseSet.P4, projection, region, precision, options),
+				P1: contactFillPath(eventByKind.P1, moonRiseSet.P1, projection, region, precision, options),
+				U1: contactFillPath(eventByKind.U1, moonRiseSet.U1, projection, region, precision, options),
+				U2: contactFillPath(eventByKind.U2, moonRiseSet.U2, projection, region, precision, options),
+				MAX: contactFillPath(eventByKind.MAX, moonRiseSet.MAX, projection, region, precision, options),
+				U3: contactFillPath(eventByKind.U3, moonRiseSet.U3, projection, region, precision, options),
+				U4: contactFillPath(eventByKind.U4, moonRiseSet.U4, projection, region, precision, options),
+				P4: contactFillPath(eventByKind.P4, moonRiseSet.P4, projection, region, precision, options),
 			},
 		}
 	} else {

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -151,9 +151,9 @@ export class AzimuthalEquidistant extends AzimuthalProjection {
 export abstract class CylindricalProjection implements Projection {
 	constructor(readonly options?: ProjectionOptions) {}
 
-	abstract project(lambda: Angle, phi: Angle, out?: Point): Point | undefined
+	abstract project(lambda: Angle, phi: Angle, out?: Point, options?: ProjectionOptions): Point | undefined
 
-	abstract unproject(x: number, y: number, out?: Point): Point | undefined
+	abstract unproject(x: number, y: number, out?: Point, options?: ProjectionOptions): Point | undefined
 }
 
 export class Mercator extends CylindricalProjection {

--- a/src/sun.eclipse.local.ts
+++ b/src/sun.eclipse.local.ts
@@ -1,12 +1,13 @@
 import { type Angle, normalizeAngle, normalizePI } from './angle'
 import { ASEC2RAD, DAYSEC, EARTH_RADIUS_KM, PI } from './constants'
+import { F, hourAngleFromLongitude, type SunMoonPosition } from './eclipse'
 import { eraGst06a } from './erfa'
 import type { Point } from './geometry'
 import { clamp } from './math'
 import { bisection, brentMinimize, type RootFindingOptions } from './optimization'
 import { nearestSolarEclipse, type SolarEclipse } from './sun'
 // oxfmt-ignore
-import { besselianSampleAtJulianDay, centralAxisIntersectsEarth, centralLineKind, computePolynomialBesselianElements, evaluateBesselian, F, findMaximumPoint, hourAngleFromLongitude, projectFundamentalPoint, solarAltitudeAtPoint, SUN_RADIUS_EARTH_RADII, type GeoPoint, type InstantBesselianElements, type PolynomialBesselianElements, type SunMoonPosition } from './sun.eclipse.map'
+import { besselianSampleAtJulianDay, centralAxisIntersectsEarth, centralLineKind, computePolynomialBesselianElements, evaluateBesselian, findMaximumPoint, projectFundamentalPoint, solarAltitudeAtPoint, SUN_RADIUS_EARTH_RADII, type SolarEclipseGeoPoint, type InstantBesselianElements, type PolynomialBesselianElements } from './sun.eclipse.map'
 import { type Time, timeAtJulianDay, toJulianDay, tt } from './time'
 import type { Writable } from './types'
 
@@ -353,7 +354,7 @@ export interface SolarEclipseExtremeCircumstances {
 	// Duration of the central (total/annular) phase in seconds; null when the point is not central.
 	readonly centralDuration: number | null
 	// Local eclipse character at the event; null when the point is not central.
-	readonly kind: GeoPoint['kind'] | null
+	readonly kind: SolarEclipseGeoPoint['kind'] | null
 }
 
 const DEFAULT_LOCAL_SOLAR_ECLIPSE_CIRCUMSTANCES_OPTIONS: LocalSolarEclipseCircumstancesOptions = {}
@@ -490,7 +491,7 @@ function localStateAtJulianDay(pbe: PolynomialBesselianElements, longitude: Angl
 // right ascension/declination and Greenwich apparent sidereal time; without it, it falls back to the
 // Besselian shadow-axis altitude (an approximation: the axis is treated as the Sun direction and the
 // geodetic latitude is used directly, matching solarAltitudeAtPoint in sun.eclipse.ts).
-function computeSolarAltitude(time: Time, longitude: Angle, latitude: Angle, position: SunMoonPosition | undefined, fallbackBesselian?: InstantBesselianElements) {
+function computeSolarAltitude(time: Time, longitude: Angle, latitude: Angle, position?: SunMoonPosition, fallbackBesselian?: InstantBesselianElements) {
 	if (position) {
 		const deltaT = position.deltaT ?? 0
 		const ttTime = tt(time)
@@ -1583,7 +1584,7 @@ function centralConeGap(be: Pick<InstantBesselianElements, 'mu' | 'deltaT' | 'de
 // shadow-axis declination as the Sun direction (exact on the central line). The standard horizontal
 // transform gives azimuth from the South through West; adding PI rotates it to the North-through-East
 // convention used by the NASA tables.
-function solarAzimuthAtPoint(pbe: PolynomialBesselianElements, point: GeoPoint) {
+function solarAzimuthAtPoint(pbe: PolynomialBesselianElements, point: SolarEclipseGeoPoint) {
 	const be = besselianSampleAtJulianDay(pbe, point.jd!)
 	const H = hourAngleFromLongitude(point.x, be.mu, be.deltaTLongitudeCorrection)
 	const sinPhi = Math.sin(point.y)
@@ -1605,7 +1606,7 @@ function centralPhaseDurationSeconds(pbe: PolynomialBesselianElements, longitude
 
 // Assembles the full summary circumstances at one central-eclipse point: geographic location, TD/UT1 times,
 // solar altitude and azimuth, and (when the point is central) the path width, central duration and character.
-function extremeCircumstancesAt(pbe: PolynomialBesselianElements, point: GeoPoint): SolarEclipseExtremeCircumstances {
+function extremeCircumstancesAt(pbe: PolynomialBesselianElements, point: SolarEclipseGeoPoint): SolarEclipseExtremeCircumstances {
 	const jd = point.jd!
 	const time = timeAtJulianDay(pbe.time0, jd)
 	const centralDuration = centralPhaseDurationSeconds(pbe, point.x, point.y, jd)

--- a/src/sun.eclipse.local.ts
+++ b/src/sun.eclipse.local.ts
@@ -7,7 +7,7 @@ import { bisection, brentMinimize, type RootFindingOptions } from './optimizatio
 import { nearestSolarEclipse, type SolarEclipse } from './sun'
 // oxfmt-ignore
 import { besselianSampleAtJulianDay, centralAxisIntersectsEarth, centralLineKind, computePolynomialBesselianElements, evaluateBesselian, F, findMaximumPoint, hourAngleFromLongitude, projectFundamentalPoint, solarAltitudeAtPoint, SUN_RADIUS_EARTH_RADII, type GeoPoint, type InstantBesselianElements, type PolynomialBesselianElements, type SunMoonPosition } from './sun.eclipse.map'
-import { type Time, timeShift, toJulianDay, tt } from './time'
+import { type Time, timeAtJulianDay, toJulianDay, tt } from './time'
 import type { Writable } from './types'
 
 // Local solar eclipse circumstances ("Local View"): for a single geographic point this module resolves
@@ -369,11 +369,6 @@ const DEFAULT_LOCAL_VIEW_OPTIONS: LocalSolarEclipseViewOptions = {
 	includeGhostDisks: true,
 	includeHorizon: true,
 	horizonBandPaddingPx: 4,
-}
-
-// Builds a Time at a Julian Day, preserving the reference time scale and providers.
-function timeAtJulianDay(reference: Time, julianDay: number) {
-	return timeShift(reference, julianDay - reference.day - reference.fraction)
 }
 
 // Computes the local fundamental-plane geometry for one observer at one instant, following the same

--- a/src/sun.eclipse.map.ts
+++ b/src/sun.eclipse.map.ts
@@ -8,7 +8,7 @@ import { sphericalInterpolate, sphericalSeparation, type Point } from './geometr
 import { matMulVec } from './mat3'
 import { clamp, type NumberArray } from './math'
 import { bisection, brentMinimize, brentRoot, type RootFindingOptions } from './optimization'
-import type { Projection, ProjectionPolylineOptions } from './projection'
+import type { CylindricalProjection, ProjectionOptions } from './projection'
 import { polynomialRegression } from './regression'
 import type { SolarEclipse } from './sun'
 import { precessionNutationMatrix, timeShift, timeSubtract, toJulianDay, tt, type Time } from './time'
@@ -373,9 +373,10 @@ export interface SolarEclipseRiseSetCurveOptions {
 }
 
 // Options for projecting eclipse map geometry onto a (cylindrical) SVG.
-export interface SolarEclipseMapSvgProjectionOptions extends ProjectionPolylineOptions {
+export interface SolarEclipseMapSvgProjectionOptions {
 	// Number of decimal places kept in the path coordinates (default 2).
 	readonly precision?: number
+	readonly projectionOptions?: ProjectionOptions | undefined
 }
 
 export interface SolarEclipseMapPoints {
@@ -412,6 +413,11 @@ export interface SolarEclipseMapSvgPaths {
 	readonly riseSetCurves: string
 	// Projected pixel coordinates of the named contact and greatest-eclipse points, when present.
 	readonly points: SolarEclipseMapPoints
+}
+
+const DEFAULT_SOLAR_ECLIPSE_MAP_SVG_PROJECTION_OPTIONS: SolarEclipseMapSvgProjectionOptions = {
+	precision: 2,
+	projectionOptions: undefined,
 }
 
 function finitePoint(point: GeoPoint | undefined): point is GeoPoint {
@@ -3424,7 +3430,7 @@ export function computeSunMoonPositionAt(time: Time, sun: PositionAndVelocityOve
 // Serializes projected polyline or polygon pieces into an SVG path data string. Each piece becomes one
 // subpath (M ... L ...); pieces with fewer than two points are skipped. When close is true each subpath
 // is closed with Z, suitable for filled polygons.
-export function pointsToSvgPathData(pieces: readonly (readonly Point[])[], close = false, precision = 2) {
+export function pointsToSvgPathData(pieces: readonly (readonly Point[])[], close = false, precision: number = 2) {
 	const subpaths: string[] = []
 
 	function formatCoordinate(value: number) {
@@ -3451,7 +3457,7 @@ export function pointsToSvgPathData(pieces: readonly (readonly Point[])[], close
 // angular "beak" near +-180. The 'pi'-mode projection preserves an exact +-PI seam vertex, so the post-wrap
 // piece resumes on the left edge (-PI) rather than being folded back onto the right one (+PI). The split
 // happens only here, at serialization time: the geographic geometry itself is never mutated.
-function projectSplitPieces(geo: GeoBranch, close: boolean, projection: Projection, options: ProjectionPolylineOptions) {
+function projectSplitPieces(geo: GeoBranch, close: boolean, projection: CylindricalProjection, options?: ProjectionOptions) {
 	const pieces: Point[][] = []
 
 	for (const segment of splitGeoLineAtAntimeridian(geo, close)) {
@@ -3459,11 +3465,12 @@ function projectSplitPieces(geo: GeoBranch, close: boolean, projection: Projecti
 
 		for (const point of segment) {
 			const projected = projection.project(point.x, point.y, undefined, options)
+
 			if (projected === undefined) {
 				if (piece.length >= 2) pieces.push(piece)
 				piece = []
 			} else {
-				piece.push({ x: projected.x, y: projected.y })
+				piece.push(projected)
 			}
 		}
 
@@ -3475,10 +3482,10 @@ function projectSplitPieces(geo: GeoBranch, close: boolean, projection: Projecti
 
 // Projects geographic polylines and serializes them into one SVG path data string of open subpaths,
 // split at the antimeridian during projection only.
-export function geoPolylinesToSvgPathData(lines: readonly GeoBranch[], projection: Projection, { precision = 2, ...options }: SolarEclipseMapSvgProjectionOptions = {}) {
+export function geoPolylinesToSvgPathData(lines: readonly GeoBranch[], projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions = DEFAULT_SOLAR_ECLIPSE_MAP_SVG_PROJECTION_OPTIONS) {
 	const pieces: Point[][] = []
-	for (const line of lines) for (const piece of projectSplitPieces(line, false, projection, options)) pieces.push(piece)
-	return pointsToSvgPathData(pieces, false, precision)
+	for (const line of lines) for (const piece of projectSplitPieces(line, false, projection, options.projectionOptions)) pieces.push(piece)
+	return pointsToSvgPathData(pieces, false)
 }
 
 // Projects solar eclipse map geometry and serializes each polyline feature into SVG path data strings,
@@ -3487,10 +3494,10 @@ export function geoPolylinesToSvgPathData(lines: readonly GeoBranch[], projectio
 // branch is serialized as its own subpath (M ... L ...): the end of one branch is never connected to the
 // start of another, so a near-pole fold the solver could not trace through is drawn as separate arcs rather
 // than a straight spike. The geometry itself is never mutated.
-export function solarEclipseMapToSvgPaths(geometry: SolarEclipseMapGeometry, projection: Projection, options: SolarEclipseMapSvgProjectionOptions = {}): SolarEclipseMapSvgPaths {
+export function solarEclipseMapToSvgPaths(geometry: SolarEclipseMapGeometry, projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions = DEFAULT_SOLAR_ECLIPSE_MAP_SVG_PROJECTION_OPTIONS): SolarEclipseMapSvgPaths {
 	// Project named points with the same options as the curves, so points and lines stay aligned (P0.3).
 	function projectPoint(point: GeoPoint | undefined) {
-		return point ? projection.project(point.x, point.y, undefined, options) : undefined
+		return point ? projection.project(point.x, point.y, undefined, options.projectionOptions) : undefined
 	}
 
 	const { points, lines } = geometry

--- a/src/sun.eclipse.map.ts
+++ b/src/sun.eclipse.map.ts
@@ -3485,7 +3485,7 @@ function projectSplitPieces(geo: GeoBranch, close: boolean, projection: Cylindri
 export function geoPolylinesToSvgPathData(lines: readonly GeoBranch[], projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions = DEFAULT_SOLAR_ECLIPSE_MAP_SVG_PROJECTION_OPTIONS) {
 	const pieces: Point[][] = []
 	for (const line of lines) for (const piece of projectSplitPieces(line, false, projection, options.projectionOptions)) pieces.push(piece)
-	return pointsToSvgPathData(pieces, false)
+	return pointsToSvgPathData(pieces, false, options.precision)
 }
 
 // Projects solar eclipse map geometry and serializes each polyline feature into SVG path data strings,

--- a/src/sun.eclipse.map.ts
+++ b/src/sun.eclipse.map.ts
@@ -1,19 +1,17 @@
 import { type Angle, normalizeAngle, normalizePI } from './angle'
-import type { PositionAndVelocityOverTime } from './astrometry'
-import { AU_KM, DAYSEC, DEG2RAD, EARTH_RADIUS_KM, LIGHT_TIME_AU, PI, PIOVERTWO, RAD2DEG, SPEED_OF_LIGHT_AU_DAY, TAU, WGS84_FLATTENING } from './constants'
-import type { EquatorialCoordinate } from './coordinate'
-import { deltaTByEspenakMeeus2006 } from './deltat'
-import { eraAb, eraEpj, eraGst06a, eraP2s, eraS2p } from './erfa'
+import { DAYSEC, DEG2RAD, PI, PIOVERTWO, RAD2DEG, TAU } from './constants'
+// oxfmt-ignore
+import { bisectRoot, derivativeEarthLimbOmega, earthLimbCircleIntersections, earthLimbExtremes, earthLimbOmega, earthLimbPoint, earthLimbSignedDistance, F, GEOMETRY_TANGENCY_EPSILON, geoPolylinesToSvgPathData, hourAngleFromLongitude, INV_F, longitudeFromHourAngle, normalizeLongitude, refineRoot, type EclipseGeoBranch, type EclipseGeoCurve, type EclipseGeoPoint, type SunMoonPosition, type SunMoonProvider } from './eclipse'
+import { eraGst06a, eraS2p } from './erfa'
 import { sphericalInterpolate, sphericalSeparation, type Point } from './geometry'
-import { matMulVec } from './mat3'
 import { clamp, type NumberArray } from './math'
-import { bisection, brentMinimize, brentRoot, type RootFindingOptions } from './optimization'
+import { brentMinimize } from './optimization'
 import type { CylindricalProjection, ProjectionOptions } from './projection'
 import { polynomialRegression } from './regression'
 import type { SolarEclipse } from './sun'
-import { precessionNutationMatrix, timeAtJulianDay, timeShift, timeSubtract, toJulianDay, tt, type Time } from './time'
+import { timeAtJulianDay, timeShift, timeSubtract, toJulianDay, tt, type Time } from './time'
 import type { Writable } from './types'
-import { vecDivScalar, vecDot, vecLength, vecMinus, vecMulScalar, vecNormalizeMut } from './vec3'
+import { vecDot, vecLength, vecMinus, vecNormalizeMut } from './vec3'
 
 // Solar eclipse map geometry engine. The module is layered as:
 //   A. Besselian elements (polynomial fit, instant elements, evaluation).
@@ -32,15 +30,6 @@ import { vecDivScalar, vecDot, vecLength, vecMinus, vecMulScalar, vecNormalizeMu
 //   - Delta T in seconds; times as Time or Julian Day; distances in Earth equatorial radii;
 //   - longitude is east-positive in [-PI, PI].
 
-// Earth polar/equatorial radius ratio (1 - flattening).
-export const F = 1 - WGS84_FLATTENING
-// Reciprocal of F, used by the geographic-latitude conversion.
-export const INV_F = 1 / F
-// Squared eccentricity of the Earth ellipsoid used for limb flattening, e^2 = 1 - (b/a)^2.
-export const EARTH_E2 = 1 - F * F
-// Callers building PolynomialBesselianElements from a dynamical-time (TDT) tabulation set deltaTLongitudeCorrection to
-// DELTA_T_LONGITUDE_FACTOR * deltaT; elements with UT-based mu (this module's own) use 0.
-export const DELTA_T_LONGITUDE_FACTOR = 0.00417807 * DEG2RAD
 const DEFAULT_LONGITUDE_STEP = 1 * DEG2RAD
 const DEFAULT_MAX_ANGULAR_STEP = 1 * DEG2RAD
 const DEFAULT_RISE_SET_STEP_SECONDS = 30
@@ -105,13 +94,6 @@ const SOLVER_TIME_TOLERANCE_DAYS = 0.1 / DAYSEC
 // is still far from zero; such a false positive is rejected. Kept looser than the < 1e-3 tangency tolerance
 // the acceptance tests assert, so every genuine solution is preserved.
 const CURVE_RESIDUAL_TOLERANCE = 1e-4
-// Numerical tolerance for tangential circle/ellipse intersections: a squared half-chord slightly below
-// zero is treated as a grazing (single) contact rather than no contact.
-const GEOMETRY_TANGENCY_EPSILON = 1e-14
-// Residual tolerance (squared Earth radii) for a tangential circle/limb-ellipse intersection detected as
-// a near-zero local extremum of g(theta) = distanceSquared - radius^2 that never changes sign. A genuine
-// tangency is a double root; this catches it when it does not land exactly on a scan sample.
-const LIMB_TANGENCY_RESIDUAL = 1e-9
 // Residual tolerance (Earth radii) for a grazing temporal contact: a local extremum of the contact
 // residual whose |value| drops to or below this is taken as a tangential (double) root even without a
 // sign change. Kept tight so a non-central eclipse, whose internal residual stays well above zero, never
@@ -234,16 +216,6 @@ export interface InstantBesselianElements {
 	readonly tanF2: number
 }
 
-// Apparent or geocentric Sun and Moon position sample used to generate Besselian elements.
-export interface SunMoonPosition {
-	// Apparent or geocentric Sun equatorial coordinate.
-	readonly sun: Required<EquatorialCoordinate>
-	// Apparent or geocentric Moon equatorial coordinate.
-	readonly moon: Required<EquatorialCoordinate>
-	// Delta T in seconds for this sample.
-	readonly deltaT?: number
-}
-
 // Local eclipse character along the central line, used to mark the total/annular transition of a hybrid eclipse.
 export type HybridEclipseKind = 'total' | 'annular'
 
@@ -259,59 +231,47 @@ export type RefractionMode = 'none' | 'empirical'
 // Default refraction model: the empirical horizon lift, matching the published refracted references.
 const DEFAULT_REFRACTION_MODE: RefractionMode = 'empirical'
 
-// Geographic point returned by the eclipse geometry engine.
-export interface GeoPoint {
-	// Longitude in radians, east-positive, normalized to [-PI, PI].
-	readonly x: Angle
-	// Latitude in radians, normalized to [-PI/2, PI/2].
-	readonly y: Angle
-	// Optional Julian Day associated with this point.
-	readonly jd?: number
-	// Optional local eclipse character at this point; set on central-line points so a hybrid eclipse's
-	// total and annular stretches can be distinguished where the local umbral cone radius changes sign.
-	readonly kind?: HybridEclipseKind
-}
-
-export type GeoBranch = GeoPoint[]
-export type GeoCurve = GeoBranch[]
+export type SolarEclipseGeoPoint = EclipseGeoPoint<{ kind?: HybridEclipseKind }>
+export type SolarEclipseGeoBranch = EclipseGeoBranch<SolarEclipseGeoPoint>
+export type SolarEclipseGeoCurve = EclipseGeoCurve<SolarEclipseGeoPoint>
 
 // Named eclipse contact and central-path endpoints.
 export interface SolarEclipseContactPoints {
 	// First external penumbral contact (partial eclipse begins on Earth).
-	readonly P1?: GeoPoint
+	readonly P1?: SolarEclipseGeoPoint
 	// First internal penumbral contact (penumbra wholly on Earth).
-	readonly P2?: GeoPoint
+	readonly P2?: SolarEclipseGeoPoint
 	// Last internal penumbral contact (penumbra wholly on Earth).
-	readonly P3?: GeoPoint
+	readonly P3?: SolarEclipseGeoPoint
 	// Last external penumbral contact (partial eclipse ends on Earth).
-	readonly P4?: GeoPoint
+	readonly P4?: SolarEclipseGeoPoint
 	// First external umbral/antumbral cone tangency with the limb. Informational only: it never
 	// controls the umbra-limit polylines.
-	readonly U1?: GeoPoint
+	readonly U1?: SolarEclipseGeoPoint
 	// First internal umbral/antumbral cone tangency with the limb (umbra wholly on Earth). Informational only.
-	readonly U2?: GeoPoint
+	readonly U2?: SolarEclipseGeoPoint
 	// Last internal umbral/antumbral cone tangency with the limb. Informational only.
-	readonly U3?: GeoPoint
+	readonly U3?: SolarEclipseGeoPoint
 	// Last external umbral/antumbral cone tangency with the limb. Informational only.
-	readonly U4?: GeoPoint
+	readonly U4?: SolarEclipseGeoPoint
 	// First central-line contact with Earth (the shadow axis grazes the limb where the central line begins).
-	readonly C1?: GeoPoint
+	readonly C1?: SolarEclipseGeoPoint
 	// Last central-line contact with Earth (the shadow axis grazes the limb where the central line ends).
-	readonly C2?: GeoPoint
+	readonly C2?: SolarEclipseGeoPoint
 	// Greatest eclipse point.
-	readonly Max?: GeoPoint
+	readonly Max?: SolarEclipseGeoPoint
 	// Northern penumbral-limit extreme. Informational only: it never controls the penumbra-limit
 	// polylines. When both penumbral limits reach Earth, N1/N2 are the northern limit's two terminator
 	// cusps ordered chronologically; for a grazing partial, N1 is the earlier cusp of the single limit
 	// (chronological, not poleward — both cusps may share a hemisphere).
-	readonly N1?: GeoPoint
+	readonly N1?: SolarEclipseGeoPoint
 	// Second endpoint of the northern penumbral limit. Absent for a grazing partial. Informational only.
-	readonly N2?: GeoPoint
+	readonly N2?: SolarEclipseGeoPoint
 	// Southern penumbral-limit extreme; for a grazing partial, S1 is the later cusp of the single limit.
 	// S1/S2 otherwise mirror N1/N2 for the southern limit. Informational only.
-	readonly S1?: GeoPoint
+	readonly S1?: SolarEclipseGeoPoint
 	// Second endpoint of the southern penumbral limit. Absent for a grazing partial. Informational only.
-	readonly S2?: GeoPoint
+	readonly S2?: SolarEclipseGeoPoint
 }
 
 // Projection-agnostic solar eclipse map geometry: the physically meaningful points and polylines only.
@@ -321,22 +281,22 @@ export interface SolarEclipseMapGeometry {
 	// Drawable geographic polylines, still unprojected.
 	readonly lines: {
 		// Central line of totality or annularity. Empty for partial and non-central eclipses.
-		readonly centerLine: GeoBranch
+		readonly centerLine: SolarEclipseGeoBranch
 		// Northern totality or annularity limit (G = 1), split at discontinuities and at its latitude
 		// apex. Empty for partial eclipses; may still exist for non-central total/annular eclipses whose
 		// axis misses the Earth (so centerLine is empty) but whose umbra still grazes the limb.
-		readonly umbraNorth: GeoCurve
+		readonly umbraNorth: SolarEclipseGeoCurve
 		// Southern totality or annularity limit (G = 1), split like umbraNorth.
-		readonly umbraSouth: GeoCurve
+		readonly umbraSouth: SolarEclipseGeoCurve
 		// Northern partial eclipse limit (G = 0), as continuity branches. Points within a branch may be
 		// connected; separate branches (e.g. the two arcs meeting at a longitude-fold cusp the solver could
 		// not trace through) must never be joined, so a near-pole fold is drawn as distinct arcs rather than a
 		// straight spike across the map.
-		readonly penumbraNorth: GeoCurve
+		readonly penumbraNorth: SolarEclipseGeoCurve
 		// Southern partial eclipse limit (G = 0), as continuity branches like penumbraNorth.
-		readonly penumbraSouth: GeoCurve
+		readonly penumbraSouth: SolarEclipseGeoCurve
 		// Sunrise and sunset eclipse curves.
-		readonly riseSetCurves: GeoCurve
+		readonly riseSetCurves: SolarEclipseGeoCurve
 	}
 }
 
@@ -420,22 +380,22 @@ const DEFAULT_SOLAR_ECLIPSE_MAP_SVG_PROJECTION_OPTIONS: SolarEclipseMapSvgProjec
 	projectionOptions: undefined,
 }
 
-function finitePoint(point: GeoPoint | undefined): point is GeoPoint {
+function finitePoint(point: EclipseGeoPoint | undefined): point is EclipseGeoPoint {
 	return !!point && Number.isFinite(point.x) && Number.isFinite(point.y) && point.y >= -PIOVERTWO && point.y <= PIOVERTWO && point.x >= -PI && point.x <= PI
 }
 
-function samePoint(a: GeoPoint, b: GeoPoint) {
+function samePoint(a: EclipseGeoPoint, b: EclipseGeoPoint) {
 	return Math.abs(a.x - b.x) < 1e-9 && Math.abs(a.y - b.y) < 1e-9 && Math.abs((a.jd ?? 0) - (b.jd ?? 0)) < 1e-10
 }
 
 // Geographic-only point equality (ignores jd and uses spherical separation, so +PI and -PI on the
 // antimeridian and points coincident only in space are treated as one). Used when chaining curve branches
 // by spatial continuity, where two branches can meet at the same location carrying slightly different times.
-function sameGeoPoint(a: GeoPoint, b: GeoPoint) {
+function sameGeoPoint(a: EclipseGeoPoint, b: EclipseGeoPoint) {
 	return angularDistance(a, b) < 1e-9
 }
 
-function pushDistinct(points: GeoBranch, point: GeoPoint | undefined) {
+function pushDistinct(points: EclipseGeoBranch, point: EclipseGeoPoint | undefined) {
 	if (!finitePoint(point)) return
 	if (points.length === 0 || !samePoint(points.at(-1)!, point)) points.push(point)
 }
@@ -479,27 +439,27 @@ function fitCubic(x: Readonly<NumberArray>, y: Readonly<NumberArray>) {
 	return polynomialRegression(x, y, 3).coefficients
 }
 
-function angularDistance(a: GeoPoint, b: GeoPoint) {
+function angularDistance(a: EclipseGeoPoint, b: EclipseGeoPoint) {
 	return sphericalSeparation(a.x, a.y, b.x, b.y)
 }
 
-function longitudeGap(a: GeoPoint, b: GeoPoint) {
+function longitudeGap(a: EclipseGeoPoint, b: EclipseGeoPoint) {
 	const gap = Math.abs(a.x - b.x)
 	return gap > PI ? TAU - gap : gap
 }
 
-function curveGapNeedsRefinement(a: GeoPoint, b: GeoPoint, maxAngularStep: Angle) {
+function curveGapNeedsRefinement(a: EclipseGeoPoint, b: EclipseGeoPoint, maxAngularStep: Angle) {
 	if (angularDistance(a, b) > maxAngularStep) return true
 	if (Math.max(Math.abs(a.y), Math.abs(b.y)) <= CURVE_POLAR_LONGITUDE_REFINEMENT_LATITUDE) return false
 	return Math.hypot(longitudeGap(a, b), a.y - b.y) > maxAngularStep
 }
 
-function curveBridgeGapNeedsRefinement(a: GeoPoint, b: GeoPoint, maxAngularStep: Angle) {
+function curveBridgeGapNeedsRefinement(a: EclipseGeoPoint, b: EclipseGeoPoint, maxAngularStep: Angle) {
 	if (curveGapNeedsRefinement(a, b, maxAngularStep)) return true
 	return Math.max(Math.abs(a.y), Math.abs(b.y)) > CURVE_POLAR_LONGITUDE_REFINEMENT_LATITUDE && Math.hypot(longitudeGap(a, b), a.y - b.y) > maxAngularStep * 0.25
 }
 
-function interpolateGreatCirclePoint(a: GeoPoint, b: GeoPoint, fraction: number): GeoPoint {
+function interpolateGreatCirclePoint(a: EclipseGeoPoint, b: EclipseGeoPoint, fraction: number): EclipseGeoPoint {
 	const [longitude, latitude] = sphericalInterpolate(a.x, a.y, b.x, b.y, fraction)
 
 	return {
@@ -514,7 +474,7 @@ function validStep(value: number | undefined, fallback: number) {
 }
 
 // Interpolates between two geographic points along the great-circle arc.
-export function intermediateGreatCircle(a: GeoPoint, b: GeoPoint, fraction: number) {
+export function intermediateGreatCircle(a: EclipseGeoPoint, b: EclipseGeoPoint, fraction: number) {
 	return interpolateGreatCirclePoint(a, b, clamp(fraction, 0, 1))
 }
 
@@ -619,7 +579,7 @@ const PBE_STEP_DAYS = 1 / 24
 const PBE_OFFSETS = [-3, -1.5, 0, 1.5, 3] as const
 
 // Computes approximate polynomial Besselian elements from caller-provided Sun and Moon samples.
-export function computePolynomialBesselianElements(maximumTime: Time, getSunMoonPosition: (time: Time) => SunMoonPosition): PolynomialBesselianElements {
+export function computePolynomialBesselianElements(maximumTime: Time, sunMoonPosition: SunMoonProvider): PolynomialBesselianElements {
 	const maximumJulianDay = toJulianDay(maximumTime)
 	const julianDay0 = Math.round(maximumJulianDay * 24) / 24
 	const time0 = timeAtJulianDay(maximumTime, julianDay0)
@@ -638,7 +598,7 @@ export function computePolynomialBesselianElements(maximumTime: Time, getSunMoon
 	for (let i = 0; i < n; i++) {
 		const offset = PBE_OFFSETS[i]
 		const sampleTime = timeShift(time0, offset * PBE_STEP_DAYS)
-		const position = getSunMoonPosition(sampleTime)
+		const position = sunMoonPosition(sampleTime)
 		const instant = instantBesselianFromSunMoon(sampleTime, position)
 		x[i] = instant.x
 		y[i] = instant.y
@@ -760,271 +720,13 @@ function besselianShadowProjection(position: SunMoonPosition) {
 
 // B. PROJECTION AND EARTH GEOMETRY
 
-// Computes the flattening scale for the Earth-limb ellipse in the fundamental plane:
-// the limb is x^2 + (omega*y)^2 = 1 with omega = 1 / sqrt(1 - e^2 cos^2 d).
-export function earthLimbOmega(d: Angle) {
-	const cosD = Math.cos(d)
-	return 1 / Math.sqrt(1 - EARTH_E2 * cosD * cosD)
-}
-
-// Derivative d(omega)/d(d) of the limb flattening scale, used to carry the d-dependence of the limb
-// into the central-line endpoint solver: omega = s^(-1/2), s = 1 - e^2 cos^2 d,
-// so d(omega)/dd = -e^2 cos d sin d * s^(-3/2).
-export function derivativeEarthLimbOmega(d: Angle) {
-	const cosD = Math.cos(d)
-	const sinD = Math.sin(d)
-	const s = 1 - EARTH_E2 * cosD * cosD
-	return (-EARTH_E2 * cosD * sinD) / (s * Math.sqrt(s))
-}
-
-// Number of uniform theta samples used to bracket extrema and crossings on the Earth-limb ellipse. The
-// limb is smooth and nearly circular (flattening ~1/298), so a 2 deg scan reliably brackets every
-// extremum/intersection basin before local refinement (ternary search for extrema, bisection for
-// crossings), which then converges to full precision independently of this resolution.
-const LIMB_SCAN_STEPS = 180
-
-// Returns the point on the Earth-limb ellipse x^2 + (omega y)^2 = 1 at parameter theta.
-export function earthLimbPoint(theta: number, omega: number) {
-	return [Math.cos(theta), Math.sin(theta) / omega] as const
-}
-
-function earthLimbDistanceSquared(theta: number, cx: number, cy: number, omega: number) {
-	const dx = Math.cos(theta) - cx
-	const dy = Math.sin(theta) / omega - cy
-	return dx * dx + dy * dy
-}
-
-// Precomputed cos/sin of the uniform limb scan grid (theta = TAU*k/LIMB_SCAN_STEPS), since those angles are
-// always the same; the continuous refinements still call Math.cos/sin on off-grid theta.
-const LIMB_SCAN_COS = new Float64Array(LIMB_SCAN_STEPS)
-const LIMB_SCAN_SIN = new Float64Array(LIMB_SCAN_STEPS)
-
-for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
-	const theta = (TAU * k) / LIMB_SCAN_STEPS
-	LIMB_SCAN_COS[k] = Math.cos(theta)
-	LIMB_SCAN_SIN[k] = Math.sin(theta)
-}
-
-// Reused scan buffer for earthLimbCircleIntersections, avoiding a Float64Array allocation per call. Safe as
-// a single module workspace: the function is synchronous and never re-enters itself.
-const LIMB_SCAN_VALUES = new Float64Array(LIMB_SCAN_STEPS)
-
-// Squared distance to (cx, cy) from a limb-scan grid point given its precomputed cos/sin.
-function limbDistanceSquaredFromCosSin(cos: number, sin: number, cx: number, cy: number, omega: number) {
-	const dx = cos - cx
-	const dy = sin / omega - cy
-	return dx * dx + dy * dy
-}
-
-// Ternary search of a unimodal limb extremum within a one-step bracket. Robust fallback for refineLimbExtreme.
-function ternaryLimbExtreme(thetaGuess: number, halfWidth: number, cx: number, cy: number, omega: number, minimize: boolean) {
-	let lo = thetaGuess - halfWidth
-	let hi = thetaGuess + halfWidth
-
-	for (let i = 0; i < 60 && hi - lo > 1e-12; i++) {
-		const m1 = lo + (hi - lo) / 3
-		const m2 = hi - (hi - lo) / 3
-		const f1 = earthLimbDistanceSquared(m1, cx, cy, omega)
-		const f2 = earthLimbDistanceSquared(m2, cx, cy, omega)
-		if (minimize ? f1 < f2 : f1 > f2) hi = m2
-		else lo = m1
-	}
-
-	return (lo + hi) * 0.5
-}
-
-// Refines a limb extremum (minimum or maximum of the squared distance to (cx, cy)) from a scan guess.
-// Newton on the first derivative of D^2(theta) converges in a handful of evaluations (the limb is nearly
-// circular, so the basin is convex), replacing the 60-step ternary search; it falls back to ternary
-// whenever the curvature has the wrong sign or a step would leave the one-step bracket.
-function refineLimbExtreme(thetaGuess: number, halfWidth: number, cx: number, cy: number, omega: number, minimize: boolean) {
-	const lo = thetaGuess - halfWidth
-	const hi = thetaGuess + halfWidth
-	let theta = thetaGuess
-
-	for (let i = 0; i < 12; i++) {
-		const cos = Math.cos(theta)
-		const sin = Math.sin(theta)
-		const dx = cos - cx
-		const dy = sin / omega - cy
-		// First and second derivatives of D^2(theta) = dx^2 + dy^2.
-		const first = 2 * (dx * -sin + (dy * cos) / omega)
-		const second = 2 * (sin * sin - dx * cos + (cos * cos) / (omega * omega) - (dy * sin) / omega)
-
-		// A minimum needs positive curvature, a maximum negative; otherwise Newton would walk the wrong way.
-		if (!Number.isFinite(second) || second === 0 || (minimize ? second < 0 : second > 0)) break
-
-		const step = first / second
-		theta -= step
-
-		if (!Number.isFinite(theta) || theta < lo || theta > hi) break
-		if (Math.abs(step) < 1e-13) return theta
-	}
-
-	return ternaryLimbExtreme(thetaGuess, halfWidth, cx, cy, omega, minimize)
-}
-
-// Nearest and farthest points of the Earth-limb ellipse to a fundamental-plane point, with the signed
-// inside/outside flag. This replaces the unit-circle distance used previously for
-// contacts and rise/set, so the oblique projection of the ellipsoid is honored exactly.
-export interface EarthLimbExtremes {
-	// Distance to the nearest limb point, in Earth equatorial radii.
-	readonly minDistance: number
-	// Distance to the farthest limb point, in Earth equatorial radii.
-	readonly maxDistance: number
-	// theta of the nearest limb point, in radians.
-	readonly nearestTheta: number
-	// theta of the farthest limb point, in radians.
-	readonly farthestTheta: number
-	// Whether (cx, cy) lies inside the limb ellipse.
-	readonly inside: boolean
-}
-
-export function earthLimbExtremes(cx: number, cy: number, omega: number): EarthLimbExtremes {
-	const step = TAU / LIMB_SCAN_STEPS
-	let minTheta = 0
-	let maxTheta = 0
-	let minD2 = Infinity
-	let maxD2 = -Infinity
-
-	for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
-		const d2 = limbDistanceSquaredFromCosSin(LIMB_SCAN_COS[k], LIMB_SCAN_SIN[k], cx, cy, omega)
-		if (d2 < minD2) {
-			minD2 = d2
-			minTheta = k * step
-		}
-		if (d2 > maxD2) {
-			maxD2 = d2
-			maxTheta = k * step
-		}
-	}
-
-	const nearestTheta = refineLimbExtreme(minTheta, step, cx, cy, omega, true)
-	const farthestTheta = refineLimbExtreme(maxTheta, step, cx, cy, omega, false)
-	const omegaCy = omega * cy
-
-	return {
-		minDistance: Math.sqrt(earthLimbDistanceSquared(nearestTheta, cx, cy, omega)),
-		maxDistance: Math.sqrt(earthLimbDistanceSquared(farthestTheta, cx, cy, omega)),
-		nearestTheta,
-		farthestTheta,
-		inside: cx * cx + omegaCy * omegaCy < 1,
-	}
-}
-
-// Signed distance from a fundamental-plane point to the Earth-limb ellipse boundary: negative inside,
-// positive outside. The classical contact equations on the unit circle (hypot - 1 -+ r) become
-// signedDistance -+ r on the ellipse.
-function earthLimbSignedDistance(cx: number, cy: number, omega: number) {
-	const extremes = earthLimbExtremes(cx, cy, omega)
-	return extremes.inside ? -extremes.minDistance : extremes.minDistance
-}
-
-// Collapses thetas that are within tolerance of each other (also across the 0/TAU wrap) into a single
-// representative, keeping the input order. Used to drop duplicate circle/limb intersection angles that a
-// sign-change and a tangency pass can both report for the same root.
-function deduplicateAngularRoots(thetas: readonly number[], tolerance: number) {
-	const out: number[] = []
-
-	for (const theta of thetas) {
-		const wrapped = normalizeAngle(theta)
-		let duplicate = false
-
-		for (const kept of out) {
-			const delta = Math.abs(normalizePI(wrapped - kept))
-			if (delta <= tolerance) {
-				duplicate = true
-				break
-			}
-		}
-
-		if (!duplicate) out.push(wrapped)
-	}
-
-	return out
-}
-
-function EarthLimbCircleIntersectionPointComparator(a: readonly [number, number], b: readonly [number, number]) {
-	return b[1] - a[1]
-}
-
-// Intersections of a circle of the given radius centered at (cx, cy) with the Earth-limb ellipse,
-// returned as limb points (cos theta, sin theta / omega) ordered by descending y. The circle and the
-// ellipse can meet in up to four points, so g(theta) = earthLimbDistanceSquared(theta) - radius^2 is
-// scanned uniformly and every root is captured: exact zeros and sign changes (the transversal crossings),
-// plus near-zero local extrema that never change sign (tangencies, which are double roots and would
-// otherwise be missed unless they landed exactly on a sample). This is the ellipse counterpart of
-// findCircleIntersections for rise/set.
-export function earthLimbCircleIntersections(cx: number, cy: number, omega: number, radius: number) {
-	if (!Number.isFinite(radius) || radius < 0 || !Number.isFinite(cx) || !Number.isFinite(cy)) return []
-
-	const r2 = radius * radius
-	const g = (theta: number) => earthLimbDistanceSquared(theta, cx, cy, omega) - r2
-	const step = TAU / LIMB_SCAN_STEPS
-
-	// g is TAU-periodic, so sample [0, TAU) once (reusing the scan buffer) and read neighbors modularly.
-	const values = LIMB_SCAN_VALUES
-	for (let k = 0; k < LIMB_SCAN_STEPS; k++) values[k] = limbDistanceSquaredFromCosSin(LIMB_SCAN_COS[k], LIMB_SCAN_SIN[k], cx, cy, omega) - r2
-
-	const thetas: number[] = []
-
-	// Transversal crossings: exact zeros on a sample and sign changes between neighbors.
-	for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
-		const value = values[k]
-		const next = values[(k + 1) % LIMB_SCAN_STEPS]
-
-		if (Math.abs(value) <= GEOMETRY_TANGENCY_EPSILON) thetas.push(k * step)
-		else if (value * next < 0) {
-			const root = bisectRoot(g, k * step, (k + 1) * step)
-			if (root !== undefined) thetas.push(root)
-		}
-	}
-
-	// Tangencies: a strict local minimum or maximum of g whose refined extremum value is within tolerance
-	// of zero is a grazing (double) contact that the sign-change pass cannot see.
-	for (let k = 0; k < LIMB_SCAN_STEPS; k++) {
-		const previous = values[(k - 1 + LIMB_SCAN_STEPS) % LIMB_SCAN_STEPS]
-		const value = values[k]
-		const next = values[(k + 1) % LIMB_SCAN_STEPS]
-		const isMinimum = value < previous && value < next
-		const isMaximum = value > previous && value > next
-
-		if (isMinimum || isMaximum) {
-			const extreme = refineLimbExtreme(k * step, step, cx, cy, omega, isMinimum)
-			if (Math.abs(g(extreme)) <= LIMB_TANGENCY_RESIDUAL) thetas.push(extreme)
-		}
-	}
-
-	const roots = deduplicateAngularRoots(thetas, 1e-7)
-	const points: (readonly [number, number])[] = []
-	for (const theta of roots) points.push(earthLimbPoint(theta, omega))
-	points.sort(EarthLimbCircleIntersectionPointComparator)
-	return points
-}
-
-// Single source of truth for the hour-angle -> longitude conversion. The project uses east-positive
-// longitude, so lambda = H - mu + correction, where the correction is 0.00417807 deg per second of
-// Delta T in radians. The sign is pinned by tests against NASA eclipse path tables and the subsolar point.
-export function longitudeFromHourAngle(hourAngle: Angle, mu: Angle, correction: Angle) {
-	return normalizeLongitude(hourAngle - mu + correction)
-}
-
-export function normalizeLongitude(longitude: Angle) {
-	return longitude === PI || longitude === -PI ? longitude : normalizePI(longitude)
-}
-
-// Inverse of longitudeFromHourAngle: local hour angle of the shadow axis at an east-positive longitude.
-export function hourAngleFromLongitude(longitude: Angle, mu: Angle, correction: Angle) {
-	return longitude + mu - correction
-}
-
 // Projects one fundamental-plane point on or inside the Earth limb to geographic longitude and latitude.
 // This is the single source of truth for the fundamental plane -> geographic conversion: every contact,
 // curve and rise/set point goes through it. A point outside the limb returns undefined (only a
 // numerically grazing point, within GEOMETRY_TANGENCY_EPSILON, is snapped to the limb): callers that
 // need a representative on-Earth point for an outside input must request it explicitly via
 // projectClosestEarthLimbPoint, instead of relying on a hidden clamp.
-export function projectFundamentalPoint(be: BesselianSample, x: number, y: number): GeoPoint | undefined {
+export function projectFundamentalPoint(be: BesselianSample, x: number, y: number): EclipseGeoPoint | undefined {
 	if (!Number.isFinite(x) || !Number.isFinite(y)) return undefined
 
 	const sinD = Math.sin(be.d)
@@ -1064,25 +766,6 @@ export function projectClosestEarthLimbPoint(be: BesselianSample, x: number, y: 
 }
 
 // C. CONTACTS AND CENTRAL ENDPOINTS
-
-const BISECT_ROOT_OPTIONS: RootFindingOptions = { tolerance: CONTACT_TOLERANCE_DAYS }
-
-function bisectRoot(f: (x: number) => number, min: number, max: number) {
-	try {
-		return bisection(f, min, max, BISECT_ROOT_OPTIONS).root
-	} catch {
-		return undefined
-	}
-}
-
-// Refines a bracketed root, preferring Brent (superlinear) and falling back to bisection if Brent rejects the bracket.
-function refineRoot(f: (x: number) => number, min: number, max: number) {
-	try {
-		return brentRoot(f, min, max, BISECT_ROOT_OPTIONS).root
-	} catch {
-		return bisectRoot(f, min, max)
-	}
-}
 
 function NumberComparator(a: number, b: number) {
 	return a - b
@@ -1595,7 +1278,7 @@ export function findEclipseCurvePoint(pbe: PolynomialBesselianElements, longitud
 export function findCurvePoints(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, options: SolarEclipseCurveOptions = {}) {
 	const maxAngularStep = validStep(options.maxAngularStep, DEFAULT_MAX_ANGULAR_STEP)
 	const refractionMode = options.refractionMode ?? DEFAULT_REFRACTION_MODE
-	const points: GeoBranch = []
+	const points: EclipseGeoBranch = []
 	for (const branch of findCurveBranches(pbe, i, G, options)) for (const point of branch) points.push(point)
 	return mendCurveCusps(orderCurvePoints(deduplicatePoints(points)), pbe, i, G, maxAngularStep, refractionMode)
 }
@@ -1605,10 +1288,10 @@ export function findCurvePoints(pbe: PolynomialBesselianElements, i: -1 | 0 | 1,
 // Julian Day; consecutive points are physically adjacent and a wide gap between them is either a re-solvable
 // cusp (continuous) or a genuine discontinuity (not re-solvable). bridgeCurveGap inserts solved points only
 // for the former, leaving real discontinuities as gaps.
-function mendCurveCusps(points: GeoBranch, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode) {
+function mendCurveCusps(points: EclipseGeoBranch, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode) {
 	if (points.length < 2) return points
 
-	const out: GeoBranch = [points[0]]
+	const out: EclipseGeoBranch = [points[0]]
 
 	for (let k = 1; k < points.length; k++) {
 		bridgeCurveGap(out, pbe, points[k - 1], points[k], i, G, maxAngularStep, refractionMode, 0)
@@ -1628,7 +1311,7 @@ function mendCurveCusps(points: GeoBranch, pbe: PolynomialBesselianElements, i: 
 // intermediate longitude, so the midpoint is sought from several latitude seeds (the interpolated latitude,
 // then each endpoint) and the first one that satisfies betweenness is kept, preventing a seed from
 // snapping onto the other arc and dropping the bridge.
-function bridgeCurveGap(out: GeoBranch, pbe: PolynomialBesselianElements, a: GeoPoint, b: GeoPoint, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode, depth: number) {
+function bridgeCurveGap(out: EclipseGeoBranch, pbe: PolynomialBesselianElements, a: EclipseGeoPoint, b: EclipseGeoPoint, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode, depth: number) {
 	if (depth >= SEGMENT_REFINEMENT_MAX_DEPTH || !curveBridgeGapNeedsRefinement(a, b, maxAngularStep)) return
 
 	const mid = solveCurveMidpointBetween(pbe, a, b, i, G, refractionMode)
@@ -1651,7 +1334,7 @@ function bridgeCurveGap(out: GeoBranch, pbe: PolynomialBesselianElements, a: Geo
 // a bridgeable cusp.
 const MIDPOINT_BALANCE = 0.75
 
-function solveCurveMidpointBetween(pbe: PolynomialBesselianElements, a: GeoPoint, b: GeoPoint, i: -1 | 0 | 1, G: number, refractionMode: RefractionMode) {
+function solveCurveMidpointBetween(pbe: PolynomialBesselianElements, a: EclipseGeoPoint, b: EclipseGeoPoint, i: -1 | 0 | 1, G: number, refractionMode: RefractionMode) {
 	const ab = angularDistance(a, b)
 	const limit = MIDPOINT_BALANCE * ab
 	const intermediate = interpolateGreatCirclePoint(a, b, 0.5)
@@ -1696,7 +1379,7 @@ function findCurveBranchPoints(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, 
 	const maxAngularStep = validStep(options.maxAngularStep, DEFAULT_MAX_ANGULAR_STEP)
 	const refractionMode = options.refractionMode ?? DEFAULT_REFRACTION_MODE
 	const maxDrawableGap = Math.max(BRANCH_MAX_DRAWABLE_GAP, maxAngularStep * CURVE_GAP_SPLIT_FACTOR)
-	const branches: GeoCurve = []
+	const branches: EclipseGeoCurve = []
 
 	// The continuation scan traces smooth arcs; the fixed-seed scan recovers arcs it orphans at near-polar
 	// folds. Both feed the same cleanup/dedup/reconnect pipeline, which collapses the arcs they share.
@@ -1736,7 +1419,7 @@ function findCurveBranchPoints(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, 
 // (within CURVE_SPATIAL_EPSILON) with a non-adjacent vertex of the branch and is reached by a step larger
 // than the fold threshold; trimming it keeps the branch a simple open arc without moving any retained point.
 // foldStep: minimum step (radians) that flags an endpoint connection as an anomalous fold-back jump.
-function trimFoldBackEndpoints(branch: GeoBranch, foldStep: Angle) {
+function trimFoldBackEndpoints(branch: EclipseGeoBranch, foldStep: Angle) {
 	let start = 0
 	let end = branch.length - 1
 
@@ -1748,8 +1431,8 @@ function trimFoldBackEndpoints(branch: GeoBranch, foldStep: Angle) {
 
 // Applies branch-level cleanup that removes drawable solver artifacts without changing valid samples.
 // foldStep is the minimum angular jump treated as a fold; closeTolerance joins near-coincident neighbours.
-function trimCurveBranchArtifacts(branches: GeoCurve, foldStep: Angle, closeTolerance: Angle) {
-	const out: GeoCurve = []
+function trimCurveBranchArtifacts(branches: EclipseGeoCurve, foldStep: Angle, closeTolerance: Angle) {
+	const out: EclipseGeoCurve = []
 
 	for (const branch of branches) {
 		const trimmed = trimInteriorFoldBackSpikes(trimFoldBackEndpoints(branch, foldStep), foldStep, closeTolerance)
@@ -1763,12 +1446,12 @@ function trimCurveBranchArtifacts(branches: GeoCurve, foldStep: Angle, closeTole
 // nearly coincident but B several angular steps away is not a sampled cusp; it is a transient jump to the
 // neighbouring solution that would draw a short spike and then return to the original arc.
 // foldStep: minimum distance from the spike vertex to both neighbours; closeTolerance: A/C coincidence.
-function trimInteriorFoldBackSpikes(branch: GeoBranch, foldStep: Angle, closeTolerance: Angle) {
+function trimInteriorFoldBackSpikes(branch: EclipseGeoBranch, foldStep: Angle, closeTolerance: Angle) {
 	let current = branch
 
 	while (current.length >= 3) {
 		let removed = false
-		const out: GeoBranch = [current[0]]
+		const out: EclipseGeoBranch = [current[0]]
 
 		for (let k = 1; k < current.length - 1; k++) {
 			const previous = out.at(-1)!
@@ -1792,7 +1475,7 @@ function trimInteriorFoldBackSpikes(branch: GeoBranch, foldStep: Angle, closeTol
 }
 
 // Whether point coincides geographically (within CURVE_SPATIAL_EPSILON) with any branch vertex in [from, to].
-function coincidesWithRange(branch: GeoBranch, point: GeoPoint, from: number, to: number) {
+function coincidesWithRange(branch: EclipseGeoBranch, point: EclipseGeoPoint, from: number, to: number) {
 	for (let k = from; k <= to; k++) if (angularDistance(branch[k], point) <= CURVE_SPATIAL_EPSILON) return true
 	return false
 }
@@ -1801,20 +1484,20 @@ function coincidesWithRange(branch: GeoBranch, point: GeoPoint, from: number, to
 // Where two seed tracks meet they can deposit the same vertex with slightly different times; collapsing the
 // duplicate keeps the branch a clean polyline without moving any point. Never sorts and never reverses, so
 // the solver's continuity order is preserved.
-function cleanCurveBranch(branch: GeoBranch) {
-	const out: GeoBranch = []
+function cleanCurveBranch(branch: EclipseGeoBranch) {
+	const out: EclipseGeoBranch = []
 	for (const point of branch) pushCleanCurvePoint(out, point)
 	return out
 }
 
-const EMPTY_GEO_POINTS: GeoBranch = []
+const EMPTY_GEO_POINTS: EclipseGeoBranch = []
 const BRANCH_ENDPOINTS = [0, 1] as const
 
-function pushCleanCurvePoint(out: GeoBranch, point: GeoPoint) {
+function pushCleanCurvePoint(out: EclipseGeoBranch, point: EclipseGeoPoint) {
 	if (out.length === 0 || !sameGeoPoint(out.at(-1)!, point)) out.push(point)
 }
 
-function appendBranchPoints(out: GeoBranch, branch: GeoBranch, reverse: boolean) {
+function appendBranchPoints(out: EclipseGeoBranch, branch: EclipseGeoBranch, reverse: boolean) {
 	if (reverse) {
 		for (let k = branch.length - 1; k >= 0; k--) pushCleanCurvePoint(out, branch[k])
 	} else {
@@ -1822,8 +1505,8 @@ function appendBranchPoints(out: GeoBranch, branch: GeoBranch, reverse: boolean)
 	}
 }
 
-function mergeBranchesAtCusp(a: GeoBranch, b: GeoBranch, bridge: GeoBranch, endpointA: 0 | 1, endpointB: 0 | 1) {
-	const out: GeoBranch = []
+function mergeBranchesAtCusp(a: EclipseGeoBranch, b: EclipseGeoBranch, bridge: EclipseGeoBranch, endpointA: 0 | 1, endpointB: 0 | 1) {
+	const out: EclipseGeoBranch = []
 	appendBranchPoints(out, a, endpointA === 0)
 	for (const point of bridge) pushCleanCurvePoint(out, point)
 	appendBranchPoints(out, b, endpointB === 1)
@@ -1838,7 +1521,7 @@ function mergeBranchesAtCusp(a: GeoBranch, b: GeoBranch, bridge: GeoBranch, endp
 // bridge only up to where it first reaches b's near endpoint (the genuine fold arc) and append b forward from
 // there, giving branchA -> fold -> b as one arc. Returns undefined when the bridge never reaches that
 // endpoint, i.e. the overlap is a real retrace and not a fold. e.g. the 6174-10-22 annular umbra-north limit.
-function mergeFoldThroughBranchEndpoint(branchA: GeoBranch, branchB: GeoBranch, bridge: GeoBranch, endpointA: 0 | 1, endpointB: 0 | 1, tolerance: Angle) {
+function mergeFoldThroughBranchEndpoint(branchA: EclipseGeoBranch, branchB: EclipseGeoBranch, bridge: EclipseGeoBranch, endpointA: 0 | 1, endpointB: 0 | 1, tolerance: Angle) {
 	if (bridge.length === 0) return undefined
 
 	// b's near (re-anchor) endpoint is the one opposite the joint endB.
@@ -1878,16 +1561,16 @@ const CUSP_RECONNECT_OVERLAP_ARC = 10 * DEG2RAD
 const CUSP_RECONNECT_POLE_LATITUDE = 85 * DEG2RAD
 const CUSP_RECONNECT_POLAR_LONGITUDE_LIMIT = 30 * DEG2RAD
 
-function pointInReconnectPolarCap(point: GeoPoint) {
+function pointInReconnectPolarCap(point: EclipseGeoPoint) {
 	return Math.abs(point.y) > CUSP_RECONNECT_POLE_LATITUDE
 }
 
-function bridgeEntersReconnectPolarCap(bridge: GeoBranch) {
+function bridgeEntersReconnectPolarCap(bridge: EclipseGeoBranch) {
 	for (const point of bridge) if (pointInReconnectPolarCap(point)) return true
 	return false
 }
 
-function bridgeHasLargePolarLongitudeStep(a: GeoPoint, b: GeoPoint, bridge: GeoBranch) {
+function bridgeHasLargePolarLongitudeStep(a: EclipseGeoPoint, b: EclipseGeoPoint, bridge: EclipseGeoBranch) {
 	let previous = a
 
 	for (const point of bridge) {
@@ -1898,7 +1581,7 @@ function bridgeHasLargePolarLongitudeStep(a: GeoPoint, b: GeoPoint, bridge: GeoB
 	return Math.min(Math.abs(previous.y), Math.abs(b.y)) > CUSP_RECONNECT_POLE_LATITUDE && longitudeGap(previous, b) > CUSP_RECONNECT_POLAR_LONGITUDE_LIMIT
 }
 
-function canReconnectPolarCusp(a: GeoPoint, b: GeoPoint, bridge: GeoBranch, gap: Angle, maxDrawableGap: Angle) {
+function canReconnectPolarCusp(a: EclipseGeoPoint, b: EclipseGeoPoint, bridge: EclipseGeoBranch, gap: Angle, maxDrawableGap: Angle) {
 	if (!pointInReconnectPolarCap(a) && !pointInReconnectPolarCap(b) && !bridgeEntersReconnectPolarCap(bridge)) return true
 	return (gap <= maxDrawableGap || bridge.length > 0) && !bridgeHasLargePolarLongitudeStep(a, b, bridge)
 }
@@ -1908,8 +1591,8 @@ function canReconnectPolarCusp(a: GeoPoint, b: GeoPoint, bridge: GeoBranch, gap:
 // a vertical-tangent fold cusp leaves one irreducible step near the tip, so continuityGap is the looser
 // drawable-gap threshold; a true discontinuity inserts no points and leaves the full (larger) gap, so it is
 // still rejected.
-function solveContinuousBridge(pbe: PolynomialBesselianElements, a: GeoPoint, b: GeoPoint, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, continuityGap: Angle, refractionMode: RefractionMode) {
-	const bridge: GeoBranch = []
+function solveContinuousBridge(pbe: PolynomialBesselianElements, a: EclipseGeoPoint, b: EclipseGeoPoint, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, continuityGap: Angle, refractionMode: RefractionMode) {
+	const bridge: EclipseGeoBranch = []
 	bridgeCurveGap(bridge, pbe, a, b, i, G, maxAngularStep, refractionMode, 0)
 
 	let previous = a
@@ -1923,7 +1606,7 @@ function solveContinuousBridge(pbe: PolynomialBesselianElements, a: GeoPoint, b:
 
 // Whether a branch doubles back over itself: two points close in space but far apart in arc length. Near the
 // degenerate poles a re-solved bridge can fold an arc back onto an existing one; such a merge is rejected.
-function branchRetraces(branch: GeoBranch, tolerance: Angle, minArcSeparation: Angle) {
+function branchRetraces(branch: EclipseGeoBranch, tolerance: Angle, minArcSeparation: Angle) {
 	const arc = new Float64Array(branch.length)
 	for (let k = 1; k < branch.length; k++) arc[k] = arc[k - 1] + angularDistance(branch[k - 1], branch[k])
 
@@ -1943,8 +1626,8 @@ function branchRetraces(branch: GeoBranch, tolerance: Angle, minArcSeparation: A
 // exposes the missing cusp endpoint so the final reconnection can bridge the adjacent branch without
 // drawing a visible gap.
 // tolerance: endpoint coincidence threshold in radians; minLoopArc: minimum along-branch loop length.
-function trimRetracedBranchEnds(branches: GeoCurve, tolerance: Angle, minLoopArc: Angle) {
-	const out: GeoCurve = []
+function trimRetracedBranchEnds(branches: EclipseGeoCurve, tolerance: Angle, minLoopArc: Angle) {
+	const out: EclipseGeoCurve = []
 
 	for (const branch of branches) {
 		// Start-trim and end-trim each gate on the OTHER endpoint leaving the trimmed loop, so a branch that
@@ -1968,7 +1651,7 @@ function trimRetracedBranchEnds(branches: GeoCurve, tolerance: Angle, minLoopArc
 
 // Trims a loop at the start of a branch when a later point revisits the start after a meaningful arc and
 // the remaining tail leaves that endpoint. The returned array aliases the original points.
-function trimRetracedBranchStart(branch: GeoBranch, tolerance: Angle, minLoopArc: Angle) {
+function trimRetracedBranchStart(branch: EclipseGeoBranch, tolerance: Angle, minLoopArc: Angle) {
 	if (branch.length < 4) return branch
 
 	const start = branch[0]
@@ -1993,7 +1676,7 @@ function trimRetracedBranchStart(branch: GeoBranch, tolerance: Angle, minLoopArc
 
 // Trims a loop at the end of a branch using the same criterion as trimRetracedBranchStart, scanning the
 // branch in reverse. The returned array aliases the original points.
-function trimRetracedBranchEnd(branch: GeoBranch, tolerance: Angle, minLoopArc: Angle) {
+function trimRetracedBranchEnd(branch: EclipseGeoBranch, tolerance: Angle, minLoopArc: Angle) {
 	if (branch.length < 4) return branch
 
 	const end = branch.at(-1)!
@@ -2024,15 +1707,15 @@ function trimRetracedBranchEnd(branch: GeoBranch, tolerance: Angle, minLoopArc: 
 // succeeds) and the merged branch does not retrace itself: a true discontinuity has no connecting curve, and
 // a pole-degenerate bridge folds back, so both are left as separate branches and no spike is ever drawn.
 // Pairs that already touch are skipped so nothing is retraced.
-function reconnectBranchCusps(branches: GeoCurve, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, maxDrawableGap: Angle, refractionMode: RefractionMode, allowTouchingMerge = true) {
-	const result: GeoCurve = []
+function reconnectBranchCusps(branches: EclipseGeoCurve, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, maxDrawableGap: Angle, refractionMode: RefractionMode, allowTouchingMerge = true) {
+	const result: EclipseGeoCurve = []
 	for (const branch of branches) result.push(branch.slice())
 
 	while (true) {
 		let bestGap = Infinity
 		let bestA = -1
 		let bestB = -1
-		let bestMerged: GeoBranch | undefined
+		let bestMerged: EclipseGeoBranch | undefined
 
 		for (let a = 0; a < result.length; a++) {
 			const branchA = result[a]
@@ -2095,13 +1778,13 @@ function reconnectBranchCusps(branches: GeoCurve, pbe: PolynomialBesselianElemen
 const BRANCH_CONTAINMENT_STEPS = 1.5
 
 // Whether a point lies on a branch, i.e. within tolerance of any of its samples.
-function pointOnBranch(point: GeoPoint, branch: GeoBranch, tolerance: Angle) {
+function pointOnBranch(point: EclipseGeoPoint, branch: EclipseGeoBranch, tolerance: Angle) {
 	for (const sample of branch) if (angularDistance(point, sample) <= tolerance) return true
 	return false
 }
 
 // Whether a point is covered by any known branch within the same angular tolerance pointOnBranch uses.
-function pointOnAnyBranch(point: GeoPoint, branches: GeoCurve, tolerance: Angle) {
+function pointOnAnyBranch(point: EclipseGeoPoint, branches: EclipseGeoCurve, tolerance: Angle) {
 	for (let b = 0; b < branches.length; b++) {
 		if (pointOnBranch(point, branches[b], tolerance)) return true
 	}
@@ -2115,7 +1798,7 @@ function pointOnAnyBranch(point: GeoPoint, branches: GeoCurve, tolerance: Angle)
 // limit a couple of steps past the host's endpoint (e.g. the 5578-05-13 penumbra-south sub-arc that lies on
 // the main branch but overshoots its start by ~1.5 deg). Independent of orientation, since proximity ignores
 // order.
-function branchCoveredBy(branch: GeoBranch, host: GeoBranch, tolerance: Angle, maxOverhang: Angle) {
+function branchCoveredBy(branch: EclipseGeoBranch, host: EclipseGeoBranch, tolerance: Angle, maxOverhang: Angle) {
 	let firstCovered = -1
 	let lastCovered = -1
 
@@ -2138,13 +1821,13 @@ function branchCoveredBy(branch: GeoBranch, host: GeoBranch, tolerance: Angle, m
 }
 
 // Arc length (radians) of the branch points in [from, to], used to bound an uncovered end overhang.
-function overhangArcLength(branch: GeoBranch, from: number, to: number) {
+function overhangArcLength(branch: EclipseGeoBranch, from: number, to: number) {
 	let arc = 0
 	for (let k = from + 1; k <= to; k++) arc += angularDistance(branch[k - 1], branch[k])
 	return arc
 }
 
-function BranchComparatorByLengthDescending(a: GeoBranch, b: GeoBranch) {
+function BranchComparatorByLengthDescending(a: EclipseGeoBranch, b: EclipseGeoBranch) {
 	return b.length - a.length
 }
 
@@ -2153,13 +1836,13 @@ function BranchComparatorByLengthDescending(a: GeoBranch, b: GeoBranch) {
 // acquired the solution; left in, the continuity chainer would retrace those overlaps and fold the arc back
 // on itself (sharp 180-degree kinks). Considering branches longest first keeps the densest, most complete
 // copy and discards every sub-arc covered by it.
-function deduplicateBranches(branches: GeoCurve, maxAngularStep: Angle) {
+function deduplicateBranches(branches: EclipseGeoCurve, maxAngularStep: Angle) {
 	const tolerance = maxAngularStep * BRANCH_CONTAINMENT_STEPS
 	// A redundant sub-arc may overshoot the host's endpoint by a short stub (a seed tracing the same limit a
 	// few steps further); tolerate an overhang up to the fold-gap threshold so the duplicate is still dropped.
 	const maxOverhang = maxAngularStep * CURVE_GAP_SPLIT_FACTOR
 	const byLength = branches.toSorted(BranchComparatorByLengthDescending)
-	const kept: GeoCurve = []
+	const kept: EclipseGeoCurve = []
 
 	for (const branch of byLength) {
 		let found = false
@@ -2178,7 +1861,7 @@ function deduplicateBranches(branches: GeoCurve, maxAngularStep: Angle) {
 }
 
 // Returns the seed's open branch, starting a new one when it has none because a curve branch begins or reappears.
-function openCurveSeedBranch(branches: GeoCurve, activeBySeed: Array<GeoBranch | undefined>, seedIndex: number): GeoBranch {
+function openCurveSeedBranch(branches: EclipseGeoCurve, activeBySeed: Array<EclipseGeoBranch | undefined>, seedIndex: number): EclipseGeoBranch {
 	let branch = activeBySeed[seedIndex]
 
 	if (!branch) {
@@ -2202,9 +1885,9 @@ function findCurveBranches(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: n
 	const maxAngularStep = validStep(options.maxAngularStep, DEFAULT_MAX_ANGULAR_STEP)
 	const refractionMode = options.refractionMode ?? DEFAULT_REFRACTION_MODE
 	const seeds = CURVE_SEED_LATITUDES
-	const branches: GeoCurve = []
-	const previousBySeed = new Array<GeoPoint | undefined>(CURVE_SEED_LATITUDES_LENGTH)
-	const activeBySeed = new Array<GeoBranch | undefined>(CURVE_SEED_LATITUDES_LENGTH)
+	const branches: EclipseGeoCurve = []
+	const previousBySeed = new Array<EclipseGeoPoint | undefined>(CURVE_SEED_LATITUDES_LENGTH)
+	const activeBySeed = new Array<EclipseGeoBranch | undefined>(CURVE_SEED_LATITUDES_LENGTH)
 
 	for (let longitude = -PI; longitude <= PI + 1e-12; longitude += longitudeStep) {
 		const lon = Math.min(longitude, PI)
@@ -2273,7 +1956,7 @@ function findCurveBranches(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: n
 // are merged by deduplicateBranches/reconnect.
 // Probes a non-polar fixed seed at coarse longitudes and returns true when it can reach a curve point not
 // already covered by continuation/fallback branches; such a seed earns the full dense fallback scan.
-function fixedSeedProbeFindsUncoveredArc(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, seedLatitude: Angle, longitudeStep: Angle, refractionMode: RefractionMode, knownBranches: GeoCurve, tolerance: Angle) {
+function fixedSeedProbeFindsUncoveredArc(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, seedLatitude: Angle, longitudeStep: Angle, refractionMode: RefractionMode, knownBranches: EclipseGeoCurve, tolerance: Angle) {
 	const probeStep = Math.max(longitudeStep, FIXED_SEED_PROBE_LONGITUDE_STEP)
 
 	for (let longitude = -PI; longitude <= PI + 1e-12; longitude += probeStep) {
@@ -2285,10 +1968,10 @@ function fixedSeedProbeFindsUncoveredArc(pbe: PolynomialBesselianElements, i: -1
 }
 
 // Traces one fixed seed densely at every longitude sample, appending continuity arcs to out.
-function pushFixedSeedCurveArcsForSeed(out: GeoCurve, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, seedLatitude: Angle, longitudeStep: Angle, maxAngularStep: Angle, refractionMode: RefractionMode) {
+function pushFixedSeedCurveArcsForSeed(out: EclipseGeoCurve, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, seedLatitude: Angle, longitudeStep: Angle, maxAngularStep: Angle, refractionMode: RefractionMode) {
 	const foldStep = maxAngularStep * CURVE_GAP_SPLIT_FACTOR
-	let current: GeoBranch | undefined
-	let previous: GeoPoint | undefined
+	let current: EclipseGeoBranch | undefined
+	let previous: EclipseGeoPoint | undefined
 
 	for (let longitude = -PI; longitude <= PI + 1e-12; longitude += longitudeStep) {
 		const lon = Math.min(longitude, PI)
@@ -2310,15 +1993,15 @@ function pushFixedSeedCurveArcsForSeed(out: GeoCurve, pbe: PolynomialBesselianEl
 
 // Runs the adaptive fixed-seed fallback, using knownBranches as the coverage baseline and returning only the
 // dense fallback arcs that were worth tracing for this curve family.
-function findFixedSeedCurveArcs(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, knownBranches: GeoCurve, options: SolarEclipseCurveOptions = {}) {
+function findFixedSeedCurveArcs(pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, knownBranches: EclipseGeoCurve, options: SolarEclipseCurveOptions = {}) {
 	const longitudeStep = validStep(options.longitudeStep, DEFAULT_LONGITUDE_STEP)
 	const maxAngularStep = validStep(options.maxAngularStep, DEFAULT_MAX_ANGULAR_STEP)
 	const refractionMode = options.refractionMode ?? DEFAULT_REFRACTION_MODE
 	const coverageTolerance = CURVE_SPATIAL_EPSILON
 	const n = knownBranches.length
-	const coverageBranches = new Array<GeoBranch>(n)
+	const coverageBranches = new Array<EclipseGeoBranch>(n)
 	for (let b = 0; b < n; b++) coverageBranches[b] = knownBranches[b]
-	const branches: GeoCurve = []
+	const branches: EclipseGeoCurve = []
 
 	for (let s = 0; s < CURVE_SEED_LATITUDES_LENGTH; s++) {
 		const seedLatitude = CURVE_SEED_LATITUDES[s]
@@ -2335,8 +2018,8 @@ function findFixedSeedCurveArcs(pbe: PolynomialBesselianElements, i: -1 | 0 | 1,
 	return branches
 }
 
-function findNearestCurvePointAtLongitude(pbe: PolynomialBesselianElements, longitude: Angle, anchor: GeoPoint, i: -1 | 0 | 1, G: number, refractionMode: RefractionMode) {
-	let best: GeoPoint | undefined
+function findNearestCurvePointAtLongitude(pbe: PolynomialBesselianElements, longitude: Angle, anchor: EclipseGeoPoint, i: -1 | 0 | 1, G: number, refractionMode: RefractionMode) {
+	let best: EclipseGeoPoint | undefined
 	let bestDistance = Infinity
 
 	const point = findEclipseCurvePoint(pbe, longitude, anchor.y, i, G, refractionMode)
@@ -2363,10 +2046,10 @@ function findNearestCurvePointAtLongitude(pbe: PolynomialBesselianElements, long
 // longitude where the solver converged and the first where it did not. A fold can have two roots at the
 // same longitude, so each midpoint is selected by proximity to the branch anchor instead of a single Newton
 // seed; otherwise the endpoint can jump to the other side of the fold and leave a visible cusp gap.
-function refineCurveBoundary(pbe: PolynomialBesselianElements, aLon: Angle, bLon: Angle, anchor: GeoPoint, validLow: boolean, i: -1 | 0 | 1, G: number, refractionMode: RefractionMode = DEFAULT_REFRACTION_MODE) {
+function refineCurveBoundary(pbe: PolynomialBesselianElements, aLon: Angle, bLon: Angle, anchor: EclipseGeoPoint, validLow: boolean, i: -1 | 0 | 1, G: number, refractionMode: RefractionMode = DEFAULT_REFRACTION_MODE) {
 	let low = aLon
 	let high = bLon
-	let best: GeoPoint | undefined
+	let best: EclipseGeoPoint | undefined
 
 	for (let step = 0; step < BOUNDARY_REFINEMENT_STEPS; step++) {
 		const mid = (low + high) * 0.5
@@ -2395,7 +2078,7 @@ const SEGMENT_REFINEMENT_MAX_DEPTH = 8
 // apart than maxAngularStep, by recursive bisection: each midpoint is seeded from the
 // great-circle-interpolated coordinates and solved, so the inserted points are physical solutions
 // (never interpolated artifacts) and every emitted step honors maxAngularStep up to the depth limit.
-function appendRefinedSegment(points: GeoBranch, pbe: PolynomialBesselianElements, a: GeoPoint, b: GeoPoint, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode = DEFAULT_REFRACTION_MODE, depth = 0) {
+function appendRefinedSegment(points: EclipseGeoBranch, pbe: PolynomialBesselianElements, a: EclipseGeoPoint, b: EclipseGeoPoint, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode = DEFAULT_REFRACTION_MODE, depth = 0) {
 	if (depth >= SEGMENT_REFINEMENT_MAX_DEPTH || !curveGapNeedsRefinement(a, b, maxAngularStep)) return
 
 	const intermediate = interpolateGreatCirclePoint(a, b, 0.5)
@@ -2416,21 +2099,21 @@ function appendRefinedSegment(points: GeoBranch, pbe: PolynomialBesselianElement
 	appendRefinedSegment(points, pbe, mid, b, i, G, maxAngularStep, refractionMode, depth + 1)
 }
 
-function deduplicatePoints(points: GeoBranch) {
-	const out: GeoBranch = []
+function deduplicatePoints(points: EclipseGeoBranch) {
+	const out: EclipseGeoBranch = []
 	for (const point of points) pushDistinct(out, point)
 	return out
 }
 
-function GeoPointComparatorByJDAscending(a: GeoPoint, b: GeoPoint) {
+function GeoPointComparatorByJDAscending(a: EclipseGeoPoint, b: EclipseGeoPoint) {
 	return a.jd! - b.jd!
 }
 
-function GeoPointComparatorByXOrYAscending(a: GeoPoint, b: GeoPoint) {
+function GeoPointComparatorByXOrYAscending(a: EclipseGeoPoint, b: EclipseGeoPoint) {
 	return a.x - b.x || a.y - b.y
 }
 
-function orderCurvePoints(points: GeoBranch) {
+function orderCurvePoints(points: EclipseGeoBranch) {
 	if (points.length <= 2) return points
 
 	let allHaveJulianDay = true
@@ -2447,7 +2130,7 @@ function orderCurvePoints(points: GeoBranch) {
 		// Two seeds reaching the same instant yield the same location, so collapse a point only when it
 		// coincides with the previous one both in time AND space. A fold can place two distinct locations
 		// at nearly the same instant; those are kept so the branch is not silently merged (section 2.2).
-		const ordered: GeoBranch = []
+		const ordered: EclipseGeoBranch = []
 
 		for (const point of points) {
 			const last = ordered.at(-1)
@@ -2463,10 +2146,10 @@ function orderCurvePoints(points: GeoBranch) {
 }
 
 // Appends the drawable pieces of one curve to `out`, splitting only at physical discontinuities.
-function pushSplitDisconnectedPolylines(out: GeoCurve, points: GeoBranch, maxGap: Angle) {
+function pushSplitDisconnectedPolylines(out: EclipseGeoCurve, points: EclipseGeoBranch, maxGap: Angle) {
 	if (points.length === 0) return
 
-	let current: GeoBranch = [points[0]]
+	let current: EclipseGeoBranch = [points[0]]
 
 	for (let i = 1; i < points.length; i++) {
 		if (angularDistance(points[i - 1], points[i]) > maxGap) {
@@ -2481,8 +2164,8 @@ function pushSplitDisconnectedPolylines(out: GeoCurve, points: GeoBranch, maxGap
 }
 
 // Splits every branch into drawable pieces without allocating a callback result per branch.
-function splitCurveBranches(branches: readonly GeoBranch[], maxGap: Angle) {
-	const pieces: GeoCurve = []
+function splitCurveBranches(branches: readonly EclipseGeoBranch[], maxGap: Angle) {
+	const pieces: EclipseGeoCurve = []
 	for (const branch of branches) pushSplitDisconnectedPolylines(pieces, branch, maxGap)
 	return pieces
 }
@@ -2491,15 +2174,15 @@ function splitCurveBranches(branches: readonly GeoBranch[], maxGap: Angle) {
 // are farther apart than maxGap the curve has left the sunlit hemisphere (or the solver family is
 // physically disconnected there), so the pieces must not be joined by a straight chord. Pieces with
 // fewer than two points are dropped as undrawable.
-export function splitDisconnectedPolylines(points: GeoBranch, maxGap: Angle) {
-	const pieces: GeoCurve = []
+export function splitDisconnectedPolylines(points: EclipseGeoBranch, maxGap: Angle) {
+	const pieces: EclipseGeoCurve = []
 	pushSplitDisconnectedPolylines(pieces, points, maxGap)
 	return pieces
 }
 
 // Splits a polar/circumpolar limit at its largest absolute latitude, a two-piece
 // rendering of a limit that folds back over itself near a pole.
-export function splitAtMaxAbsLatitude(points: GeoBranch) {
+export function splitAtMaxAbsLatitude(points: EclipseGeoBranch) {
 	if (points.length <= 2) return [points.slice()]
 
 	let index = 0
@@ -2532,15 +2215,15 @@ export function splitAtMaxAbsLatitude(points: GeoBranch) {
 }
 
 // Splits each branch at its latitude apex without allocating a callback fan-out pass.
-function splitBranchesAtMaxAbsLatitude(branches: GeoCurve) {
-	const out: GeoCurve = []
+function splitBranchesAtMaxAbsLatitude(branches: EclipseGeoCurve) {
+	const out: EclipseGeoCurve = []
 	for (const branch of branches) {
 		for (const piece of splitAtMaxAbsLatitude(branch)) out.push(piece)
 	}
 	return out
 }
 
-function reconnectSplitCurveCusps(branches: GeoCurve, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode) {
+function reconnectSplitCurveCusps(branches: EclipseGeoCurve, pbe: PolynomialBesselianElements, i: -1 | 0 | 1, G: number, maxAngularStep: Angle, refractionMode: RefractionMode) {
 	const maxDrawableGap = Math.max(BRANCH_MAX_DRAWABLE_GAP, maxAngularStep * CURVE_GAP_SPLIT_FACTOR)
 	const reconnected = reconnectBranchCusps(deduplicateBranches(branches, maxAngularStep), pbe, i, G, maxAngularStep, maxDrawableGap, refractionMode, false)
 	const pieces = splitCurveBranches(reconnected, maxDrawableGap)
@@ -2558,8 +2241,8 @@ function reconnectSplitCurveCusps(branches: GeoCurve, pbe: PolynomialBesselianEl
 // Nearest curve sample to a point across every branch, with its angular distance. Unlike a capped search
 // the caller decides acceptance, so a spatially distant but temporally matching grazing cusp can still be
 // taken (see alignUmbralContactPoints).
-function nearestCurveSample(point: GeoPoint, branches: readonly GeoBranch[], out: { sample: GeoPoint; distance: number }) {
-	let best: GeoPoint | undefined
+function nearestCurveSample(point: EclipseGeoPoint, branches: readonly EclipseGeoBranch[], out: { sample: EclipseGeoPoint; distance: number }) {
+	let best: EclipseGeoPoint | undefined
 	let bestDistance = Infinity
 
 	for (const branch of branches) {
@@ -2588,10 +2271,10 @@ const UMBRA_CONTACT_POINTS = ['U1', 'U2', 'U3', 'U4'] as const
 // U1..U4 mark terminator cusps that coincide with umbra-limit branch endpoints, so when the grazing-limb
 // geometry makes spatial distance unreliable the cusp is identified by endpoint time. Considers only the two
 // endpoints of each branch, since an interior sample at a coincidentally close time is not the cusp.
-function nearestEndpointByTime(point: GeoPoint, branches: readonly GeoBranch[], timeTolerance: number) {
+function nearestEndpointByTime(point: EclipseGeoPoint, branches: readonly EclipseGeoBranch[], timeTolerance: number) {
 	if (point.jd === undefined) return undefined
 
-	let best: GeoPoint | undefined
+	let best: EclipseGeoPoint | undefined
 	let bestDelta = timeTolerance
 
 	for (const branch of branches) {
@@ -2616,7 +2299,7 @@ function nearestEndpointByTime(point: GeoPoint, branches: readonly GeoBranch[], 
 // almost tangent to the limb, it is snapped to the branch endpoint nearest in time. The temporally nearest
 // cusp can be several degrees away and need not be the spatially nearest sample (another branch's flank may
 // pass marginally closer), so the time match is required, not just probed on the spatial pick. jd is preserved.
-function alignUmbralContactPoints(points: Writable<SolarEclipseContactPoints>, branches: readonly GeoBranch[], maxAngularStep: Angle) {
+function alignUmbralContactPoints(points: Writable<SolarEclipseContactPoints>, branches: readonly EclipseGeoBranch[], maxAngularStep: Angle) {
 	const spatialLimit = maxAngularStep * CURVE_GAP_SPLIT_FACTOR
 	const best: Parameters<typeof nearestCurveSample>[2] = { sample: undefined as never, distance: 0 }
 
@@ -2645,14 +2328,14 @@ const RISE_SET_REFINE_MAX_DEPTH = 10
 // points, so the crossings are kept as a list instead of a fixed upper/lower pair.
 interface RiseSetSample {
 	readonly jd: number
-	readonly crossings: GeoBranch
+	readonly crossings: EclipseGeoBranch
 }
 
 // One traced rise/set branch: a continuous run of limb crossings with the last appended point cached for
 // the nearest-neighbour continuity match against the next sample's crossings.
 interface RiseSetBranch {
-	points: GeoBranch
-	last: GeoPoint
+	points: EclipseGeoBranch
+	last: EclipseGeoPoint
 }
 
 // Finds the intersections of the Earth unit circle with a circle of the given radius centered at
@@ -2689,7 +2372,7 @@ export function findCircleIntersections(cx: number, cy: number, radius: number) 
 function riseSetCrossings(pbe: PolynomialBesselianElements, jd: number) {
 	const be = besselianSampleAtJulianDay(pbe, jd)
 	const crossings = earthLimbCircleIntersections(be.x, be.y, earthLimbOmega(be.d), Math.abs(be.l1))
-	const points: GeoBranch = []
+	const points: EclipseGeoBranch = []
 
 	for (const crossing of crossings) {
 		const point = projectFundamentalPoint(be, crossing[0], crossing[1])
@@ -2699,7 +2382,7 @@ function riseSetCrossings(pbe: PolynomialBesselianElements, jd: number) {
 	return points
 }
 
-function isGeoPoint(point?: Point | GeoPoint): point is GeoPoint {
+function isGeoPoint(point?: Point | EclipseGeoPoint): point is EclipseGeoPoint {
 	return finitePoint(point) && point.jd !== undefined
 }
 
@@ -2713,12 +2396,12 @@ function RiseSetBranchComparatorByHigherLatitude(a: RiseSetBranch, b: RiseSetBra
 // at the day-side gap, its variable set of crossings (0..4) is tracked into continuity branches, and each
 // branch is anchored to the P1/P2/P3/P4 contacts so it passes through them. Fast-moving stretches near the
 // cusps are densified by subdividing in time so the curve follows the geometry rather than a straight chord.
-export function computeRiseSetCurves(pbe: PolynomialBesselianElements, P1: GeoPoint, P4: GeoPoint, optionalContacts: Pick<SolarEclipseContactPoints, 'P2' | 'P3' | 'N1' | 'N2' | 'S1' | 'S2'> = {}, options?: SolarEclipseRiseSetCurveOptions) {
+export function computeRiseSetCurves(pbe: PolynomialBesselianElements, P1: EclipseGeoPoint, P4: EclipseGeoPoint, optionalContacts: Pick<SolarEclipseContactPoints, 'P2' | 'P3' | 'N1' | 'N2' | 'S1' | 'S2'> = {}, options?: SolarEclipseRiseSetCurveOptions) {
 	if (P1.jd === undefined || P4.jd === undefined || P4.jd < P1.jd) return []
 
 	const stepDays = validStep(options?.step, DEFAULT_RISE_SET_STEP_SECONDS) / DAYSEC
 	const adaptive = options?.adaptive ?? true
-	const contacts: GeoBranch = []
+	const contacts: EclipseGeoBranch = []
 	if (isGeoPoint(P1)) contacts.push(P1)
 	if (isGeoPoint(optionalContacts.P2)) contacts.push(optionalContacts.P2)
 	if (isGeoPoint(optionalContacts.P3)) contacts.push(optionalContacts.P3)
@@ -2769,7 +2452,7 @@ export function computeRiseSetCurves(pbe: PolynomialBesselianElements, P1: GeoPo
 	// The tangency cusp bounding a phase falls within one sampling step of the phase's last crossing, so
 	// match cusps to contacts by time (near the tangent the crossings can still be far apart in space).
 	const snapJd = 2 * stepDays
-	const curves: GeoCurve = []
+	const curves: EclipseGeoCurve = []
 
 	for (const phase of phases) {
 		const branches = traceRiseSetBranches(pbe, phase, adaptive)
@@ -2860,8 +2543,8 @@ function traceRiseSetBranches(pbe: PolynomialBesselianElements, phase: readonly 
 
 // Prepends and appends the phase's tangency-cusp contacts to a traced branch, densifying the cusp
 // approaches in time so the branch bends into the contacts rather than jumping in a straight chord.
-function anchorRiseSetBranch(pbe: PolynomialBesselianElements, points: GeoBranch, start: GeoPoint | undefined, end: GeoPoint | undefined, adaptive: boolean) {
-	const out: GeoBranch = []
+function anchorRiseSetBranch(pbe: PolynomialBesselianElements, points: EclipseGeoBranch, start: EclipseGeoPoint | undefined, end: EclipseGeoPoint | undefined, adaptive: boolean) {
+	const out: EclipseGeoBranch = []
 
 	if (start) {
 		out.push(start)
@@ -2881,7 +2564,7 @@ function anchorRiseSetBranch(pbe: PolynomialBesselianElements, points: GeoBranch
 // Recursively inserts true limb crossings between two consecutive points of one branch while the step
 // exceeds the angular limit, so the curve bends smoothly into the cusps instead of jumping in a straight
 // line. At each midpoint the crossing nearest the great-circle-interpolated target stays on the branch.
-function refineRiseSetBranchGap(pbe: PolynomialBesselianElements, jdA: number, aPoint: GeoPoint, jdB: number, bPoint: GeoPoint, out: GeoBranch, depth: number) {
+function refineRiseSetBranchGap(pbe: PolynomialBesselianElements, jdA: number, aPoint: EclipseGeoPoint, jdB: number, bPoint: EclipseGeoPoint, out: EclipseGeoBranch, depth: number) {
 	if (depth >= RISE_SET_REFINE_MAX_DEPTH || !(angularDistance(aPoint, bPoint) > DEFAULT_MAX_ANGULAR_STEP)) return
 
 	const jd = (jdA + jdB) * 0.5
@@ -2912,10 +2595,10 @@ function refineRiseSetBranchGap(pbe: PolynomialBesselianElements, jdA: number, a
 // endpoint. Without the direction guard a single-sample phase (a very short grazing partial) can snap both
 // its start and end to the same contact whichever is nearest, drawing a backward then forward spike (e.g.
 // the 2893-12-29 partial, whose lone sunset crossing is closest to P4, so P4 was used as the start too).
-function nearestContactByJd(jd: number | undefined, contacts: GeoBranch, toleranceJd: number, direction: -1 | 0 | 1 = 0) {
+function nearestContactByJd(jd: number | undefined, contacts: EclipseGeoBranch, toleranceJd: number, direction: -1 | 0 | 1 = 0) {
 	if (jd === undefined) return undefined
 
-	let best: GeoPoint | undefined
+	let best: EclipseGeoPoint | undefined
 	let bestDelta = toleranceJd
 
 	for (const contact of contacts) {
@@ -2942,8 +2625,8 @@ const RISE_SET_CUSP_INSERT_MAX_GAP = DEFAULT_MAX_ANGULAR_STEP * CURVE_GAP_SPLIT_
 // spike from the curve up to the cusp. Such an insertion is rejected; the cusp remains a marker only.
 const RISE_SET_CUSP_MAX_DETOUR = DEFAULT_MAX_ANGULAR_STEP
 
-function insertRiseSetCuspPoints(curves: GeoCurve, cusps: readonly (GeoPoint | undefined)[]) {
-	const out: GeoCurve = []
+function insertRiseSetCuspPoints(curves: EclipseGeoCurve, cusps: readonly (EclipseGeoPoint | undefined)[]) {
+	const out: EclipseGeoCurve = []
 	for (const curve of curves) out.push(curve.slice())
 
 	for (const cusp of cusps) {
@@ -3023,13 +2706,13 @@ function solveCentralLineTransition(pbe: PolynomialBesselianElements, jdA: numbe
 // compatibility; this is the per-character view of a hybrid eclipse, whose central line alternates total <-> annular.
 export interface CentralLineByKind {
 	// Total-eclipse sub-polylines of the central line, in chronological order.
-	readonly total: GeoCurve
+	readonly total: SolarEclipseGeoCurve
 	// Annular-eclipse sub-polylines of the central line, in chronological order.
-	readonly annular: GeoCurve
+	readonly annular: SolarEclipseGeoCurve
 }
 
 // Keeps only drawable central-line segments, matching the previous final filter without an extra pass.
-function pushDrawableSegment(out: GeoCurve, segment: GeoBranch) {
+function pushDrawableSegment(out: EclipseGeoCurve, segment: EclipseGeoBranch) {
 	if (segment.length >= 2) out.push(segment)
 }
 
@@ -3040,12 +2723,12 @@ function pushDrawableSegment(out: GeoCurve, segment: GeoBranch) {
 // total<->annular crossover (where the local umbral radius is zero) is root-solved between the two
 // bracketing samples and inserted as a shared seam, so the total and annular segments meet without a gap;
 // each side gets its own copy tagged with that side's kind to keep segments homogeneous.
-export function splitCentralLineByKind(centerLine: GeoBranch, pbe?: PolynomialBesselianElements): CentralLineByKind {
-	const total: GeoCurve = []
-	const annular: GeoCurve = []
-	let current: GeoBranch | undefined
+export function splitCentralLineByKind(centerLine: SolarEclipseGeoBranch, pbe?: PolynomialBesselianElements): CentralLineByKind {
+	const total: EclipseGeoCurve = []
+	const annular: EclipseGeoCurve = []
+	let current: SolarEclipseGeoBranch | undefined
 	let currentKind: HybridEclipseKind | undefined
-	let previous: GeoPoint | undefined
+	let previous: SolarEclipseGeoPoint | undefined
 
 	for (const point of centerLine) {
 		const kind = point.kind
@@ -3069,8 +2752,8 @@ export function splitCentralLineByKind(centerLine: GeoBranch, pbe?: PolynomialBe
 		previous = point
 	}
 
-	const drawableTotal: GeoCurve = []
-	const drawableAnnular: GeoCurve = []
+	const drawableTotal: EclipseGeoCurve = []
+	const drawableAnnular: EclipseGeoCurve = []
 	for (const segment of total) pushDrawableSegment(drawableTotal, segment)
 	for (const segment of annular) pushDrawableSegment(drawableAnnular, segment)
 	return { total: drawableTotal, annular: drawableAnnular }
@@ -3089,9 +2772,9 @@ export function computeSolarEclipseMapGeometry(eclipse: SolarEclipse, pbe: Polyn
 	const refractionMode = options?.refractionMode ?? DEFAULT_REFRACTION_MODE
 	const curveOptions: SolarEclipseCurveOptions = { longitudeStep, maxAngularStep, refractionMode }
 
-	let centerLine: GeoBranch = []
-	let umbraNorth: GeoCurve = []
-	let umbraSouth: GeoCurve = []
+	let centerLine: SolarEclipseGeoBranch = []
+	let umbraNorth: SolarEclipseGeoCurve = []
+	let umbraSouth: SolarEclipseGeoCurve = []
 
 	// Whether the shadow axis truly intersects the ellipsoid (the precise geometric test that replaces the
 	// gamma threshold), and whether the umbra/antumbra touches Earth at all. The axis test is authoritative
@@ -3111,7 +2794,7 @@ export function computeSolarEclipseMapGeometry(eclipse: SolarEclipse, pbe: Polyn
 		// two sub-polylines that meet at the apex. Branches are never joined across a discontinuity.
 		umbraNorth = reconnectSplitCurveCusps(splitBranchesAtMaxAbsLatitude(findCurveBranchPoints(pbe, 1, 1, curveOptions)), pbe, 1, 1, maxAngularStep, refractionMode)
 		umbraSouth = reconnectSplitCurveCusps(splitBranchesAtMaxAbsLatitude(findCurveBranchPoints(pbe, -1, 1, curveOptions)), pbe, -1, 1, maxAngularStep, refractionMode)
-		const umbraBranches: GeoCurve = []
+		const umbraBranches: EclipseGeoCurve = []
 		for (const branch of umbraNorth) umbraBranches.push(branch)
 		for (const branch of umbraSouth) umbraBranches.push(branch)
 		alignUmbralContactPoints(points, umbraBranches, maxAngularStep)
@@ -3126,7 +2809,7 @@ export function computeSolarEclipseMapGeometry(eclipse: SolarEclipse, pbe: Polyn
 		const line = assembleCenterLine(pbe, C1, C2, findCurvePoints(pbe, 0, 0, curveOptions), maxAngularStep, refractionMode)
 		// Tag each central-line point with its local total/annular character so a hybrid eclipse's
 		// transition is recoverable from the geometry.
-		const taggedCenterLine: GeoBranch = []
+		const taggedCenterLine: SolarEclipseGeoBranch = []
 		for (const point of line) taggedCenterLine.push(point.jd === undefined ? point : { x: point.x, y: point.y, jd: point.jd, kind: centralLineKind(pbe, point.jd) })
 		centerLine = taggedCenterLine
 	}
@@ -3177,13 +2860,13 @@ export function computeSolarEclipseMapGeometry(eclipse: SolarEclipse, pbe: Polyn
 // points (never artificial connectors). Near the limb the projected line moves arbitrarily fast, so
 // scan points within the time-collapse epsilon of an endpoint are dropped in favor of the exact
 // C1/C2 contact, keeping them as the true endpoints of the polyline.
-function assembleCenterLine(pbe: PolynomialBesselianElements, C1: GeoPoint | undefined, C2: GeoPoint | undefined, scan: GeoBranch, maxAngularStep: Angle, refractionMode: RefractionMode = DEFAULT_REFRACTION_MODE) {
-	const interior: GeoBranch = []
+function assembleCenterLine(pbe: PolynomialBesselianElements, C1: EclipseGeoPoint | undefined, C2: EclipseGeoPoint | undefined, scan: EclipseGeoBranch, maxAngularStep: Angle, refractionMode: RefractionMode = DEFAULT_REFRACTION_MODE) {
+	const interior: EclipseGeoBranch = []
 	for (const point of scan) if (isCenterLineInteriorPoint(point, C1, C2)) interior.push(point)
-	const assembled: GeoBranch = []
+	const assembled: EclipseGeoBranch = []
 
 	if (C1 && interior.length > 0) {
-		const head: GeoBranch = []
+		const head: EclipseGeoBranch = []
 		appendRefinedSegment(head, pbe, C1, interior[0], 0, 0, maxAngularStep, refractionMode)
 		for (const p of head) if (isCenterLineInteriorPoint(p, C1, C2)) assembled.push(p)
 	}
@@ -3191,7 +2874,7 @@ function assembleCenterLine(pbe: PolynomialBesselianElements, C1: GeoPoint | und
 	for (const p of interior) assembled.push(p)
 
 	if (C2 && interior.length > 0) {
-		const tail: GeoBranch = []
+		const tail: EclipseGeoBranch = []
 		appendRefinedSegment(tail, pbe, interior.at(-1)!, C2, 0, 0, maxAngularStep, refractionMode)
 		for (const p of tail) if (isCenterLineInteriorPoint(p, C1, C2)) assembled.push(p)
 	}
@@ -3203,13 +2886,13 @@ function assembleCenterLine(pbe: PolynomialBesselianElements, C1: GeoPoint | und
 }
 
 // Whether a scanned central-line point belongs strictly between the solved C1/C2 endpoint instants.
-function isCenterLineInteriorPoint(point: GeoPoint, C1: GeoPoint | undefined, C2: GeoPoint | undefined) {
+function isCenterLineInteriorPoint(point: EclipseGeoPoint, C1: EclipseGeoPoint | undefined, C2: EclipseGeoPoint | undefined) {
 	return point.jd !== undefined && (C1?.jd === undefined || point.jd > C1.jd + CURVE_TIME_EPSILON_DAYS) && (C2?.jd === undefined || point.jd < C2.jd - CURVE_TIME_EPSILON_DAYS)
 }
 
 // Geometric solar altitude (radians) of an observer at a limit point at its own instant. The two named
 // extremes of a grazing penumbral limit are its terminator cusps, where this drops to ~0.
-export function solarAltitudeAtPoint(pbe: PolynomialBesselianElements, point: GeoPoint) {
+export function solarAltitudeAtPoint(pbe: PolynomialBesselianElements, point: EclipseGeoPoint) {
 	const be = besselianSampleAtJulianDay(pbe, point.jd!)
 	const H = hourAngleFromLongitude(point.x, be.mu, be.deltaTLongitudeCorrection)
 	const sinh = Math.sin(be.d) * Math.sin(point.y) + Math.cos(be.d) * Math.cos(point.y) * Math.cos(H)
@@ -3223,11 +2906,11 @@ const PENUMBRAL_CUSP_MIN_SEPARATION = 5 * DEG2RAD
 // Penumbral-limit cusps for a multi-branch curve, found without flattening the branches into a temporary
 // array. This mirrors penumbralLimitCusps: choose the lowest-altitude point, then the lowest-altitude point
 // spatially separated from it; fall back to the first/last drawable endpoints when no separated cusp exists.
-function penumbralCurveCusps(pbe: PolynomialBesselianElements, curve: GeoCurve) {
-	let first: GeoPoint | undefined
+function penumbralCurveCusps(pbe: PolynomialBesselianElements, curve: EclipseGeoCurve) {
+	let first: EclipseGeoPoint | undefined
 	let firstAltitude = Infinity
-	let fallbackStart: GeoPoint | undefined
-	let fallbackEnd: GeoPoint | undefined
+	let fallbackStart: EclipseGeoPoint | undefined
+	let fallbackEnd: EclipseGeoPoint | undefined
 
 	for (let b = 0; b < curve.length; b++) {
 		const branch = curve[b]
@@ -3247,7 +2930,7 @@ function penumbralCurveCusps(pbe: PolynomialBesselianElements, curve: GeoCurve) 
 
 	if (!first) return [undefined, undefined] as const
 
-	let second: GeoPoint | undefined
+	let second: EclipseGeoPoint | undefined
 	let secondAltitude = Infinity
 	for (let b = 0; b < curve.length; b++) {
 		const branch = curve[b]
@@ -3266,222 +2949,11 @@ function penumbralCurveCusps(pbe: PolynomialBesselianElements, curve: GeoCurve) 
 
 // Multi-branch penumbral endpoints ordered by eclipse chronology, avoiding the allocation that flat() would
 // create in the map assembly hot path.
-function penumbralCurveEndpointsByTime(pbe: PolynomialBesselianElements, curve: GeoCurve) {
+function penumbralCurveEndpointsByTime(pbe: PolynomialBesselianElements, curve: EclipseGeoCurve) {
 	const [a, b] = penumbralCurveCusps(pbe, curve)
 	if (!a || !b) return [undefined, undefined] as const
 	if (a.jd !== undefined && b.jd !== undefined) return a.jd <= b.jd ? [a, b] : [b, a]
 	return a.y <= b.y ? [a, b] : [b, a]
-}
-
-// Splits a geographic polyline into drawable antimeridian-safe segments.
-export function splitPolylineAtAntimeridian(line: GeoBranch) {
-	return splitGeoLineAtAntimeridian(line, false)
-}
-
-// Splits a geographic polygon ring into antimeridian-safe drawable rings.
-export function splitPolygonAtAntimeridian(ring: GeoBranch) {
-	return splitGeoLineAtAntimeridian(ring, true)
-}
-
-function splitGeoLineAtAntimeridian(line: GeoBranch, close: boolean) {
-	if (line.length < 2) return []
-
-	const segments: GeoCurve = []
-	let current: GeoBranch = [line[0]]
-	const count = close ? line.length + 1 : line.length
-
-	for (let i = 1; i < count; i++) {
-		const previous = line[(i - 1) % line.length]
-		const point = line[i % line.length]
-		const delta = point.x - previous.x
-
-		if (Math.abs(delta) > PI) {
-			const crossingLon = delta > 0 ? -PI : PI
-			const oppositeLon = -crossingLon
-			const t = (crossingLon - previous.x) / (point.x + (delta > 0 ? -TAU : TAU) - previous.x)
-			const clampedT = clamp(t, 0, 1)
-			const lat = previous.y + (point.y - previous.y) * clampedT
-			const jd = previous.jd !== undefined && point.jd !== undefined ? previous.jd + (point.jd - previous.jd) * clampedT : undefined
-			current.push({ x: crossingLon, y: lat, jd })
-			if (current.length > 1) segments.push(current)
-			current = [{ x: oppositeLon, y: lat, jd }, point]
-		} else {
-			current.push(point)
-		}
-	}
-
-	if (current.length > 1) segments.push(current)
-
-	// For a closed ring whose first vertex is not on the seam, the opening arc (the first segment) and
-	// the closing arc (the last segment) both belong to the start hemisphere and were split apart at
-	// line[0]; rejoin them so the hemisphere closes along the antimeridian seam rather than across the
-	// map interior. Each remaining segment already enters and leaves on the same seam, so closing it with
-	// Z follows the seam edge.
-	if (close && segments.length >= 2) {
-		const firstSegment = segments[0]
-		const lastSegment = segments.at(-1)!
-
-		if (samePoint(firstSegment[0], lastSegment.at(-1)!)) {
-			lastSegment.pop()
-			const joined: GeoBranch = []
-			for (const point of lastSegment) joined.push(point)
-			for (const point of firstSegment) joined.push(point)
-			segments[0] = joined
-			segments.pop()
-		}
-	}
-
-	return segments
-}
-
-const AU_IN_EARTH_RADII = AU_KM / EARTH_RADIUS_KM
-// Light travel time per AU in days, used to retard body positions to their emission epoch.
-const LIGHT_TIME_DAYS_PER_AU = LIGHT_TIME_AU / DAYSEC
-// Light-time iterations. Two passes converge the retarded geocentric position well below the map's
-// angular resolution for the Sun (~8.3 min one-way) and the Moon (~1.3 s one-way).
-const LIGHT_TIME_ITERATIONS = 2
-
-// Computes the apparent geocentric Sun and Moon positions used to derive Besselian elements. Both bodies
-// are corrected for light-time (retarded emission position) and annual aberration (the geocenter's
-// barycentric velocity), then rotated from ICRF/J2000 into the true equator and equinox of date. Delta T
-// is taken from the Espenak and Meeus 2006 polynomials for the sample epoch.
-//
-// Time-scale contract: the dynamical steps (ephemeris sampling, precession and nutation) are
-// dynamical-time operations, so the input time should be TT/TDB; the providers and
-// precessionNutationMatrix convert internally and the scale difference is sub-millisecond either way.
-// Earth rotation enters only later, in instantBesselianFromSunMoon, where mu is built from UT1 (= TT -
-// Delta T) and Greenwich apparent sidereal time, keeping the rotation strictly in UT.
-//   time: instant of evaluation in a dynamical scale (TT or TDB); other scales convert internally.
-//   sun: barycentric Sun position and velocity provider, in AU and AU/day, equatorial ICRF/J2000.
-//   earth: barycentric Earth position and velocity provider, in AU and AU/day, equatorial ICRF/J2000.
-//   moon: geocentric Moon position and velocity provider, in AU and AU/day, equatorial ICRF/J2000.
-export function computeSunMoonPositionAt(time: Time, sun: PositionAndVelocityOverTime, earth: PositionAndVelocityOverTime, moon: PositionAndVelocityOverTime): SunMoonPosition {
-	const earthBarycentric = earth(time)
-	const earthPosition = earthBarycentric[0]
-
-	// Observer (geocenter) barycentric velocity in units of the speed of light, plus the reciprocal Lorentz
-	// factor, both consumed by eraAb for annual aberration.
-	const aberrationVelocity = vecDivScalar(earthBarycentric[1], SPEED_OF_LIGHT_AU_DAY)
-	const reciprocalLorentz = Math.sqrt(1 - vecDot(aberrationVelocity, aberrationVelocity))
-
-	// Light-time corrected geocentric Sun position: seen where it was when its light departed.
-	let sunGeometric = vecMinus(sun(time)[0], earthPosition)
-
-	for (let i = 0; i < LIGHT_TIME_ITERATIONS; i++) {
-		const tau = vecLength(sunGeometric) * LIGHT_TIME_DAYS_PER_AU
-		sunGeometric = vecMinus(sun(timeShift(time, -tau))[0], earthPosition)
-	}
-
-	const sunDistance = vecLength(sunGeometric)
-
-	// Light-time corrected geocentric Moon position. The Moon provider is geocentric (Moon - Earth at the
-	// sampled epoch); retarding it alone would also recede the origin, yielding Moon(t - tau) - Earth(t -
-	// tau). The apparent geocentric vector must keep the observer at the geocenter of the observation
-	// epoch, so the Earth displacement Earth(t) - Earth(t - tau) is added back.
-	let moonGeometric = moon(time)[0]
-
-	for (let i = 0; i < LIGHT_TIME_ITERATIONS; i++) {
-		const tau = vecLength(moonGeometric) * LIGHT_TIME_DAYS_PER_AU
-		const retarded = timeShift(time, -tau)
-		moonGeometric = vecMinus(moon(retarded)[0], vecMinus(earthPosition, earth(retarded)[0]))
-	}
-
-	const moonDistance = vecLength(moonGeometric)
-	const pnm = precessionNutationMatrix(time)
-
-	// Apply annual aberration to the unit direction (the Sun-observer distance drives the relativistic
-	// deflection term), restore the body distance, then rotate ICRF/J2000 into the true equator of date.
-	const sunApparent = vecDivScalar(sunGeometric, sunDistance)
-	eraAb(sunApparent, aberrationVelocity, sunDistance, reciprocalLorentz, sunApparent)
-	vecMulScalar(sunApparent, sunDistance, sunApparent)
-	matMulVec(pnm, sunApparent, sunApparent)
-
-	const moonApparent = vecDivScalar(moonGeometric, moonDistance)
-	eraAb(moonApparent, aberrationVelocity, sunDistance, reciprocalLorentz, moonApparent)
-	vecMulScalar(moonApparent, moonDistance, moonApparent)
-	matMulVec(pnm, moonApparent, moonApparent)
-
-	const [sRA, sDEC, sD] = eraP2s(...sunApparent)
-	const [mRA, mDEC, mD] = eraP2s(...moonApparent)
-
-	// Decimal year for the Delta T model. The sub-minute scale difference between time scales is irrelevant
-	// for Delta T, which varies on the order of a second per year.
-	const year = eraEpj(time.day, time.fraction)
-
-	return {
-		sun: {
-			rightAscension: sRA,
-			declination: sDEC,
-			distance: sD * AU_IN_EARTH_RADII,
-		},
-		moon: {
-			rightAscension: mRA,
-			declination: mDEC,
-			distance: mD * AU_IN_EARTH_RADII,
-		},
-		deltaT: deltaTByEspenakMeeus2006(year),
-	}
-}
-
-// Serializes projected polyline or polygon pieces into an SVG path data string. Each piece becomes one
-// subpath (M ... L ...); pieces with fewer than two points are skipped. When close is true each subpath
-// is closed with Z, suitable for filled polygons.
-export function pointsToSvgPathData(pieces: readonly (readonly Point[])[], close = false, precision: number = 2) {
-	const subpaths: string[] = []
-
-	function formatCoordinate(value: number) {
-		return Number(value.toFixed(precision)).toString()
-	}
-
-	for (const piece of pieces) {
-		if (piece.length < 2) continue
-
-		// Build each subpath from tokens joined once, instead of growing a string with repeated `+=`.
-		const tokens: string[] = [`M${formatCoordinate(piece[0].x)} ${formatCoordinate(piece[0].y)}`]
-		for (let i = 1; i < piece.length; i++) tokens.push(`L${formatCoordinate(piece[i].x)} ${formatCoordinate(piece[i].y)}`)
-		if (close) tokens.push('Z')
-
-		subpaths.push(tokens.join(''))
-	}
-
-	return subpaths.join('')
-}
-
-// Splits one geographic line (or ring when close is true) at the antimeridian with the exact +-180
-// crossing inserted, then projects each piece. Inserting the crossing keeps every piece reaching the map
-// edge instead of stopping at the last sample before the wrap, which otherwise leaves a visible gap or
-// angular "beak" near +-180. The 'pi'-mode projection preserves an exact +-PI seam vertex, so the post-wrap
-// piece resumes on the left edge (-PI) rather than being folded back onto the right one (+PI). The split
-// happens only here, at serialization time: the geographic geometry itself is never mutated.
-function projectSplitPieces(geo: GeoBranch, close: boolean, projection: CylindricalProjection, options?: ProjectionOptions) {
-	const pieces: Point[][] = []
-
-	for (const segment of splitGeoLineAtAntimeridian(geo, close)) {
-		let piece: Point[] = []
-
-		for (const point of segment) {
-			const projected = projection.project(point.x, point.y, undefined, options)
-
-			if (projected === undefined) {
-				if (piece.length >= 2) pieces.push(piece)
-				piece = []
-			} else {
-				piece.push(projected)
-			}
-		}
-
-		if (piece.length >= 2) pieces.push(piece)
-	}
-
-	return pieces
-}
-
-// Projects geographic polylines and serializes them into one SVG path data string of open subpaths,
-// split at the antimeridian during projection only.
-export function geoPolylinesToSvgPathData(lines: readonly GeoBranch[], projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions = DEFAULT_SOLAR_ECLIPSE_MAP_SVG_PROJECTION_OPTIONS) {
-	const pieces: Point[][] = []
-	for (const line of lines) for (const piece of projectSplitPieces(line, false, projection, options.projectionOptions)) pieces.push(piece)
-	return pointsToSvgPathData(pieces, false, options.precision)
 }
 
 // Projects solar eclipse map geometry and serializes each polyline feature into SVG path data strings,
@@ -3492,19 +2964,20 @@ export function geoPolylinesToSvgPathData(lines: readonly GeoBranch[], projectio
 // than a straight spike. The geometry itself is never mutated.
 export function solarEclipseMapToSvgPaths(geometry: SolarEclipseMapGeometry, projection: CylindricalProjection, options: SolarEclipseMapSvgProjectionOptions = DEFAULT_SOLAR_ECLIPSE_MAP_SVG_PROJECTION_OPTIONS): SolarEclipseMapSvgPaths {
 	// Project named points with the same options as the curves, so points and lines stay aligned (P0.3).
-	function projectPoint(point: GeoPoint | undefined) {
+	function projectPoint(point: EclipseGeoPoint | undefined) {
 		return point ? projection.project(point.x, point.y, undefined, options.projectionOptions) : undefined
 	}
 
 	const { points, lines } = geometry
+	const { precision, projectionOptions } = options
 
 	return {
-		centerLine: geoPolylinesToSvgPathData([lines.centerLine], projection, options),
-		umbraNorth: geoPolylinesToSvgPathData(lines.umbraNorth, projection, options),
-		umbraSouth: geoPolylinesToSvgPathData(lines.umbraSouth, projection, options),
-		penumbraNorth: geoPolylinesToSvgPathData(lines.penumbraNorth, projection, options),
-		penumbraSouth: geoPolylinesToSvgPathData(lines.penumbraSouth, projection, options),
-		riseSetCurves: geoPolylinesToSvgPathData(lines.riseSetCurves, projection, options),
+		centerLine: geoPolylinesToSvgPathData([lines.centerLine], projection, precision, projectionOptions),
+		umbraNorth: geoPolylinesToSvgPathData(lines.umbraNorth, projection, precision, projectionOptions),
+		umbraSouth: geoPolylinesToSvgPathData(lines.umbraSouth, projection, precision, projectionOptions),
+		penumbraNorth: geoPolylinesToSvgPathData(lines.penumbraNorth, projection, precision, projectionOptions),
+		penumbraSouth: geoPolylinesToSvgPathData(lines.penumbraSouth, projection, precision, projectionOptions),
+		riseSetCurves: geoPolylinesToSvgPathData(lines.riseSetCurves, projection, precision, projectionOptions),
 		points: {
 			P1: projectPoint(points.P1),
 			P2: projectPoint(points.P2),

--- a/src/sun.eclipse.map.ts
+++ b/src/sun.eclipse.map.ts
@@ -11,7 +11,7 @@ import { bisection, brentMinimize, brentRoot, type RootFindingOptions } from './
 import type { CylindricalProjection, ProjectionOptions } from './projection'
 import { polynomialRegression } from './regression'
 import type { SolarEclipse } from './sun'
-import { precessionNutationMatrix, timeShift, timeSubtract, toJulianDay, tt, type Time } from './time'
+import { precessionNutationMatrix, timeAtJulianDay, timeShift, timeSubtract, toJulianDay, tt, type Time } from './time'
 import type { Writable } from './types'
 import { vecDivScalar, vecDot, vecLength, vecMinus, vecMulScalar, vecNormalizeMut } from './vec3'
 
@@ -511,10 +511,6 @@ function interpolateGreatCirclePoint(a: GeoPoint, b: GeoPoint, fraction: number)
 
 function validStep(value: number | undefined, fallback: number) {
 	return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback
-}
-
-function timeAtJulianDay(reference: Time, julianDay: number) {
-	return timeShift(reference, julianDay - reference.day - reference.fraction)
 }
 
 // Interpolates between two geographic points along the great-circle arc.

--- a/src/time.ts
+++ b/src/time.ts
@@ -278,6 +278,11 @@ export function timeShift(time: Time, fraction: number): Time {
 	return normalized
 }
 
+// Builds a Time at a Julian Day, preserving the reference time scale and providers.
+export function timeAtJulianDay(reference: Time, julianDay: number) {
+	return timeShift(reference, julianDay - reference.day - reference.fraction)
+}
+
 // Caches the timescale for target based on source.
 function timescale(target: Time, source: Time) {
 	const c = cache(target, source.cache)

--- a/tests/eclipse.test.ts
+++ b/tests/eclipse.test.ts
@@ -1,0 +1,270 @@
+import { expect, test, describe } from 'bun:test'
+import { deg } from '../src/angle'
+import { PI, TAU } from '../src/constants'
+// oxfmt-ignore
+import { derivativeEarthLimbOmega, EARTH_E2, earthLimbCircleIntersections, earthLimbExtremes, earthLimbOmega, earthLimbPoint, geoPolylinesToSvgPathData, hourAngleFromLongitude, longitudeFromHourAngle, pointsToSvgPathData, splitPolygonAtAntimeridian, splitPolylineAtAntimeridian, type EclipseGeoBranch } from '../src/eclipse'
+import type { Projection } from '../src/projection'
+
+test('longitude convention is east-positive and centralized in the hour-angle helpers', () => {
+	const mu = deg(100)
+	const correction = deg(0.0817)
+	const H = deg(40)
+	const longitude = longitudeFromHourAngle(H, mu, correction)
+
+	// lambda = H - mu + correction, east-positive (Astrarium's west-positive mirror negated).
+	expect(longitude).toBeCloseTo(deg(40 - 100 + 0.0817), 12)
+	// The inverse helper round-trips exactly when no TAU wrap is involved.
+	expect(hourAngleFromLongitude(longitude, mu, correction)).toBeCloseTo(H, 12)
+})
+
+describe('earth-limb ellipse geometry', () => {
+	const E2 = EARTH_E2
+
+	function omega(d: number) {
+		return 1 / Math.sqrt(1 - E2 * Math.cos(d) * Math.cos(d))
+	}
+
+	test('earthLimbOmega and its derivative are consistent (finite difference)', () => {
+		for (const d of [deg(-80), deg(-20), 0, deg(15), deg(60), deg(85)]) {
+			expect(earthLimbOmega(d)).toBeCloseTo(omega(d), 12)
+			const h = 1e-6
+			const numeric = (earthLimbOmega(d + h) - earthLimbOmega(d - h)) / (2 * h)
+			expect(derivativeEarthLimbOmega(d)).toBeCloseTo(numeric, 6)
+		}
+		// At the equator (d = 0) the flattening scale is maximal, so its derivative vanishes.
+		expect(derivativeEarthLimbOmega(0)).toBeCloseTo(0, 12)
+	})
+
+	test('earthLimbPoint lies exactly on the limb ellipse x^2 + (omega y)^2 = 1', () => {
+		const w = omega(deg(23))
+		for (const theta of [0, 0.5, 1.3, PI, 4.2, 6]) {
+			const [x, y] = earthLimbPoint(theta, w)
+			expect(x * x + (w * y) ** 2).toBeCloseTo(1, 12)
+		}
+	})
+
+	test('earthLimbExtremes finds the true nearest and farthest limb points', () => {
+		const w = omega(deg(40))
+		// A point inside the ellipse.
+		const inside = earthLimbExtremes(0.2, -0.1, w)
+		expect(inside.inside).toBe(true)
+		expect(inside.minDistance).toBeLessThan(inside.maxDistance)
+		// A point outside the ellipse.
+		const outside = earthLimbExtremes(1.6, 0.9, w)
+		expect(outside.inside).toBe(false)
+
+		// The reported nearest/farthest distances are the global extrema over a dense theta scan.
+		for (const sample of [inside, outside]) {
+			const cx = sample === inside ? 0.2 : 1.6
+			const cy = sample === inside ? -0.1 : 0.9
+			let min = Infinity
+			let max = -Infinity
+			for (let k = 0; k < 2000; k++) {
+				const [x, y] = earthLimbPoint((k / 2000) * TAU, w)
+				const dist = Math.hypot(x - cx, y - cy)
+				min = Math.min(min, dist)
+				max = Math.max(max, dist)
+			}
+			expect(sample.minDistance).toBeLessThanOrEqual(min + 1e-6)
+			expect(sample.maxDistance).toBeGreaterThanOrEqual(max - 1e-6)
+			// The nearest point sits on the ellipse.
+			const [nx, ny] = earthLimbPoint(sample.nearestTheta, w)
+			expect(nx * nx + (w * ny) ** 2).toBeCloseTo(1, 10)
+		}
+	})
+
+	test('earthLimbCircleIntersections solves the circle-ellipse system (two, tangent, none)', () => {
+		const w = omega(deg(35))
+		const cx = 0.3
+		const cy = -0.2
+
+		// Radius chosen so the shadow circle cuts the limb twice.
+		const radius = 0.9
+		const crossings = earthLimbCircleIntersections(cx, cy, w, radius)
+		expect(crossings.length).toBeGreaterThanOrEqual(2)
+		// Ordered by descending y, and each crossing satisfies BOTH equations.
+		for (let i = 1; i < crossings.length; i++) expect(crossings[i - 1][1]).toBeGreaterThanOrEqual(crossings[i][1])
+		for (const [x, y] of crossings) {
+			expect(x * x + (w * y) ** 2).toBeCloseTo(1, 6)
+			expect(Math.hypot(x - cx, y - cy)).toBeCloseTo(radius, 6)
+		}
+
+		// A radius larger than the farthest limb distance from a far-outside center: no intersection.
+		expect(earthLimbCircleIntersections(5, 0, w, 0.5)).toHaveLength(0)
+	})
+
+	test('earthLimbCircleIntersections handles a high-declination (more flattened) limb near the pole', () => {
+		const w = omega(deg(85))
+		// Center near the pole region of the fundamental plane.
+		const crossings = earthLimbCircleIntersections(0, 0.8, w, 0.6)
+		expect(crossings.length).toBeGreaterThanOrEqual(2)
+		for (const [x, y] of crossings) {
+			expect(x * x + (w * y) ** 2).toBeCloseTo(1, 6)
+			expect(Math.hypot(x - 0, y - 0.8)).toBeCloseTo(0.6, 6)
+		}
+	})
+})
+
+describe('circle-ellipse intersection multiplicity and tangency', () => {
+	// A circle and an ellipse can meet in four points; the solver must return all of them.
+	// Synthetic flattened limb x^2 + (2y)^2 = 1 (omega = 2) and a concentric circle of radius 0.7 cut at
+	// the four points (+-0.566, +-0.412).
+	test('earthLimbCircleIntersections returns four crossings when the geometry has four', () => {
+		const omega = 2
+		const radius = 0.7
+		const crossings = earthLimbCircleIntersections(0, 0, omega, radius)
+
+		expect(crossings).toHaveLength(4)
+		// Ordered by descending y, and each crossing lies on BOTH the ellipse and the circle.
+		for (let i = 1; i < crossings.length; i++) expect(crossings[i - 1][1]).toBeGreaterThanOrEqual(crossings[i][1])
+		for (const [x, y] of crossings) {
+			expect(x * x + (omega * y) ** 2).toBeCloseTo(1, 6)
+			expect(Math.hypot(x, y)).toBeCloseTo(radius, 6)
+		}
+	})
+
+	// A grazing (tangential) contact is a double root that never changes sign; placed off the 2-degree scan
+	// grid it would be missed without explicit tangency detection.
+	test('earthLimbCircleIntersections detects an off-grid tangency with no sign change', () => {
+		const omega = 2
+		const theta0 = 0.05
+		const px = Math.cos(theta0)
+		const py = Math.sin(theta0) / omega
+		// Outward ellipse normal at P = grad(x^2 + (omega y)^2) = (2x, 2 omega^2 y), normalized.
+		const gradientX = 2 * px
+		const gradientY = 2 * omega * omega * py
+		const gradientLength = Math.hypot(gradientX, gradientY)
+		// Radius below the local radius of curvature (~0.25 near the vertex) so the circle is tangent from
+		// outside at exactly one point rather than cutting the ellipse twice.
+		const radius = 0.15
+		const cx = px + (radius * gradientX) / gradientLength
+		const cy = py + (radius * gradientY) / gradientLength
+
+		const crossings = earthLimbCircleIntersections(cx, cy, omega, radius)
+		expect(crossings).toHaveLength(1)
+		expect(Math.hypot(crossings[0][0] - px, crossings[0][1] - py)).toBeLessThan(0.02)
+	})
+})
+
+test('pointsToSvgPathData emits one M..L.. subpath per piece and closes polygons', () => {
+	const open = pointsToSvgPathData([
+		[
+			{ x: 1, y: 2 },
+			{ x: 3, y: 4 },
+			{ x: 5, y: 6 },
+		],
+	])
+
+	expect(open).toBe('M1 2L3 4L5 6')
+
+	const closed = pointsToSvgPathData(
+		[
+			[
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+				{ x: 10, y: 10 },
+			],
+		],
+		true,
+	)
+
+	expect(closed.startsWith('M0 0')).toBe(true)
+	expect(closed.endsWith('Z')).toBe(true)
+
+	// Two pieces produce two subpaths; degenerate pieces are dropped; empty input yields an empty string.
+	expect(
+		pointsToSvgPathData([
+			[
+				{ x: 0, y: 0 },
+				{ x: 1, y: 1 },
+			],
+			[
+				{ x: 2, y: 2 },
+				{ x: 3, y: 3 },
+			],
+		]).match(/M/g),
+	).toHaveLength(2)
+
+	expect(pointsToSvgPathData([[{ x: 0, y: 0 }]])).toBe('')
+	expect(pointsToSvgPathData([])).toBe('')
+})
+
+test('pointsToSvgPathData rounds coordinates to the requested precision', () => {
+	expect(
+		pointsToSvgPathData(
+			[
+				[
+					{ x: 1.23456, y: 2.98765 },
+					{ x: 3.1, y: 4 },
+				],
+			],
+			false,
+			3,
+		),
+	).toBe('M1.235 2.988L3.1 4')
+})
+
+test('antimeridian splitting keeps segments within a hemisphere and continuous across the seam', () => {
+	const line: EclipseGeoBranch = [
+		{ x: deg(150), y: deg(5) },
+		{ x: deg(178), y: deg(8) },
+		{ x: deg(-176), y: deg(11) },
+		{ x: deg(-150), y: deg(14) },
+	]
+
+	const segments = splitPolylineAtAntimeridian(line)
+	expect(segments).toHaveLength(2)
+
+	for (const segment of segments) for (let i = 1; i < segment.length; i++) expect(Math.abs(segment[i].x - segment[i - 1].x)).toBeLessThanOrEqual(PI)
+
+	const seamEnd = segments[0].at(-1)!
+	const seamStart = segments[1][0]
+	expect(Math.abs(seamEnd.x)).toBeCloseTo(PI, 10)
+	expect(Math.abs(seamStart.x)).toBeCloseTo(PI, 10)
+	expect(seamEnd.x).toBe(-seamStart.x)
+	// Latitude is continuous across the inserted seam point.
+	expect(seamEnd.y).toBeCloseTo(seamStart.y, 10)
+})
+
+test('split helpers avoid direct antimeridian joins', () => {
+	const line: EclipseGeoBranch = [
+		{ x: deg(170), y: deg(10) },
+		{ x: deg(-170), y: deg(12) },
+		{ x: deg(-160), y: deg(15) },
+	]
+
+	const segments = splitPolylineAtAntimeridian(line)
+	const rings = splitPolygonAtAntimeridian(line)
+
+	expect(segments.length).toBeGreaterThan(1)
+	expect(rings.length).toBeGreaterThan(1)
+	expect(segments[0].at(-1)!.x).toBe(PI)
+	expect(segments[1][0].x).toBe(-PI)
+
+	const point = [{ x: 0, y: 0 }]
+	expect(splitPolylineAtAntimeridian(point)).toHaveLength(0)
+	expect(splitPolygonAtAntimeridian(point)).toHaveLength(0)
+})
+
+test('projected path serialization breaks at projection gaps', () => {
+	const clippedProjection: Projection = {
+		project(longitude, latitude) {
+			return Math.abs(latitude) > deg(80) ? undefined : { x: longitude / deg(1), y: latitude / deg(1) }
+		},
+		unproject() {
+			return undefined
+		},
+	}
+	const path = geoPolylinesToSvgPathData(
+		[
+			[
+				{ x: deg(-10), y: deg(70) },
+				{ x: 0, y: deg(85) },
+				{ x: deg(10), y: deg(70) },
+			],
+		],
+		clippedProjection,
+	)
+
+	expect(path).toBe('')
+})

--- a/tests/eclipse.util.ts
+++ b/tests/eclipse.util.ts
@@ -4,8 +4,8 @@ import { sphericalSeparation } from '../src/geometry'
 import { nearestSolarEclipse } from '../src/sun'
 // oxfmt-ignore
 import { type SolarEclipseGeoPoint, type PolynomialBesselianElements, intermediateGreatCircle, findEclipseCurvePoint, computePolynomialBesselianElements, computeSolarEclipseMapGeometry, evaluateBesselian, BRANCH_MAX_DRAWABLE_GAP } from '../src/sun.eclipse.map'
-import { F, sunMoonPosition, type EclipseGeoBranch, type EclipseGeoCurve, type SunMoonPosition, type SunMoonProvider } from '../src/eclipse'
-import { timeYMD, type Time, time, Timescale } from '../src/time'
+import { F, sunMoonPosition, type EclipseGeoBranch, type EclipseGeoCurve, type SunMoonProvider } from '../src/eclipse'
+import { timeYMD, time, Timescale } from '../src/time'
 
 const CATALOG_STEP = deg(Number.parseFloat(Bun.env.SOLAR_ECLIPSE_CATALOG_STEP_DEG || '0.5'))
 const CATALOG_MAX_DRAWABLE_GAP = Math.max(BRANCH_MAX_DRAWABLE_GAP, CATALOG_STEP * 4)
@@ -118,17 +118,9 @@ export function maxBranchSegment(curve: EclipseGeoCurve) {
 export function geometryFor(year: number, month: number, day: number) {
 	const STEP = 0.5 * DEG2RAD
 	const eclipse = nearestSolarEclipse(timeYMD(year, month, day), true)
-	const elements = computePolynomialBesselianElements(eclipse.maximalTime, cachedSunMoonPosition)
+	const elements = computePolynomialBesselianElements(eclipse.maximalTime, sunMoonPosition)
 	const geometry = computeSolarEclipseMapGeometry(eclipse, elements, { longitudeStep: STEP, maxAngularStep: STEP, includeRiseSetCurves: false })
 	return { eclipse, elements, geometry }
-}
-
-const SUN_MOON_POSITION_CACHE = new Map<string, SunMoonPosition>()
-
-// Cached apparent Sun/Moon position provider from the analytical VSOP87E + ELP/MPP02 ephemerides.
-export function cachedSunMoonPosition(time: Time) {
-	const key = `${time.scale}-${time.day}-${time.fraction}`
-	return SUN_MOON_POSITION_CACHE.getOrInsertComputed(key, () => sunMoonPosition(time))
 }
 
 export function fixedSunMoonPosition(rightAscension: number, declination: number = 0): SunMoonProvider {

--- a/tests/eclipse.util.ts
+++ b/tests/eclipse.util.ts
@@ -3,10 +3,9 @@ import { DEG2RAD, PI, TAU } from '../src/constants'
 import { sphericalSeparation } from '../src/geometry'
 import { nearestSolarEclipse } from '../src/sun'
 // oxfmt-ignore
-import { type GeoPoint, type PolynomialBesselianElements, intermediateGreatCircle, findEclipseCurvePoint, computePolynomialBesselianElements, computeSolarEclipseMapGeometry, computeSunMoonPositionAt, evaluateBesselian, BRANCH_MAX_DRAWABLE_GAP, F, type GeoCurve, type GeoBranch } from '../src/sun.eclipse.map'
-import * as elpmpp02 from '../src/elpmpp02'
+import { type SolarEclipseGeoPoint, type PolynomialBesselianElements, intermediateGreatCircle, findEclipseCurvePoint, computePolynomialBesselianElements, computeSolarEclipseMapGeometry, evaluateBesselian, BRANCH_MAX_DRAWABLE_GAP } from '../src/sun.eclipse.map'
+import { F, sunMoonPosition, type EclipseGeoBranch, type EclipseGeoCurve, type SunMoonPosition, type SunMoonProvider } from '../src/eclipse'
 import { timeYMD, type Time, time, Timescale } from '../src/time'
-import * as vsop87e from '../src/vsop87e'
 
 const CATALOG_STEP = deg(Number.parseFloat(Bun.env.SOLAR_ECLIPSE_CATALOG_STEP_DEG || '0.5'))
 const CATALOG_MAX_DRAWABLE_GAP = Math.max(BRANCH_MAX_DRAWABLE_GAP, CATALOG_STEP * 4)
@@ -25,7 +24,7 @@ export function muRate(elements: PolynomialBesselianElements, jd: number) {
 // curve solver drives to zero (W is the cross-track offset of the observer from the shadow axis, |E| the
 // shadow-edge radius). Near zero means the point lies exactly on the requested magnitude curve: the umbra
 // edge for G = 1, the penumbra edge for G = 0. Detects points that did not converge onto the physical limit.
-export function limitTangencyResidual(elements: PolynomialBesselianElements, point: GeoPoint, i: -1 | 1, G: number) {
+export function limitTangencyResidual(elements: PolynomialBesselianElements, point: SolarEclipseGeoPoint, i: -1 | 1, G: number) {
 	const be = evaluateBesselian(elements, time(point.jd!, 0, Timescale.TT))
 	const dmu = muRate(elements, point.jd!)
 	const sinD = Math.sin(be.d)
@@ -51,7 +50,7 @@ export function limitTangencyResidual(elements: PolynomialBesselianElements, poi
 
 // Counts interior vertices whose direction turns by more than threshold radians: the serrilhado detector.
 // Antimeridian-wrapping and zero-length steps are skipped. Zero means a smooth physical curve.
-export function countKinks(branch: GeoBranch, threshold: number) {
+export function countKinks(branch: EclipseGeoBranch, threshold: number) {
 	let count = 0
 
 	for (let i = 1; i < branch.length - 1; i++) {
@@ -70,7 +69,7 @@ export function countKinks(branch: GeoBranch, threshold: number) {
 }
 
 // Great-circle interpolation of a time-parametrized curve at an arbitrary Julian Day.
-export function interpolateAtJulianDay(line: GeoBranch, jd: number) {
+export function interpolateAtJulianDay(line: EclipseGeoBranch, jd: number) {
 	for (let i = 1; i < line.length; i++) {
 		if (line[i - 1].jd! <= jd && jd <= line[i].jd!) {
 			const fraction = (jd - line[i - 1].jd!) / (line[i].jd! - line[i - 1].jd!)
@@ -103,7 +102,7 @@ export function longestProjectedSegment(pathData: string) {
 }
 
 // Largest spherical edge between consecutive points within any branch, skipping antimeridian wraps.
-export function maxBranchSegment(curve: GeoCurve) {
+export function maxBranchSegment(curve: EclipseGeoCurve) {
 	let max = 0
 
 	for (const branch of curve) {
@@ -119,16 +118,28 @@ export function maxBranchSegment(curve: GeoCurve) {
 export function geometryFor(year: number, month: number, day: number) {
 	const STEP = 0.5 * DEG2RAD
 	const eclipse = nearestSolarEclipse(timeYMD(year, month, day), true)
-	const elements = computePolynomialBesselianElements(eclipse.maximalTime, sunMoonPosition)
+	const elements = computePolynomialBesselianElements(eclipse.maximalTime, cachedSunMoonPosition)
 	const geometry = computeSolarEclipseMapGeometry(eclipse, elements, { longitudeStep: STEP, maxAngularStep: STEP, includeRiseSetCurves: false })
 	return { eclipse, elements, geometry }
 }
 
-export function sunMoonPosition(t: Time) {
-	return computeSunMoonPositionAt(t, vsop87e.sun, vsop87e.earth, elpmpp02.moon)
+const SUN_MOON_POSITION_CACHE = new Map<string, SunMoonPosition>()
+
+// Cached apparent Sun/Moon position provider from the analytical VSOP87E + ELP/MPP02 ephemerides.
+export function cachedSunMoonPosition(time: Time) {
+	const key = `${time.scale}-${time.day}-${time.fraction}`
+	return SUN_MOON_POSITION_CACHE.getOrInsertComputed(key, () => sunMoonPosition(time))
 }
 
-export function endpointRetraces(branch: GeoBranch, fromStart: boolean) {
+export function fixedSunMoonPosition(rightAscension: number, declination: number = 0): SunMoonProvider {
+	return () => ({
+		sun: { rightAscension: rightAscension - PI + deg(0.1), declination: 0, distance: 1 },
+		moon: { rightAscension, declination, distance: 60 },
+		deltaT: 0,
+	})
+}
+
+export function endpointRetraces(branch: EclipseGeoBranch, fromStart: boolean) {
 	if (branch.length < 4) return false
 
 	const endpoint = fromStart ? branch[0] : branch.at(-1)!
@@ -149,7 +160,7 @@ export function endpointRetraces(branch: GeoBranch, fromStart: boolean) {
 	return false
 }
 
-export function catalogBranchRetraces(branch: GeoBranch, tolerance: Angle, minArcSeparation: Angle) {
+export function catalogBranchRetraces(branch: EclipseGeoBranch, tolerance: Angle, minArcSeparation: Angle) {
 	const arc = new Float64Array(branch.length)
 
 	for (let k = 1; k < branch.length; k++) arc[k] = arc[k - 1] + sphericalSeparation(branch[k - 1].x, branch[k - 1].y, branch[k].x, branch[k].y)
@@ -177,7 +188,7 @@ const CATALOG_BRIDGE_MAX_DEPTH = 10
 
 // Solves an in-between curve point on the great-circle-midpoint meridian of a..b that lies strictly between
 // them (both sub-distances within CATALOG_BRIDGE_BALANCE of the gap), or undefined when none is found.
-function solveCatalogBridgeMidpoint(elements: PolynomialBesselianElements, a: GeoPoint, b: GeoPoint, i: -1 | 1, G: number) {
+function solveCatalogBridgeMidpoint(elements: PolynomialBesselianElements, a: SolarEclipseGeoPoint, b: SolarEclipseGeoPoint, i: -1 | 1, G: number) {
 	const limit = CATALOG_BRIDGE_BALANCE * sphericalSeparation(a.x, a.y, b.x, b.y)
 	const midpoint = intermediateGreatCircle(a, b, 0.5)
 
@@ -196,7 +207,7 @@ function solveCatalogBridgeMidpoint(elements: PolynomialBesselianElements, a: Ge
 // a merge the engine correctly refuses. Requiring every recursive half to be bridgeable, down to a step that
 // can still hold an irreducible fold cusp (CATALOG_MAX_DRAWABLE_GAP), matches the engine's drawable-continuity
 // definition and only ever makes the probe stricter, so it can remove false positives but never invent gaps.
-export function hasContinuousCurveBetween(elements: PolynomialBesselianElements, a: GeoPoint, b: GeoPoint, i: -1 | 1, G: number, _gap: Angle, depth = 0): boolean {
+export function hasContinuousCurveBetween(elements: PolynomialBesselianElements, a: SolarEclipseGeoPoint, b: SolarEclipseGeoPoint, i: -1 | 1, G: number, _gap: Angle, depth = 0): boolean {
 	const gap = sphericalSeparation(a.x, a.y, b.x, b.y)
 	if (gap <= CATALOG_STEP) return true
 	if (Math.max(Math.abs(a.y), Math.abs(b.y)) > CATALOG_RECONNECT_POLE_LATITUDE) return false

--- a/tests/erfa.test.ts
+++ b/tests/erfa.test.ts
@@ -3,6 +3,7 @@ import { arcsec, toArcsec } from '../src/angle'
 import { kilometer, meter } from '../src/distance'
 import * as erfa from '../src/erfa'
 import { eraEpv00 } from '../src/erfa.earth'
+import { eraMoon98 } from '../src/erfa.moon'
 import type { Mat3, MutMat3 } from '../src/mat3'
 import { kilometerPerSecond, meterPerSecond, toKilometerPerSecond } from '../src/velocity'
 
@@ -994,4 +995,16 @@ test('eraEpb', () => {
 
 test('eraEpj', () => {
 	expect(erfa.eraEpj(2451545, -7392.5)).toBeCloseTo(1979.760438056125941, 13)
+})
+
+test('eraMoon98', () => {
+	const [p, v] = eraMoon98(2400000.5, 43999.9)
+
+	expect(p[0]).toBeCloseTo(-0.260129595997104418e-2, 13)
+	expect(p[1]).toBeCloseTo(0.6139750944302742189e-3, 13)
+	expect(p[2]).toBeCloseTo(0.2640794528229828909e-3, 13)
+
+	expect(v[0]).toBeCloseTo(-0.1244321506649895021e-3, 13)
+	expect(v[1]).toBeCloseTo(-0.5219076942678119398e-3, 13)
+	expect(v[2]).toBeCloseTo(-0.1716132214378462047e-3, 13)
 })

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -3,10 +3,10 @@ import { deg } from '../src/angle'
 import { PIOVERTWO, TAU } from '../src/constants'
 import * as elpmpp02 from '../src/elpmpp02'
 import { nearestLunarEclipse, type LunarEclipse } from '../src/moon'
-import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, type LocalLunarEclipseSvgCircle } from '../src/moon.eclipse.local'
+import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, moonAltitudeAt, type LocalLunarEclipseSvgCircle } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry } from '../src/moon.eclipse.map'
 import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
-import { type Time, timeYMDHMS } from '../src/time'
+import { timeShift, toJulianDay, type Time, timeYMDHMS } from '../src/time'
 import * as vsop87e from '../src/vsop87e'
 
 function sunMoonPosition(t: Time) {
@@ -103,6 +103,57 @@ describe('visibility classification', () => {
 		expect(local.events.MAX!.altitude).toBeLessThan(geocentricAltitude)
 		expect(local.events.MAX!.observable).toBe(false)
 	}, 6000)
+
+	// Replicates one point of the module's exact penumbral sample grid (reference = maximalTime, see scanAltitudes).
+	function gridAltitude(jd: number, longitude: number, latitude: number) {
+		const reference = TOTAL.maximalTime
+		return moonAltitudeAt(timeShift(reference, jd - reference.day - reference.fraction), longitude, latitude, sunMoonPosition)
+	}
+
+	// A short above-horizon stretch (here the sharp upper-transit peak) can fall between two fixed samples, so a
+	// sample-only check would report it unobservable; the interior search must still catch it.
+	test('Moon above the horizon only between two default samples is still classified observable', () => {
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		// Latitude = declination puts the Moon through the zenith at its transit (a sharp altitude peak);
+		// offsetting the longitude by ~half a sample step moves that peak between two default samples.
+		const latitude = max.declination
+		const longitude = max.sublunar.x + deg(0.94)
+
+		const p1jd = toJulianDay(TOTAL.firstContactPenumbraTime)
+		const p4jd = toJulianDay(TOTAL.lastContactPenumbraTime)
+		const samples = 48
+		const step = (p4jd - p1jd) / samples
+
+		// Maximum over the exact default sample grid (what a sample-only check would see), and its location.
+		let coarseMax = -Infinity
+		let imax = 0
+		for (let i = 0; i <= samples; i++) {
+			const altitude = gridAltitude(p1jd + i * step, longitude, latitude)
+			if (altitude > coarseMax) {
+				coarseMax = altitude
+				imax = i
+			}
+		}
+
+		// True peak between the two samples bracketing the coarse maximum.
+		const loZoom = p1jd + Math.max(0, imax - 1) * step
+		const hiZoom = p1jd + Math.min(samples, imax + 1) * step
+		let fineMax = -Infinity
+		for (let i = 0; i <= 40; i++) fineMax = Math.max(fineMax, gridAltitude(loZoom + (i / 40) * (hiZoom - loZoom), longitude, latitude))
+
+		// The peak genuinely falls between samples: it exceeds every default sample.
+		expect(fineMax).toBeGreaterThan(coarseMax)
+
+		// Horizon set between the coarse samples and the true peak: every default sample is below it (a
+		// sample-only check would report 'geometricOnlyBelowHorizon'), yet the Moon does rise above it.
+		const horizonAltitude = (coarseMax + fineMax) / 2
+		expect(coarseMax).toBeLessThan(horizonAltitude)
+
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { horizonAltitude })
+		expect(local.visibility.hasObservableEclipse).toBe(true)
+		expect(local.visibility.kind).not.toBe('geometricOnlyBelowHorizon')
+	}, 15000)
 })
 
 describe('P/Z orientation angles and Alt/Az', () => {

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { TAU } from '../src/constants'
+import { deg } from '../src/angle'
+import { PIOVERTWO, TAU } from '../src/constants'
 import * as elpmpp02 from '../src/elpmpp02'
 import { nearestLunarEclipse, type LunarEclipse } from '../src/moon'
 import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, type LocalLunarEclipseSvgCircle } from '../src/moon.eclipse.local'
@@ -77,6 +78,26 @@ describe('visibility classification', () => {
 		const longitude = sub.longitude > 0 ? sub.longitude - Math.PI : sub.longitude + Math.PI
 		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, -sub.latitude, sunMoonPosition)
 		expect(local.visibility.hasGeometricEclipse).toBe(true)
+	}, 6000)
+
+	// An observer a hair inside the geocentric MAX horizon curve: the geocentric Moon center is above the
+	// horizon, but once diurnal parallax (~0.95 deg) is applied the topocentric center is below it. The old
+	// geocentric conversion marked this location observable; the topocentric one must not.
+	test('observer just inside the geocentric horizon is below the topocentric horizon', () => {
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		// On the sublunar meridian (hour angle 0), geocentric altitude = 90 deg - |latitude - declination|; place
+		// the observer 0.3 deg inside the 90 deg horizon. (declination < 0 here keeps the latitude within range.)
+		const longitude = max.sublunar.x
+		const latitude = max.declination + (PIOVERTWO - deg(0.3))
+		const H = max.gast + longitude - max.rightAscension
+		const geocentricAltitude = Math.asin(Math.sin(latitude) * Math.sin(max.declination) + Math.cos(latitude) * Math.cos(max.declination) * Math.cos(H))
+		expect(geocentricAltitude).toBeGreaterThan(0)
+
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+		expect(local.events.MAX!.altitude).toBeLessThan(0)
+		expect(local.events.MAX!.altitude).toBeLessThan(geocentricAltitude)
+		expect(local.events.MAX!.observable).toBe(false)
 	}, 6000)
 })
 

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -148,7 +148,7 @@ describe('visibility classification', () => {
 		expect(local.events.MAX!.altitude).toBeLessThan(0)
 		expect(local.events.MAX!.altitude).toBeLessThan(geocentricAltitude)
 		expect(local.events.MAX!.observable).toBe(false)
-	}, 6000)
+	}, 8000)
 
 	// Replicates one point of the module's exact penumbral sample grid (reference = maximalTime, see scanAltitudes).
 	function gridAltitude(jd: number, longitude: number, latitude: number) {
@@ -251,6 +251,24 @@ describe('visibility classification', () => {
 		expect(local.details.observableDuration).toBeGreaterThan(0)
 		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
 	}, 15000)
+
+	// A high-latitude grazing moonrise/moonset whose entire above-horizon window is far shorter than scan.step / 16.
+	// With a coarse scan (2 samples, one ~2.5 h step), a fixed 16-piece subdivision of the suspect step would find
+	// both ends of the relevant sub-step below the horizon and report nothing, while phaseReachesHorizon still
+	// classifies the eclipse observable from its interior maximum. Bracketing that maximum and solving the two
+	// horizon roots around it recovers the brief duration, keeping observableDuration consistent with observability.
+	test('a grazing window shorter than a refinement sub-step still yields a positive duration', () => {
+		const samples = 2
+		const longitude = deg(-180)
+		const latitude = deg(79)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: samples })
+
+		const subStepSeconds = local.details.penumbralPhaseDuration / samples / 16
+		expect(local.visibility.hasObservableEclipse).toBe(true)
+		// The window is real but shorter than one refinement sub-step, so a both-below sub-step integration misses it.
+		expect(local.details.observableDuration).toBeGreaterThan(0)
+		expect(local.details.observableDuration).toBeLessThan(subStepSeconds)
+	}, 6000)
 
 	// Every contact can be above the horizon while the Moon still dips below it between contacts (a high-latitude
 	// lower culmination during the multi-hour penumbral interval). 'completelyVisible' must check the whole

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -1,32 +1,44 @@
 import { describe, expect, test } from 'bun:test'
 import { deg } from '../src/angle'
 import { PIOVERTWO, TAU } from '../src/constants'
-import * as elpmpp02 from '../src/elpmpp02'
-import { nearestLunarEclipse, type LunarEclipse } from '../src/moon'
+import { nearestLunarEclipse } from '../src/moon'
 import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, moonAltitudeAt, type LocalLunarEclipseSvgCircle, type LocalLunarEclipseSvgPolygon } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry } from '../src/moon.eclipse.map'
-import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
-import { timeShift, toJulianDay, type Time, timeYMDHMS } from '../src/time'
-import * as vsop87e from '../src/vsop87e'
+import type { SunMoonPosition } from '../src/sun.eclipse.map'
+import { toJulianDay, type Time, timeYMDHMS, greenwichApparentSiderealTime, timeAtJulianDay } from '../src/time'
 
-function sunMoonPosition(t: Time) {
-	return computeSunMoonPositionAt(t, vsop87e.sun, vsop87e.earth, elpmpp02.moon)
+const FAST_LONGITUDE = deg(5)
+const FAST_LATITUDE = 0
+
+// Cheap deterministic position provider for tests that exercise local-circumstance plumbing rather than the
+// analytical VSOP87/ELP ephemerides. The Moon stays high for FAST_LONGITUDE/FAST_LATITUDE, keeping visibility
+// and duration assertions stable while avoiding hundreds of expensive series evaluations.
+function fastSunMoonPosition(time: Time) {
+	const gast = greenwichApparentSiderealTime(time)
+
+	return {
+		sun: { rightAscension: gast - Math.PI + deg(0.1), declination: 0, distance: 1 },
+		moon: { rightAscension: gast, declination: 0, distance: 60 },
+		deltaT: 0,
+	}
+}
+
+function fixedSunMoonPosition(rightAscension: number, declination: number = 0) {
+	return (time: Time): SunMoonPosition => ({
+		sun: { rightAscension: rightAscension - Math.PI + deg(0.1), declination: 0, distance: 1 },
+		moon: { rightAscension, declination, distance: 60 },
+		deltaT: 0,
+	})
 }
 
 const PENUMBRAL = nearestLunarEclipse(timeYMDHMS(1973, 6, 1), true)
 const TOTAL = nearestLunarEclipse(timeYMDHMS(1997, 7, 1), true)
 const PARTIAL = nearestLunarEclipse(timeYMDHMS(1994, 5, 25), true)
 
-// Sublunar point (longitude, latitude) at maximal eclipse, where the Moon is at the zenith.
-function sublunarAtMax(eclipse: LunarEclipse) {
-	const geometry = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition)
-	const max = geometry.events.find((e) => e.kind === 'MAX')!
-	return { longitude: max.sublunar.x, latitude: max.sublunar.y }
-}
-
 // Ray-casting point-in-polygon test.
 function pointInPolygon(px: number, py: number, polygon: readonly { readonly x: number; readonly y: number }[]) {
 	let inside = false
+
 	for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
 		const xi = polygon[i].x
 		const yi = polygon[i].y
@@ -34,6 +46,7 @@ function pointInPolygon(px: number, py: number, polygon: readonly { readonly x: 
 		const yj = polygon[j].y
 		if (yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) inside = !inside
 	}
+
 	return inside
 }
 
@@ -42,51 +55,47 @@ describe('ancient dates', () => {
 	// real geometric eclipse instead of nothing.
 	test('local circumstances resolve for an eclipse before JD 0', () => {
 		const ancient = nearestLunarEclipse(timeYMDHMS(-5000, 1, 1), true)
-		const local = computeLocalLunarEclipseCircumstances(ancient, 0, 0, sunMoonPosition, { altitudeSamples: 12 })
+		const local = computeLocalLunarEclipseCircumstances(ancient, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 4 })
 		expect(local.visibility.hasGeometricEclipse).toBe(true)
 		expect(Object.keys(local.events)).toEqual(['P1', 'U1', 'MAX', 'U4', 'P4'])
 		expect(local.events.MAX!.time.day).toBeLessThan(0)
-	}, 6000)
+	})
 })
 
 describe('altitudeSamples normalization', () => {
-	// The sublunar point at MAX sees the whole eclipse above the horizon, so observableDuration equals the full
+	// The synthetic Moon stays above the horizon throughout the eclipse, so observableDuration equals the full
 	// penumbral phase only when the scan reaches P4. A fractional sample count must not make it stop short, and a
 	// non-finite count must neither hang (Infinity) nor skip the scan (NaN); all normalize to the default 48.
-	const { longitude, latitude } = sublunarAtMax(TOTAL)
-	const reference = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition).details.observableDuration
+	const reference = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition).details.observableDuration
 
 	test('fractional altitudeSamples is floored and still reaches P4', () => {
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 48.5 })
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 48.5 })
 		expect(local.details.observableDuration).toBeCloseTo(reference, 6)
 		expect(local.details.observableDuration).toBeGreaterThan(local.details.penumbralPhaseDuration * 0.99)
-	}, 6000)
+	})
 
 	test('non-finite altitudeSamples falls back to the default without hanging', () => {
 		for (const bad of [Number.POSITIVE_INFINITY, Number.NaN]) {
-			const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: bad })
+			const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: bad })
 			expect(local.details.observableDuration).toBeCloseTo(reference, 6)
 		}
-	}, 8000)
+	})
 })
 
 describe('horizonAltitude normalization', () => {
-	const { longitude, latitude } = sublunarAtMax(TOTAL)
-
 	test('non-finite horizonAltitude falls back to the geometric horizon', () => {
-		const reference = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 12 })
+		const reference = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 12 })
 		for (const bad of [Number.POSITIVE_INFINITY, Number.NaN]) {
-			const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 12, horizonAltitude: bad })
+			const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 12, horizonAltitude: bad })
 			expect(local.visibility.kind).toBe(reference.visibility.kind)
 			expect(local.details.observableDuration).toBeCloseTo(reference.details.observableDuration, 6)
 			expect(local.events.MAX!.observable).toBe(reference.events.MAX!.observable)
 		}
-	}, 8000)
+	})
 })
 
 describe('per-contact magnitudes', () => {
-	const { longitude, latitude } = sublunarAtMax(TOTAL)
-	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+	const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 4 })
 
 	test('umbral magnitude is 0 at U1/U4 and 1 at U2/U3', () => {
 		expect(local.events.U1!.umbralMagnitude).toBeCloseTo(0, 6)
@@ -105,17 +114,15 @@ describe('per-contact magnitudes', () => {
 	})
 
 	test('penumbral-only eclipse exposes its penumbral magnitude at MAX', () => {
-		const sub = sublunarAtMax(PENUMBRAL)
-		const localPen = computeLocalLunarEclipseCircumstances(PENUMBRAL, sub.longitude, sub.latitude, sunMoonPosition)
+		const localPen = computeLocalLunarEclipseCircumstances(PENUMBRAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 4 })
 		expect(localPen.events.MAX!.penumbralMagnitude).toBeCloseTo(PENUMBRAL.magnitude, 6)
 		expect(localPen.details.maximalUmbralMagnitude).toBeNull()
-	}, 6000)
+	})
 })
 
 describe('visibility classification', () => {
 	test('observer at the sublunar point sees the whole eclipse above the horizon', () => {
-		const { longitude, latitude } = sublunarAtMax(TOTAL)
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition)
 		expect(local.visibility.hasObservableEclipse).toBe(true)
 		expect(local.events.MAX!.observable).toBe(true)
 		expect(local.events.MAX!.altitude).toBeGreaterThan(0)
@@ -124,72 +131,66 @@ describe('visibility classification', () => {
 		// duration, never exceed it (the previous sample-count formula overcounted by one step).
 		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
 		expect(local.details.observableDuration).toBeGreaterThan(local.details.penumbralPhaseDuration * 0.99)
-	}, 6000)
+	})
 
 	test('observer at the antipode has the Moon below the horizon throughout', () => {
-		const sub = sublunarAtMax(TOTAL)
-		const longitude = sub.longitude > 0 ? sub.longitude - Math.PI : sub.longitude + Math.PI
-		const latitude = -sub.latitude
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE + Math.PI, -FAST_LATITUDE, fastSunMoonPosition)
 		expect(local.visibility.hasObservableEclipse).toBe(false)
 		expect(local.visibility.kind).toBe('geometricOnlyBelowHorizon')
 		expect(local.events.MAX!.observable).toBe(false)
 		expect(local.details.observableDuration).toBe(0)
-	}, 6000)
+	})
 
 	test('hasGeometricEclipse is true regardless of horizon', () => {
-		const sub = sublunarAtMax(TOTAL)
-		const longitude = sub.longitude > 0 ? sub.longitude - Math.PI : sub.longitude + Math.PI
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, -sub.latitude, sunMoonPosition)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE + Math.PI, -FAST_LATITUDE, fastSunMoonPosition)
 		expect(local.visibility.hasGeometricEclipse).toBe(true)
-	}, 6000)
+	})
 
 	// An observer a hair inside the geocentric MAX horizon curve: the geocentric Moon center is above the
 	// horizon, but once diurnal parallax (~0.95 deg) is applied the topocentric center is below it. The old
 	// geocentric conversion marked this location observable; the topocentric one must not.
 	test('observer just inside the geocentric horizon is below the topocentric horizon', () => {
-		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition)
 		const max = geometry.events.find((e) => e.kind === 'MAX')!
 		// On the sublunar meridian (hour angle 0), geocentric altitude = 90 deg - |latitude - declination|; place
-		// the observer 0.3 deg inside the 90 deg horizon. (declination < 0 here keeps the latitude within range.)
+		// the observer 0.3 deg inside the 90 deg horizon.
 		const longitude = max.sublunar.x
 		const latitude = max.declination + (PIOVERTWO - deg(0.3))
 		const H = max.gast + longitude - max.rightAscension
 		const geocentricAltitude = Math.asin(Math.sin(latitude) * Math.sin(max.declination) + Math.cos(latitude) * Math.cos(max.declination) * Math.cos(H))
 		expect(geocentricAltitude).toBeGreaterThan(0)
 
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, fastSunMoonPosition)
 		expect(local.events.MAX!.altitude).toBeLessThan(0)
 		expect(local.events.MAX!.altitude).toBeLessThan(geocentricAltitude)
 		expect(local.events.MAX!.observable).toBe(false)
-	}, 8000)
+	})
 
 	// Replicates one point of the module's exact penumbral sample grid (reference = maximalTime, see scanAltitudes).
-	function gridAltitude(jd: number, longitude: number, latitude: number) {
-		const reference = TOTAL.maximalTime
-		return moonAltitudeAt(timeShift(reference, jd - reference.day - reference.fraction), longitude, latitude, sunMoonPosition)
+	function gridAltitude(jd: number, longitude: number, latitude: number, sunMoonPosition: (time: Time) => SunMoonPosition = fastSunMoonPosition) {
+		return moonAltitudeAt(timeAtJulianDay(TOTAL.maximalTime, jd), longitude, latitude, sunMoonPosition)
 	}
 
 	// A short above-horizon stretch (here the sharp upper-transit peak) can fall between two fixed samples, so a
 	// sample-only check would report it unobservable; the interior search must still catch it.
 	test('Moon above the horizon only between two default samples is still classified observable', () => {
-		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
-		const max = geometry.events.find((e) => e.kind === 'MAX')!
 		// Latitude = declination puts the Moon through the zenith at its transit (a sharp altitude peak);
 		// offsetting the longitude by ~half a sample step moves that peak between two default samples.
-		const latitude = max.declination
-		const longitude = max.sublunar.x + deg(0.94)
+		const latitude = 0
+		const longitude = 0
 
 		const p1jd = toJulianDay(TOTAL.firstContactPenumbraTime)
 		const p4jd = toJulianDay(TOTAL.lastContactPenumbraTime)
 		const samples = 48
 		const step = (p4jd - p1jd) / samples
+		const targetJd = p1jd + 20.5 * step
+		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(timeAtJulianDay(TOTAL.maximalTime, targetJd)))
 
 		// Maximum over the exact default sample grid (what a sample-only check would see), and its location.
 		let coarseMax = -Infinity
 		let imax = 0
 		for (let i = 0; i <= samples; i++) {
-			const altitude = gridAltitude(p1jd + i * step, longitude, latitude)
+			const altitude = gridAltitude(p1jd + i * step, longitude, latitude, sunMoonPosition)
 			if (altitude > coarseMax) {
 				coarseMax = altitude
 				imax = i
@@ -200,7 +201,7 @@ describe('visibility classification', () => {
 		const loZoom = p1jd + Math.max(0, imax - 1) * step
 		const hiZoom = p1jd + Math.min(samples, imax + 1) * step
 		let fineMax = -Infinity
-		for (let i = 0; i <= 40; i++) fineMax = Math.max(fineMax, gridAltitude(loZoom + (i / 40) * (hiZoom - loZoom), longitude, latitude))
+		for (let i = 0; i <= 40; i++) fineMax = Math.max(fineMax, gridAltitude(loZoom + (i / 40) * (hiZoom - loZoom), longitude, latitude, sunMoonPosition))
 
 		// The peak genuinely falls between samples: it exceeds every default sample.
 		expect(fineMax).toBeGreaterThan(coarseMax)
@@ -217,46 +218,41 @@ describe('visibility classification', () => {
 		// two coarse samples is integrated, not dropped to zero.
 		expect(local.details.observableDuration).toBeGreaterThan(0)
 		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
-	}, 15000)
+	})
 
 	// The hard case a discrete monotonic-window test would skip: an upper-transit peak inside the FIRST scan step,
 	// after which the samples descend monotonically. The duration must still integrate the brief stretch.
 	test('a peak in the first step with monotonic neighbours still yields a positive duration', () => {
-		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
-		const p1ev = geometry.events.find((e) => e.kind === 'P1')!
-		const u1ev = geometry.events.find((e) => e.kind === 'U1')!
-
 		const p1jd = toJulianDay(TOTAL.firstContactPenumbraTime)
 		const p4jd = toJulianDay(TOTAL.lastContactPenumbraTime)
 		const samples = 48
 		const step = (p4jd - p1jd) / samples
 
-		// Place the Moon's zenith transit a quarter step after P1: the sublunar longitude there, extrapolated from
-		// the near-P1 linear rate. Latitude = declination makes that transit a sharp ~90 deg peak.
-		const wrap = (x: number) => ((((x + Math.PI) % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)) - Math.PI
-		const sublunarRate = wrap(u1ev.sublunar.x - p1ev.sublunar.x) / (u1ev.jd - p1ev.jd)
+		// Place the Moon's zenith transit a quarter step after P1. Latitude = declination makes that transit a
+		// sharp ~90 deg peak while the coarse grid samples descend monotonically after P1.
 		const targetJd = p1jd + 0.25 * step
-		const longitude = p1ev.sublunar.x + sublunarRate * (targetJd - p1jd)
-		const latitude = p1ev.declination
+		const longitude = 0
+		const latitude = 0
+		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(timeAtJulianDay(TOTAL.maximalTime, targetJd)))
 
 		// On the coarse default grid P1 is the highest sample and the grid descends monotonically afterwards: the
 		// window the discrete monotonic test would (wrongly) skip.
 		let coarseMax = -Infinity
 		let imax = 0
 		for (let i = 0; i <= samples; i++) {
-			const altitude = gridAltitude(p1jd + i * step, longitude, latitude)
+			const altitude = gridAltitude(p1jd + i * step, longitude, latitude, sunMoonPosition)
 			if (altitude > coarseMax) {
 				coarseMax = altitude
 				imax = i
 			}
 		}
 		expect(imax).toBe(0)
-		expect(gridAltitude(p1jd, longitude, latitude)).toBeGreaterThan(gridAltitude(p1jd + step, longitude, latitude))
-		expect(gridAltitude(p1jd + step, longitude, latitude)).toBeGreaterThan(gridAltitude(p1jd + 2 * step, longitude, latitude))
+		expect(gridAltitude(p1jd, longitude, latitude, sunMoonPosition)).toBeGreaterThan(gridAltitude(p1jd + step, longitude, latitude, sunMoonPosition))
+		expect(gridAltitude(p1jd + step, longitude, latitude, sunMoonPosition)).toBeGreaterThan(gridAltitude(p1jd + 2 * step, longitude, latitude, sunMoonPosition))
 
 		// The true peak in the first step exceeds every coarse sample.
 		let fineMax = -Infinity
-		for (let i = 0; i <= 40; i++) fineMax = Math.max(fineMax, gridAltitude(p1jd + (i / 40) * step, longitude, latitude))
+		for (let i = 0; i <= 40; i++) fineMax = Math.max(fineMax, gridAltitude(p1jd + (i / 40) * step, longitude, latitude, sunMoonPosition))
 		expect(fineMax).toBeGreaterThan(coarseMax)
 
 		const horizonAltitude = (coarseMax + fineMax) / 2
@@ -264,7 +260,7 @@ describe('visibility classification', () => {
 		expect(local.visibility.hasObservableEclipse).toBe(true)
 		expect(local.details.observableDuration).toBeGreaterThan(0)
 		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
-	}, 15000)
+	})
 
 	// A high-latitude grazing moonrise/moonset whose entire above-horizon window is far shorter than scan.step / 16.
 	// With a coarse scan (2 samples, one ~2.5 h step), a fixed 16-piece subdivision of the suspect step would find
@@ -273,31 +269,38 @@ describe('visibility classification', () => {
 	// horizon roots around it recovers the brief duration, keeping observableDuration consistent with observability.
 	test('a grazing window shorter than a refinement sub-step still yields a positive duration', () => {
 		const samples = 2
-		const longitude = deg(-180)
-		const latitude = deg(79)
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: samples })
+		const longitude = 0
+		const latitude = 0
+		const p1jd = toJulianDay(TOTAL.firstContactPenumbraTime)
+		const p4jd = toJulianDay(TOTAL.lastContactPenumbraTime)
+		const step = (p4jd - p1jd) / samples
+		const targetJd = p1jd + 0.5 * step
+		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(timeAtJulianDay(TOTAL.maximalTime, targetJd)))
+		const fineMax = gridAltitude(targetJd, longitude, latitude, sunMoonPosition)
+		const horizonAltitude = fineMax - deg(0.5)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: samples, horizonAltitude })
 
 		const subStepSeconds = local.details.penumbralPhaseDuration / samples / 16
 		expect(local.visibility.hasObservableEclipse).toBe(true)
 		// The window is real but shorter than one refinement sub-step, so a both-below sub-step integration misses it.
 		expect(local.details.observableDuration).toBeGreaterThan(0)
 		expect(local.details.observableDuration).toBeLessThan(subStepSeconds)
-	}, 6000)
+	})
 
 	// Every contact can be above the horizon while the Moon still dips below it between contacts (a high-latitude
 	// lower culmination during the multi-hour penumbral interval). 'completelyVisible' must check the whole
 	// interval, not just the contact samples.
 	test('contacts above the horizon with a dip below between them is not completelyVisible', () => {
-		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
-		const max = geometry.events.find((e) => e.kind === 'MAX')!
-		// High southern latitude keeps the full Moon up but low; the longitude places its lower culmination
+		// High latitude keeps the full Moon up but low; the fixed right ascension places its lower culmination
 		// roughly midway between U1 and U2, so the altitude dips to an interior minimum between contacts.
-		const latitude = -deg(70)
-		const longitude = max.sublunar.x + Math.PI + deg(16.2)
+		const latitude = deg(70)
+		const declination = deg(30)
+		const longitude = 0
+		const targetJd = (toJulianDay(TOTAL.firstContactUmbraTime) + toJulianDay(TOTAL.totalBeginTime)) * 0.5
+		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(timeAtJulianDay(TOTAL.maximalTime, targetJd)) + longitude - Math.PI, declination)
 
 		function altAt(jd: number) {
-			const reference = TOTAL.maximalTime
-			return moonAltitudeAt(timeShift(reference, jd - reference.day - reference.fraction), longitude, latitude, sunMoonPosition)
+			return gridAltitude(jd, longitude, latitude, sunMoonPosition)
 		}
 
 		// Topocentric contact altitudes (P1, U1, U2, MAX, U3, U4, P4).
@@ -321,12 +324,11 @@ describe('visibility classification', () => {
 		// ...but the Moon drops below the horizon between contacts, so the eclipse is not entirely visible.
 		expect(local.visibility.kind).not.toBe('completelyVisible')
 		expect(local.visibility.hasObservableEclipse).toBe(true)
-	}, 15000)
+	})
 })
 
 describe('P/Z orientation angles and Alt/Az', () => {
-	const { longitude, latitude } = sublunarAtMax(TOTAL)
-	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+	const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 4 })
 
 	test('every event angle is finite and normalized to [0, TAU)', () => {
 		for (const kind of Object.keys(local.events) as (keyof typeof local.events)[]) {
@@ -347,15 +349,14 @@ describe('P/Z orientation angles and Alt/Az', () => {
 	})
 
 	test('partial eclipse has no total phase duration', () => {
-		const sub = sublunarAtMax(PARTIAL)
-		const localPartial = computeLocalLunarEclipseCircumstances(PARTIAL, sub.longitude, sub.latitude, sunMoonPosition)
+		const localPartial = computeLocalLunarEclipseCircumstances(PARTIAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 4 })
 		expect(localPartial.details.totalPhaseDuration).toBeNull()
 		expect(localPartial.details.partialPhaseDuration).toBeGreaterThan(0)
-	}, 6000)
+	})
 
 	// Position angle of the Earth-shadow center on the lunar disk at a given instant (geocentric, antisolar).
 	function shadowCenterPositionAngle(time: Time) {
-		const position = sunMoonPosition(time)
+		const position = fastSunMoonPosition(time)
 		const moonRA = position.moon.rightAscension
 		const moonDEC = position.moon.declination
 		// Mirror positionAngleBetween(moon, antisolar) with shadowDEC = -sunDEC: y = cos(dec2) sin(dRA),
@@ -382,8 +383,7 @@ describe('P/Z orientation angles and Alt/Az', () => {
 })
 
 describe('Local View geometry', () => {
-	const { longitude, latitude } = sublunarAtMax(TOTAL)
-	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+	const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 4 })
 	const view = computeLocalLunarEclipseViewGeometry(local, TOTAL, { selectedEvent: 'MAX' })
 
 	function circles(role: LocalLunarEclipseSvgCircle['role']) {
@@ -421,23 +421,22 @@ describe('Local View geometry', () => {
 	})
 
 	test('falls back to MAX when the requested contact is absent', () => {
-		const sub = sublunarAtMax(PENUMBRAL)
-		const localPen = computeLocalLunarEclipseCircumstances(PENUMBRAL, sub.longitude, sub.latitude, sunMoonPosition)
+		const localPen = computeLocalLunarEclipseCircumstances(PENUMBRAL, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition, { altitudeSamples: 4 })
 		const penView = computeLocalLunarEclipseViewGeometry(localPen, PENUMBRAL, { selectedEvent: 'U2' })
 		expect(penView.requestedEvent).toBe('U2')
 		expect(penView.selectedEvent).toBe('MAX')
-	}, 6000)
+	})
 
 	// With an obstructed horizon the view horizon must track horizonAltitude, not true altitude 0: a Moon above
 	// the true horizon but below the configured one is not observable and must be drawn below the band.
 	test('selected event below a custom horizon is drawn below the band', () => {
-		const max = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition).events.find((e) => e.kind === 'MAX')!
-		// High latitude so the Moon transits low at MAX: a few degrees up, between 0 and a 10 deg obstructed horizon.
-		const longitude = max.sublunar.x
-		const latitude = max.declination + deg(83)
+		// Fixed right ascension puts MAX a few degrees up, between 0 and a 10 deg obstructed horizon.
+		const longitude = 0
+		const latitude = 0
 		const customHorizon = deg(10)
+		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(TOTAL.maximalTime) + longitude - deg(85))
 
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { horizonAltitude: customHorizon })
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 4, horizonAltitude: customHorizon })
 		const maxEvent = local.events.MAX!
 		// Above the true horizon but below the obstructed one, hence not observable.
 		expect(maxEvent.altitude).toBeGreaterThan(0)
@@ -455,15 +454,16 @@ describe('Local View geometry', () => {
 		expect(primaryInsideBand(0)).toBe(false)
 		// Drawn against the configured 10 deg horizon the Moon is below it: inside the band, matching observable=false.
 		expect(primaryInsideBand(customHorizon)).toBe(true)
-	}, 7000)
+	})
 
 	// A non-MAX selected contact whose disk is offset from the shadow center: the horizon must be anchored at the
-	// disk, not the shadow center, so the band agrees with the contact's observable flag. The 1997-09-16 total
-	// eclipse P1 at ~142 W, 80 S has a slightly negative topocentric altitude (not observable).
+	// disk, not the shadow center, so the band agrees with the contact's observable flag. The synthetic P1 altitude
+	// is slightly negative (not observable).
 	test('a non-MAX contact just below the horizon is drawn inside the band', () => {
-		const longitude = deg(-142)
-		const latitude = deg(-80)
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 12 })
+		const longitude = 0
+		const latitude = 0
+		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(TOTAL.firstContactPenumbraTime) + longitude - deg(90.5))
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 4 })
 		expect(local.events.P1!.altitude).toBeLessThan(0)
 		expect(local.events.P1!.observable).toBe(false)
 
@@ -473,5 +473,5 @@ describe('Local View geometry', () => {
 		const moon = view.shapes.find((s): s is LocalLunarEclipseSvgCircle => s.kind === 'circle' && s.role === 'moonDisk')!
 		// The below-horizon disk lands inside the below-horizon band, consistent with observable === false.
 		expect(pointInPolygon(moon.cx, moon.cy, band.points)).toBe(true)
-	}, 6000)
+	})
 })

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import { deg } from '../src/angle'
-import { PIOVERTWO, TAU } from '../src/constants'
+import { PI, PIOVERTWO, TAU } from '../src/constants'
+import type { SunMoonPosition } from '../src/eclipse'
 import { nearestLunarEclipse } from '../src/moon'
 import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, moonAltitudeAt, type LocalLunarEclipseSvgCircle, type LocalLunarEclipseSvgPolygon } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry } from '../src/moon.eclipse.map'
-import type { SunMoonPosition } from '../src/sun.eclipse.map'
 import { toJulianDay, type Time, timeYMDHMS, greenwichApparentSiderealTime, timeAtJulianDay } from '../src/time'
+import { fixedSunMoonPosition } from './eclipse.util'
 
 const FAST_LONGITUDE = deg(5)
 const FAST_LATITUDE = 0
@@ -17,18 +18,10 @@ function fastSunMoonPosition(time: Time) {
 	const gast = greenwichApparentSiderealTime(time)
 
 	return {
-		sun: { rightAscension: gast - Math.PI + deg(0.1), declination: 0, distance: 1 },
+		sun: { rightAscension: gast - PI + deg(0.1), declination: 0, distance: 1 },
 		moon: { rightAscension: gast, declination: 0, distance: 60 },
 		deltaT: 0,
 	}
-}
-
-function fixedSunMoonPosition(rightAscension: number, declination: number = 0) {
-	return (time: Time): SunMoonPosition => ({
-		sun: { rightAscension: rightAscension - Math.PI + deg(0.1), declination: 0, distance: 1 },
-		moon: { rightAscension, declination, distance: 60 },
-		deltaT: 0,
-	})
 }
 
 const PENUMBRAL = nearestLunarEclipse(timeYMDHMS(1973, 6, 1), true)
@@ -134,7 +127,7 @@ describe('visibility classification', () => {
 	})
 
 	test('observer at the antipode has the Moon below the horizon throughout', () => {
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE + Math.PI, -FAST_LATITUDE, fastSunMoonPosition)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE + PI, -FAST_LATITUDE, fastSunMoonPosition)
 		expect(local.visibility.hasObservableEclipse).toBe(false)
 		expect(local.visibility.kind).toBe('geometricOnlyBelowHorizon')
 		expect(local.events.MAX!.observable).toBe(false)
@@ -142,7 +135,7 @@ describe('visibility classification', () => {
 	})
 
 	test('hasGeometricEclipse is true regardless of horizon', () => {
-		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE + Math.PI, -FAST_LATITUDE, fastSunMoonPosition)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, FAST_LONGITUDE + PI, -FAST_LATITUDE, fastSunMoonPosition)
 		expect(local.visibility.hasGeometricEclipse).toBe(true)
 	})
 
@@ -297,7 +290,7 @@ describe('visibility classification', () => {
 		const declination = deg(30)
 		const longitude = 0
 		const targetJd = (toJulianDay(TOTAL.firstContactUmbraTime) + toJulianDay(TOTAL.totalBeginTime)) * 0.5
-		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(timeAtJulianDay(TOTAL.maximalTime, targetJd)) + longitude - Math.PI, declination)
+		const sunMoonPosition = fixedSunMoonPosition(greenwichApparentSiderealTime(timeAtJulianDay(TOTAL.maximalTime, targetJd)) + longitude - PI, declination)
 
 		function altAt(jd: number) {
 			return gridAltitude(jd, longitude, latitude, sunMoonPosition)
@@ -361,7 +354,7 @@ describe('P/Z orientation angles and Alt/Az', () => {
 		const moonDEC = position.moon.declination
 		// Mirror positionAngleBetween(moon, antisolar) with shadowDEC = -sunDEC: y = cos(dec2) sin(dRA),
 		// x = cos(dec1) sin(dec2) - sin(dec1) cos(dec2) cos(dRA).
-		const dRA = position.sun.rightAscension + Math.PI - moonRA
+		const dRA = position.sun.rightAscension + PI - moonRA
 		const y = Math.cos(position.sun.declination) * Math.sin(dRA)
 		const x = -Math.cos(moonDEC) * Math.sin(position.sun.declination) - Math.sin(moonDEC) * Math.cos(position.sun.declination) * Math.cos(dRA)
 		return Math.atan2(y, x)
@@ -377,8 +370,8 @@ describe('P/Z orientation angles and Alt/Az', () => {
 	// reported P angle must be opposite the shadow-center direction; the external U1 contact must equal it.
 	test('total-eclipse U2/U3 contact point is opposite the shadow-center direction', () => {
 		expect(angleSeparation(local.events.U1!.positionAngle, shadowCenterPositionAngle(TOTAL.firstContactUmbraTime))).toBeLessThan(1e-9)
-		expect(angleSeparation(local.events.U2!.positionAngle, shadowCenterPositionAngle(TOTAL.totalBeginTime) + Math.PI)).toBeLessThan(1e-9)
-		expect(angleSeparation(local.events.U3!.positionAngle, shadowCenterPositionAngle(TOTAL.totalEndTime) + Math.PI)).toBeLessThan(1e-9)
+		expect(angleSeparation(local.events.U2!.positionAngle, shadowCenterPositionAngle(TOTAL.totalBeginTime) + PI)).toBeLessThan(1e-9)
+		expect(angleSeparation(local.events.U3!.positionAngle, shadowCenterPositionAngle(TOTAL.totalEndTime) + PI)).toBeLessThan(1e-9)
 	})
 })
 

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -3,7 +3,7 @@ import { deg } from '../src/angle'
 import { PI, PIOVERTWO, TAU } from '../src/constants'
 import type { SunMoonPosition } from '../src/eclipse'
 import { nearestLunarEclipse } from '../src/moon'
-import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, moonAltitudeAt, type LocalLunarEclipseSvgCircle, type LocalLunarEclipseSvgPolygon } from '../src/moon.eclipse.local'
+import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, listLocalLunarEclipses, moonAltitudeAt, type LocalLunarEclipseSvgCircle, type LocalLunarEclipseSvgPolygon } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry } from '../src/moon.eclipse.map'
 import { toJulianDay, type Time, timeYMDHMS, greenwichApparentSiderealTime, timeAtJulianDay } from '../src/time'
 import { fixedSunMoonPosition } from './eclipse.util'
@@ -317,6 +317,45 @@ describe('visibility classification', () => {
 		// ...but the Moon drops below the horizon between contacts, so the eclipse is not entirely visible.
 		expect(local.visibility.kind).not.toBe('completelyVisible')
 		expect(local.visibility.hasObservableEclipse).toBe(true)
+	})
+})
+
+describe('listLocalLunarEclipses', () => {
+	// In the fast provider the Moon's hour angle equals the observer longitude (constant in time), so at
+	// FAST_LONGITUDE (latitude 0) it stays high - every eclipse observable - and at the antimeridian it stays
+	// below the horizon - none observable. Contact times still come from the real Meeus series.
+	const start = timeYMDHMS(1997, 1, 1)
+	const end = timeYMDHMS(2000, 1, 1)
+	const startJd = toJulianDay(start)
+	const endJd = toJulianDay(end)
+	const antiLongitude = FAST_LONGITUDE + PI
+
+	test('lists every eclipse in (start, end] observable from the location, earliest-first', () => {
+		const list = listLocalLunarEclipses(FAST_LONGITUDE, FAST_LATITUDE, start, end, fastSunMoonPosition)
+		expect(list.length).toBeGreaterThan(0)
+
+		for (let i = 0; i < list.length; i++) {
+			const jd = toJulianDay(list[i].eclipse.maximalTime)
+			expect(jd).toBeGreaterThan(startJd)
+			expect(jd).toBeLessThanOrEqual(endJd)
+			expect(list[i].circumstances.visibility.hasObservableEclipse).toBe(true)
+			if (i > 0) expect(jd).toBeGreaterThan(toJulianDay(list[i - 1].eclipse.maximalTime))
+		}
+	})
+
+	test('omits eclipses with the Moon below the horizon throughout', () => {
+		expect(listLocalLunarEclipses(antiLongitude, FAST_LATITUDE, start, end, fastSunMoonPosition)).toEqual([])
+	})
+
+	test('an inverted interval returns no eclipses', () => {
+		expect(listLocalLunarEclipses(FAST_LONGITUDE, FAST_LATITUDE, end, start, fastSunMoonPosition)).toEqual([])
+	})
+
+	test('returns the same circumstances a direct call would compute', () => {
+		const first = listLocalLunarEclipses(FAST_LONGITUDE, FAST_LATITUDE, start, end, fastSunMoonPosition)[0]
+		const direct = computeLocalLunarEclipseCircumstances(first.eclipse, FAST_LONGITUDE, FAST_LATITUDE, fastSunMoonPosition)
+		expect(first.circumstances.visibility.kind).toBe(direct.visibility.kind)
+		expect(first.circumstances.details.observableDuration).toBeCloseTo(direct.details.observableDuration, 6)
 	})
 })
 

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -184,6 +184,53 @@ describe('visibility classification', () => {
 		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
 	}, 15000)
 
+	// The hard case a discrete monotonic-window test would skip: an upper-transit peak inside the FIRST scan step,
+	// after which the samples descend monotonically. The duration must still integrate the brief stretch.
+	test('a peak in the first step with monotonic neighbours still yields a positive duration', () => {
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+		const p1ev = geometry.events.find((e) => e.kind === 'P1')!
+		const u1ev = geometry.events.find((e) => e.kind === 'U1')!
+
+		const p1jd = toJulianDay(TOTAL.firstContactPenumbraTime)
+		const p4jd = toJulianDay(TOTAL.lastContactPenumbraTime)
+		const samples = 48
+		const step = (p4jd - p1jd) / samples
+
+		// Place the Moon's zenith transit a quarter step after P1: the sublunar longitude there, extrapolated from
+		// the near-P1 linear rate. Latitude = declination makes that transit a sharp ~90 deg peak.
+		const wrap = (x: number) => ((((x + Math.PI) % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)) - Math.PI
+		const sublunarRate = wrap(u1ev.sublunar.x - p1ev.sublunar.x) / (u1ev.jd - p1ev.jd)
+		const targetJd = p1jd + 0.25 * step
+		const longitude = p1ev.sublunar.x + sublunarRate * (targetJd - p1jd)
+		const latitude = p1ev.declination
+
+		// On the coarse default grid P1 is the highest sample and the grid descends monotonically afterwards: the
+		// window the discrete monotonic test would (wrongly) skip.
+		let coarseMax = -Infinity
+		let imax = 0
+		for (let i = 0; i <= samples; i++) {
+			const altitude = gridAltitude(p1jd + i * step, longitude, latitude)
+			if (altitude > coarseMax) {
+				coarseMax = altitude
+				imax = i
+			}
+		}
+		expect(imax).toBe(0)
+		expect(gridAltitude(p1jd, longitude, latitude)).toBeGreaterThan(gridAltitude(p1jd + step, longitude, latitude))
+		expect(gridAltitude(p1jd + step, longitude, latitude)).toBeGreaterThan(gridAltitude(p1jd + 2 * step, longitude, latitude))
+
+		// The true peak in the first step exceeds every coarse sample.
+		let fineMax = -Infinity
+		for (let i = 0; i <= 40; i++) fineMax = Math.max(fineMax, gridAltitude(p1jd + (i / 40) * step, longitude, latitude))
+		expect(fineMax).toBeGreaterThan(coarseMax)
+
+		const horizonAltitude = (coarseMax + fineMax) / 2
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { horizonAltitude })
+		expect(local.visibility.hasObservableEclipse).toBe(true)
+		expect(local.details.observableDuration).toBeGreaterThan(0)
+		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
+	}, 15000)
+
 	// Every contact can be above the horizon while the Moon still dips below it between contacts (a high-latitude
 	// lower culmination during the multi-hour penumbral interval). 'completelyVisible' must check the whole
 	// interval, not just the contact samples.

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -154,6 +154,45 @@ describe('visibility classification', () => {
 		expect(local.visibility.hasObservableEclipse).toBe(true)
 		expect(local.visibility.kind).not.toBe('geometricOnlyBelowHorizon')
 	}, 15000)
+
+	// Every contact can be above the horizon while the Moon still dips below it between contacts (a high-latitude
+	// lower culmination during the multi-hour penumbral interval). 'completelyVisible' must check the whole
+	// interval, not just the contact samples.
+	test('contacts above the horizon with a dip below between them is not completelyVisible', () => {
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		// High southern latitude keeps the full Moon up but low; the longitude places its lower culmination
+		// roughly midway between U1 and U2, so the altitude dips to an interior minimum between contacts.
+		const latitude = -deg(70)
+		const longitude = max.sublunar.x + Math.PI + deg(16.2)
+
+		function altAt(jd: number) {
+			const reference = TOTAL.maximalTime
+			return moonAltitudeAt(timeShift(reference, jd - reference.day - reference.fraction), longitude, latitude, sunMoonPosition)
+		}
+
+		// Topocentric contact altitudes (P1, U1, U2, MAX, U3, U4, P4).
+		const contactTimes = [TOTAL.firstContactPenumbraTime, TOTAL.firstContactUmbraTime, TOTAL.totalBeginTime, TOTAL.maximalTime, TOTAL.totalEndTime, TOTAL.lastContactUmbraTime, TOTAL.lastContactPenumbraTime]
+		const contactAltitudes = contactTimes.map((t) => altAt(toJulianDay(t)))
+		const minContact = Math.min(...contactAltitudes)
+
+		// Interior minimum over (P1, P4): the lower culmination, sampled finely between the contacts.
+		const p1jd = toJulianDay(TOTAL.firstContactPenumbraTime)
+		const p4jd = toJulianDay(TOTAL.lastContactPenumbraTime)
+		let interiorMin = Infinity
+		for (let i = 1; i < 200; i++) interiorMin = Math.min(interiorMin, altAt(p1jd + (i / 200) * (p4jd - p1jd)))
+
+		// The dip is strictly below the lowest contact: an interior below-horizon stretch with every contact above.
+		expect(interiorMin).toBeLessThan(minContact)
+		const horizonAltitude = interiorMin + 0.3 * (minContact - interiorMin)
+
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { horizonAltitude })
+		// Every contact is above the configured horizon, so a contacts-only test would report completelyVisible...
+		for (const event of Object.values(local.events)) expect(event.altitude).toBeGreaterThanOrEqual(horizonAltitude)
+		// ...but the Moon drops below the horizon between contacts, so the eclipse is not entirely visible.
+		expect(local.visibility.kind).not.toBe('completelyVisible')
+		expect(local.visibility.hasObservableEclipse).toBe(true)
+	}, 15000)
 })
 
 describe('P/Z orientation angles and Alt/Az', () => {

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -133,6 +133,33 @@ describe('P/Z orientation angles and Alt/Az', () => {
 		expect(localPartial.details.totalPhaseDuration).toBeNull()
 		expect(localPartial.details.partialPhaseDuration).toBeGreaterThan(0)
 	}, 6000)
+
+	// Position angle of the Earth-shadow center on the lunar disk at a given instant (geocentric, antisolar).
+	function shadowCenterPositionAngle(time: Time) {
+		const position = sunMoonPosition(time)
+		const moonRA = position.moon.rightAscension
+		const moonDEC = position.moon.declination
+		// Mirror positionAngleBetween(moon, antisolar) with shadowDEC = -sunDEC: y = cos(dec2) sin(dRA),
+		// x = cos(dec1) sin(dec2) - sin(dec1) cos(dec2) cos(dRA).
+		const dRA = position.sun.rightAscension + Math.PI - moonRA
+		const y = Math.cos(position.sun.declination) * Math.sin(dRA)
+		const x = -Math.cos(moonDEC) * Math.sin(position.sun.declination) - Math.sin(moonDEC) * Math.cos(position.sun.declination) * Math.cos(dRA)
+		return Math.atan2(y, x)
+	}
+
+	// Smallest absolute angular separation (radians) between two angles, accounting for wrap.
+	function angleSeparation(a: number, b: number) {
+		const d = Math.abs(((a - b) % TAU) + TAU) % TAU
+		return Math.min(d, TAU - d)
+	}
+
+	// The U2/U3 internal tangency of a total eclipse contacts the umbra on the far side of the disk, so the
+	// reported P angle must be opposite the shadow-center direction; the external U1 contact must equal it.
+	test('total-eclipse U2/U3 contact point is opposite the shadow-center direction', () => {
+		expect(angleSeparation(local.events.U1!.positionAngle, shadowCenterPositionAngle(TOTAL.firstContactUmbraTime))).toBeLessThan(1e-9)
+		expect(angleSeparation(local.events.U2!.positionAngle, shadowCenterPositionAngle(TOTAL.totalBeginTime) + Math.PI)).toBeLessThan(1e-9)
+		expect(angleSeparation(local.events.U3!.positionAngle, shadowCenterPositionAngle(TOTAL.totalEndTime) + Math.PI)).toBeLessThan(1e-9)
+	})
 })
 
 describe('Local View geometry', () => {

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -166,6 +166,10 @@ describe('visibility classification', () => {
 		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { horizonAltitude })
 		expect(local.visibility.hasObservableEclipse).toBe(true)
 		expect(local.visibility.kind).not.toBe('geometricOnlyBelowHorizon')
+		// The observable duration must agree with the classification: the brief above-horizon stretch between the
+		// two coarse samples is integrated, not dropped to zero.
+		expect(local.details.observableDuration).toBeGreaterThan(0)
+		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
 	}, 15000)
 
 	// Every contact can be above the horizon while the Moon still dips below it between contacts (a high-latitude

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -60,6 +60,10 @@ describe('visibility classification', () => {
 		expect(local.events.MAX!.observable).toBe(true)
 		expect(local.events.MAX!.altitude).toBeGreaterThan(0)
 		expect(local.visibility.kind).toBe('completelyVisible')
+		// The whole eclipse is above the horizon here, so the observable time must equal the penumbral phase
+		// duration, never exceed it (the previous sample-count formula overcounted by one step).
+		expect(local.details.observableDuration).toBeLessThanOrEqual(local.details.penumbralPhaseDuration + 1e-6)
+		expect(local.details.observableDuration).toBeGreaterThan(local.details.penumbralPhaseDuration * 0.99)
 	}, 6000)
 
 	test('observer at the antipode has the Moon below the horizon throughout', () => {

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -424,4 +424,22 @@ describe('Local View geometry', () => {
 		// Drawn against the configured 10 deg horizon the Moon is below it: inside the band, matching observable=false.
 		expect(primaryInsideBand(customHorizon)).toBe(true)
 	}, 7000)
+
+	// A non-MAX selected contact whose disk is offset from the shadow center: the horizon must be anchored at the
+	// disk, not the shadow center, so the band agrees with the contact's observable flag. The 1997-09-16 total
+	// eclipse P1 at ~142 W, 80 S has a slightly negative topocentric altitude (not observable).
+	test('a non-MAX contact just below the horizon is drawn inside the band', () => {
+		const longitude = deg(-142)
+		const latitude = deg(-80)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 12 })
+		expect(local.events.P1!.altitude).toBeLessThan(0)
+		expect(local.events.P1!.observable).toBe(false)
+
+		const view = computeLocalLunarEclipseViewGeometry(local, TOTAL, { selectedEvent: 'P1' })
+		expect(view.selectedEvent).toBe('P1')
+		const band = view.shapes.find((s): s is LocalLunarEclipseSvgPolygon => s.kind === 'polygon' && s.role === 'horizonBand')!
+		const moon = view.shapes.find((s): s is LocalLunarEclipseSvgCircle => s.kind === 'circle' && s.role === 'moonDisk')!
+		// The below-horizon disk lands inside the below-horizon band, consistent with observable === false.
+		expect(pointInPolygon(moon.cx, moon.cy, band.points)).toBe(true)
+	}, 6000)
 })

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -70,6 +70,20 @@ describe('altitudeSamples normalization', () => {
 	}, 8000)
 })
 
+describe('horizonAltitude normalization', () => {
+	const { longitude, latitude } = sublunarAtMax(TOTAL)
+
+	test('non-finite horizonAltitude falls back to the geometric horizon', () => {
+		const reference = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 12 })
+		for (const bad of [Number.POSITIVE_INFINITY, Number.NaN]) {
+			const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 12, horizonAltitude: bad })
+			expect(local.visibility.kind).toBe(reference.visibility.kind)
+			expect(local.details.observableDuration).toBeCloseTo(reference.details.observableDuration, 6)
+			expect(local.events.MAX!.observable).toBe(reference.events.MAX!.observable)
+		}
+	}, 8000)
+})
+
 describe('per-contact magnitudes', () => {
 	const { longitude, latitude } = sublunarAtMax(TOTAL)
 	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -3,7 +3,7 @@ import { deg } from '../src/angle'
 import { PIOVERTWO, TAU } from '../src/constants'
 import * as elpmpp02 from '../src/elpmpp02'
 import { nearestLunarEclipse, type LunarEclipse } from '../src/moon'
-import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, moonAltitudeAt, type LocalLunarEclipseSvgCircle } from '../src/moon.eclipse.local'
+import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, moonAltitudeAt, type LocalLunarEclipseSvgCircle, type LocalLunarEclipseSvgPolygon } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry } from '../src/moon.eclipse.map'
 import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
 import { timeShift, toJulianDay, type Time, timeYMDHMS } from '../src/time'
@@ -22,6 +22,19 @@ function sublunarAtMax(eclipse: LunarEclipse) {
 	const geometry = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition)
 	const max = geometry.events.find((e) => e.kind === 'MAX')!
 	return { longitude: max.sublunar.x, latitude: max.sublunar.y }
+}
+
+// Ray-casting point-in-polygon test.
+function pointInPolygon(px: number, py: number, polygon: readonly { readonly x: number; readonly y: number }[]) {
+	let inside = false
+	for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+		const xi = polygon[i].x
+		const yi = polygon[i].y
+		const xj = polygon[j].x
+		const yj = polygon[j].y
+		if (yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) inside = !inside
+	}
+	return inside
 }
 
 describe('per-contact magnitudes', () => {
@@ -298,4 +311,33 @@ describe('Local View geometry', () => {
 		expect(penView.requestedEvent).toBe('U2')
 		expect(penView.selectedEvent).toBe('MAX')
 	}, 6000)
+
+	// With an obstructed horizon the view horizon must track horizonAltitude, not true altitude 0: a Moon above
+	// the true horizon but below the configured one is not observable and must be drawn below the band.
+	test('selected event below a custom horizon is drawn below the band', () => {
+		const max = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition).events.find((e) => e.kind === 'MAX')!
+		// High latitude so the Moon transits low at MAX: a few degrees up, between 0 and a 10 deg obstructed horizon.
+		const longitude = max.sublunar.x
+		const latitude = max.declination + deg(83)
+		const customHorizon = deg(10)
+
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { horizonAltitude: customHorizon })
+		const maxEvent = local.events.MAX!
+		// Above the true horizon but below the obstructed one, hence not observable.
+		expect(maxEvent.altitude).toBeGreaterThan(0)
+		expect(maxEvent.altitude).toBeLessThan(customHorizon)
+		expect(maxEvent.observable).toBe(false)
+
+		function primaryInsideBand(horizonAltitude: number) {
+			const view = computeLocalLunarEclipseViewGeometry(local, TOTAL, { selectedEvent: 'MAX', horizonAltitude })
+			const band = view.shapes.find((s): s is LocalLunarEclipseSvgPolygon => s.kind === 'polygon' && s.role === 'horizonBand')!
+			const moon = view.shapes.find((s): s is LocalLunarEclipseSvgCircle => s.kind === 'circle' && s.role === 'moonDisk')!
+			return pointInPolygon(moon.cx, moon.cy, band.points)
+		}
+
+		// Drawn against the true horizon (0 deg) the Moon is above it: outside the below-horizon band.
+		expect(primaryInsideBand(0)).toBe(false)
+		// Drawn against the configured 10 deg horizon the Moon is below it: inside the band, matching observable=false.
+		expect(primaryInsideBand(customHorizon)).toBe(true)
+	}, 10000)
 })

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -49,6 +49,27 @@ describe('ancient dates', () => {
 	}, 6000)
 })
 
+describe('altitudeSamples normalization', () => {
+	// The sublunar point at MAX sees the whole eclipse above the horizon, so observableDuration equals the full
+	// penumbral phase only when the scan reaches P4. A fractional sample count must not make it stop short, and a
+	// non-finite count must neither hang (Infinity) nor skip the scan (NaN); all normalize to the default 48.
+	const { longitude, latitude } = sublunarAtMax(TOTAL)
+	const reference = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition).details.observableDuration
+
+	test('fractional altitudeSamples is floored and still reaches P4', () => {
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: 48.5 })
+		expect(local.details.observableDuration).toBeCloseTo(reference, 6)
+		expect(local.details.observableDuration).toBeGreaterThan(local.details.penumbralPhaseDuration * 0.99)
+	}, 6000)
+
+	test('non-finite altitudeSamples falls back to the default without hanging', () => {
+		for (const bad of [Number.POSITIVE_INFINITY, Number.NaN]) {
+			const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition, { altitudeSamples: bad })
+			expect(local.details.observableDuration).toBeCloseTo(reference, 6)
+		}
+	}, 8000)
+})
+
 describe('per-contact magnitudes', () => {
 	const { longitude, latitude } = sublunarAtMax(TOTAL)
 	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test'
+import { TAU } from '../src/constants'
+import * as elpmpp02 from '../src/elpmpp02'
+import { nearestLunarEclipse, type LunarEclipse } from '../src/moon'
+import { computeLocalLunarEclipseCircumstances, computeLocalLunarEclipseViewGeometry, type LocalLunarEclipseSvgCircle } from '../src/moon.eclipse.local'
+import { computeLunarEclipseMapGeometry } from '../src/moon.eclipse.map'
+import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
+import { type Time, timeYMDHMS } from '../src/time'
+import * as vsop87e from '../src/vsop87e'
+
+function sunMoonPosition(t: Time) {
+	return computeSunMoonPositionAt(t, vsop87e.sun, vsop87e.earth, elpmpp02.moon)
+}
+
+const PENUMBRAL = nearestLunarEclipse(timeYMDHMS(1973, 6, 1), true)
+const TOTAL = nearestLunarEclipse(timeYMDHMS(1997, 7, 1), true)
+const PARTIAL = nearestLunarEclipse(timeYMDHMS(1994, 5, 25), true)
+
+// Sublunar point (longitude, latitude) at maximal eclipse, where the Moon is at the zenith.
+function sublunarAtMax(eclipse: LunarEclipse) {
+	const geometry = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition)
+	const max = geometry.events.find((e) => e.kind === 'MAX')!
+	return { longitude: max.sublunar.x, latitude: max.sublunar.y }
+}
+
+describe('per-contact magnitudes', () => {
+	const { longitude, latitude } = sublunarAtMax(TOTAL)
+	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+
+	test('umbral magnitude is 0 at U1/U4 and 1 at U2/U3', () => {
+		expect(local.events.U1!.umbralMagnitude).toBeCloseTo(0, 6)
+		expect(local.events.U4!.umbralMagnitude).toBeCloseTo(0, 6)
+		expect(local.events.U2!.umbralMagnitude).toBeCloseTo(1, 6)
+		expect(local.events.U3!.umbralMagnitude).toBeCloseTo(1, 6)
+	})
+
+	test('penumbral magnitude is 0 at P1/P4', () => {
+		expect(local.events.P1!.penumbralMagnitude).toBeCloseTo(0, 6)
+		expect(local.events.P4!.penumbralMagnitude).toBeCloseTo(0, 6)
+	})
+
+	test('umbral magnitude at MAX matches the eclipse magnitude', () => {
+		expect(local.events.MAX!.umbralMagnitude).toBeCloseTo(TOTAL.magnitude, 6)
+	})
+
+	test('penumbral-only eclipse exposes its penumbral magnitude at MAX', () => {
+		const sub = sublunarAtMax(PENUMBRAL)
+		const localPen = computeLocalLunarEclipseCircumstances(PENUMBRAL, sub.longitude, sub.latitude, sunMoonPosition)
+		expect(localPen.events.MAX!.penumbralMagnitude).toBeCloseTo(PENUMBRAL.magnitude, 6)
+		expect(localPen.details.maximalUmbralMagnitude).toBeNull()
+	}, 6000)
+})
+
+describe('visibility classification', () => {
+	test('observer at the sublunar point sees the whole eclipse above the horizon', () => {
+		const { longitude, latitude } = sublunarAtMax(TOTAL)
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+		expect(local.visibility.hasObservableEclipse).toBe(true)
+		expect(local.events.MAX!.observable).toBe(true)
+		expect(local.events.MAX!.altitude).toBeGreaterThan(0)
+		expect(local.visibility.kind).toBe('completelyVisible')
+	}, 6000)
+
+	test('observer at the antipode has the Moon below the horizon throughout', () => {
+		const sub = sublunarAtMax(TOTAL)
+		const longitude = sub.longitude > 0 ? sub.longitude - Math.PI : sub.longitude + Math.PI
+		const latitude = -sub.latitude
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+		expect(local.visibility.hasObservableEclipse).toBe(false)
+		expect(local.visibility.kind).toBe('geometricOnlyBelowHorizon')
+		expect(local.events.MAX!.observable).toBe(false)
+		expect(local.details.observableDuration).toBe(0)
+	}, 6000)
+
+	test('hasGeometricEclipse is true regardless of horizon', () => {
+		const sub = sublunarAtMax(TOTAL)
+		const longitude = sub.longitude > 0 ? sub.longitude - Math.PI : sub.longitude + Math.PI
+		const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, -sub.latitude, sunMoonPosition)
+		expect(local.visibility.hasGeometricEclipse).toBe(true)
+	}, 6000)
+})
+
+describe('P/Z orientation angles and Alt/Az', () => {
+	const { longitude, latitude } = sublunarAtMax(TOTAL)
+	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+
+	test('every event angle is finite and normalized to [0, TAU)', () => {
+		for (const kind of Object.keys(local.events) as (keyof typeof local.events)[]) {
+			const event = local.events[kind]!
+			for (const angle of [event.azimuth, event.positionAngle, event.zenithAngle]) {
+				expect(Number.isFinite(angle)).toBe(true)
+				expect(angle).toBeGreaterThanOrEqual(0)
+				expect(angle).toBeLessThan(TAU + 1e-9)
+			}
+			expect(Number.isFinite(event.altitude)).toBe(true)
+		}
+	})
+
+	test('details report phase durations for a total eclipse', () => {
+		expect(local.details.penumbralPhaseDuration).toBeGreaterThan(0)
+		expect(local.details.partialPhaseDuration).toBeGreaterThan(0)
+		expect(local.details.totalPhaseDuration).toBeGreaterThan(0)
+	})
+
+	test('partial eclipse has no total phase duration', () => {
+		const sub = sublunarAtMax(PARTIAL)
+		const localPartial = computeLocalLunarEclipseCircumstances(PARTIAL, sub.longitude, sub.latitude, sunMoonPosition)
+		expect(localPartial.details.totalPhaseDuration).toBeNull()
+		expect(localPartial.details.partialPhaseDuration).toBeGreaterThan(0)
+	}, 6000)
+})
+
+describe('Local View geometry', () => {
+	const { longitude, latitude } = sublunarAtMax(TOTAL)
+	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)
+	const view = computeLocalLunarEclipseViewGeometry(local, TOTAL, { selectedEvent: 'MAX' })
+
+	function circles(role: LocalLunarEclipseSvgCircle['role']) {
+		return view.shapes.filter((s): s is LocalLunarEclipseSvgCircle => s.kind === 'circle' && s.role === role)
+	}
+
+	test('draws exactly one umbra and one penumbra ring with penumbra larger', () => {
+		const umbra = circles('umbra')
+		const penumbra = circles('penumbra')
+		expect(umbra).toHaveLength(1)
+		expect(penumbra).toHaveLength(1)
+		expect(penumbra[0].r).toBeGreaterThan(umbra[0].r)
+	})
+
+	test('selected contact is drawn as the primary Moon disk and the rest as ghosts', () => {
+		const primary = circles('moonDisk')
+		const ghosts = circles('ghostMoonDisk')
+		expect(primary).toHaveLength(1)
+		expect(primary[0].event).toBe('MAX')
+		expect(ghosts).toHaveLength(6)
+		expect(view.selectedEvent).toBe('MAX')
+	})
+
+	test('includes a trajectory path and a horizon band, all finite', () => {
+		expect(view.shapes.some((s) => s.kind === 'path' && s.role === 'trajectoryPath')).toBe(true)
+		expect(view.shapes.some((s) => s.kind === 'polygon' && s.role === 'horizonBand')).toBe(true)
+		for (const shape of view.shapes) {
+			if (shape.kind === 'circle') {
+				expect(Number.isFinite(shape.cx) && Number.isFinite(shape.cy) && Number.isFinite(shape.r)).toBe(true)
+				expect(shape.r).toBeGreaterThanOrEqual(0)
+			} else if (shape.kind === 'path') {
+				expect(shape.d).not.toContain('NaN')
+			}
+		}
+	})
+
+	test('falls back to MAX when the requested contact is absent', () => {
+		const sub = sublunarAtMax(PENUMBRAL)
+		const localPen = computeLocalLunarEclipseCircumstances(PENUMBRAL, sub.longitude, sub.latitude, sunMoonPosition)
+		const penView = computeLocalLunarEclipseViewGeometry(localPen, PENUMBRAL, { selectedEvent: 'U2' })
+		expect(penView.requestedEvent).toBe('U2')
+		expect(penView.selectedEvent).toBe('MAX')
+	}, 6000)
+})

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -37,6 +37,18 @@ function pointInPolygon(px: number, py: number, polygon: readonly { readonly x: 
 	return inside
 }
 
+describe('ancient dates', () => {
+	// Contacts before JD 0 have negative days; lunarEclipseEvents must keep them, so local circumstances report a
+	// real geometric eclipse instead of nothing.
+	test('local circumstances resolve for an eclipse before JD 0', () => {
+		const ancient = nearestLunarEclipse(timeYMDHMS(-5000, 1, 1), true)
+		const local = computeLocalLunarEclipseCircumstances(ancient, 0, 0, sunMoonPosition, { altitudeSamples: 12 })
+		expect(local.visibility.hasGeometricEclipse).toBe(true)
+		expect(Object.keys(local.events)).toEqual(['P1', 'U1', 'MAX', 'U4', 'P4'])
+		expect(local.events.MAX!.time.day).toBeLessThan(0)
+	}, 6000)
+})
+
 describe('per-contact magnitudes', () => {
 	const { longitude, latitude } = sublunarAtMax(TOTAL)
 	const local = computeLocalLunarEclipseCircumstances(TOTAL, longitude, latitude, sunMoonPosition)

--- a/tests/moon.eclipse.local.test.ts
+++ b/tests/moon.eclipse.local.test.ts
@@ -339,5 +339,5 @@ describe('Local View geometry', () => {
 		expect(primaryInsideBand(0)).toBe(false)
 		// Drawn against the configured 10 deg horizon the Moon is below it: inside the band, matching observable=false.
 		expect(primaryInsideBand(customHorizon)).toBe(true)
-	}, 10000)
+	}, 7000)
 })

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -90,7 +90,7 @@ describe('horizon curve geometry', () => {
 				expect(topocentricAltitude).toBeCloseTo(0, 3)
 			}
 		}
-	})
+	}, 8000)
 
 	test('sublunar point sees the Moon at the zenith and its antipode below the horizon', () => {
 		for (const event of geometry.events) {
@@ -113,7 +113,7 @@ describe('horizon curve geometry', () => {
 			const point = branch[i]
 			expect(moonAltitudeAt(max.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(altOption, 3)
 		}
-	})
+	}, 2000)
 })
 
 describe('high declination robustness', () => {

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, test } from 'bun:test'
 import { deg, type Angle } from '../src/angle'
 import { PI, PIOVERTWO, TAU } from '../src/constants'
-import * as elpmpp02 from '../src/elpmpp02'
 import { nearestLunarEclipse } from '../src/moon'
 import { moonAltitudeAt } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry, lunarEclipseEvents, lunarEclipseMapToSvgPaths, MOON_RADIUS_EARTH_RADII, type LunarEclipseContactKind } from '../src/moon.eclipse.map'
 import { PlateCarree } from '../src/projection'
-import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
-import { type Time, timeYMDHMS } from '../src/time'
-import * as vsop87e from '../src/vsop87e'
+import { greenwichApparentSiderealTime, type Time, timeYMDHMS } from '../src/time'
+import { cachedSunMoonPosition } from './eclipse.util'
 
-// Apparent Sun/Moon position provider from the analytical VSOP87E + ELP/MPP02 ephemerides (no fixtures).
-function sunMoonPosition(t: Time) {
-	return computeSunMoonPositionAt(t, vsop87e.sun, vsop87e.earth, elpmpp02.moon)
+// Cheap deterministic position provider for tests that exercise local-circumstance plumbing rather than the
+// analytical VSOP87/ELP ephemerides. The Moon stays high for FAST_LONGITUDE/FAST_LATITUDE, keeping visibility
+// and duration assertions stable while avoiding hundreds of expensive series evaluations.
+function fastSunMoonPosition(time: Time) {
+	const gast = greenwichApparentSiderealTime(time)
+
+	return {
+		sun: { rightAscension: gast - Math.PI + deg(0.1), declination: 0, distance: 1 },
+		moon: { rightAscension: gast, declination: 0, distance: 60 },
+		deltaT: 0,
+	}
 }
 
 // Known eclipses (see tests/moon.test.ts): types verified against timeanddate.com.
@@ -69,7 +75,7 @@ describe('events by type', () => {
 		expect(ancient.totalBeginTime.day).toBe(0)
 		expect(ancient.totalBeginTime.fraction).toBe(0)
 		// Map geometry is built for the ancient eclipse rather than reporting nothing.
-		const geometry = computeLunarEclipseMapGeometry(ancient, sunMoonPosition)
+		const geometry = computeLunarEclipseMapGeometry(ancient, fastSunMoonPosition)
 		expect(geometry.events).toHaveLength(events.length)
 		expect(geometry.lines.moonRiseSet.MAX![0].length).toBeGreaterThan(0)
 	})
@@ -80,7 +86,7 @@ describe('maxAngularStep validation', () => {
 	// a RangeError from new Array(...).
 	test('invalid maxAngularStep falls back to the default instead of throwing', () => {
 		for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
-			const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { maxAngularStep: bad })
+			const geometry = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition, { maxAngularStep: bad })
 			const branch = geometry.lines.moonRiseSet.MAX![0]
 			expect(branch.length).toBeGreaterThan(1)
 			for (const point of branch) {
@@ -90,8 +96,8 @@ describe('maxAngularStep validation', () => {
 		}
 
 		// The fallback produces exactly the default-spacing curve.
-		const fallback = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { maxAngularStep: 0 }).lines.moonRiseSet.MAX![0]
-		const byDefault = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition).lines.moonRiseSet.MAX![0]
+		const fallback = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition, { maxAngularStep: 0 }).lines.moonRiseSet.MAX![0]
+		const byDefault = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition).lines.moonRiseSet.MAX![0]
 		expect(fallback.length).toBe(byDefault.length)
 	}, 4000)
 
@@ -99,7 +105,7 @@ describe('maxAngularStep validation', () => {
 	// unsafe array length and throw a RangeError; the per-curve point count must be capped instead.
 	test('a tiny maxAngularStep is capped instead of throwing', () => {
 		for (const tiny of [Number.MIN_VALUE, 1e-300, 1e-12]) {
-			const geometry = computeLunarEclipseMapGeometry(PENUMBRAL, sunMoonPosition, { maxAngularStep: tiny })
+			const geometry = computeLunarEclipseMapGeometry(PENUMBRAL, fastSunMoonPosition, { maxAngularStep: tiny })
 			const branch = geometry.lines.moonRiseSet.MAX![0]
 			// Many points (a fine curve), but bounded by the safety ceiling (+ the repeated closing vertex).
 			expect(branch.length).toBeGreaterThan(1000)
@@ -111,7 +117,7 @@ describe('maxAngularStep validation', () => {
 })
 
 describe('horizon curve geometry', () => {
-	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition)
 
 	test('every curve point is finite and within latitude bounds', () => {
 		for (const event of geometry.events) {
@@ -138,7 +144,7 @@ describe('horizon curve geometry', () => {
 			const stepN = Math.max(1, Math.floor(branch.length / 12))
 			for (let i = 0; i < branch.length; i += stepN) {
 				const point = branch[i]
-				const topocentricAltitude = moonAltitudeAt(event.time, point.x, point.y, sunMoonPosition)
+				const topocentricAltitude = moonAltitudeAt(event.time, point.x, point.y, fastSunMoonPosition)
 				expect(topocentricAltitude).toBeCloseTo(0, 3)
 			}
 		}
@@ -157,26 +163,26 @@ describe('horizon curve geometry', () => {
 
 	test('horizon altitude option shifts the curve to that topocentric altitude', () => {
 		const altOption: Angle = deg(10)
-		const geo = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { horizonAltitude: altOption })
+		const geo = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition, { horizonAltitude: altOption })
 		const max = geo.events.find((e) => e.kind === 'MAX')!
 		const branch = geo.lines.moonRiseSet.MAX![0]
 		const stepN = Math.max(1, Math.floor(branch.length / 12))
 		for (let i = 0; i < branch.length; i += stepN) {
 			const point = branch[i]
-			expect(moonAltitudeAt(max.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(altOption, 3)
+			expect(moonAltitudeAt(max.time, point.x, point.y, fastSunMoonPosition)).toBeCloseTo(altOption, 3)
 		}
 	}, 2000)
 
 	test('negative horizon altitude option lowers the topocentric curve', () => {
 		const altOption: Angle = deg(-2)
-		const geo = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { horizonAltitude: altOption })
+		const geo = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition, { horizonAltitude: altOption })
 		const max = geo.events.find((e) => e.kind === 'MAX')!
 		const branch = geo.lines.moonRiseSet.MAX![0]
 		const stepN = Math.max(1, Math.floor(branch.length / 12))
 		expect(max.horizonAltitude).toBeCloseTo(altOption, 12)
 		for (let i = 0; i < branch.length; i += stepN) {
 			const point = branch[i]
-			expect(moonAltitudeAt(max.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(altOption, 3)
+			expect(moonAltitudeAt(max.time, point.x, point.y, fastSunMoonPosition)).toBeCloseTo(altOption, 3)
 		}
 	}, 2000)
 })
@@ -185,7 +191,7 @@ describe('upper-limb visibility', () => {
 	// TOTAL is the 1997-07 eclipse, near perigee: its apparent semidiameter (~0.279 deg) is distinctly larger
 	// than the mean (~0.259 deg), so the upper-limb curve must use the per-event semidiameter from the distance.
 	test('upper-limb curve uses the per-event semidiameter from the Moon distance', () => {
-		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { limbVisibility: 'upperLimb' })
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, cachedSunMoonPosition, { limbVisibility: 'upperLimb' })
 		for (const event of geometry.events) {
 			const semidiameter = Math.asin(MOON_RADIUS_EARTH_RADII / event.distance)
 			// Near perigee, distinctly above the 0.259 deg mean a fixed lift would have used.
@@ -195,9 +201,10 @@ describe('upper-limb visibility', () => {
 			// Sampled curve points have topocentric Moon-center altitude = -asin(moonRadius / distance).
 			const branch = geometry.lines.moonRiseSet[event.kind]![0]
 			const stepN = Math.max(1, Math.floor(branch.length / 8))
+
 			for (let i = 0; i < branch.length; i += stepN) {
 				const point = branch[i]
-				expect(moonAltitudeAt(event.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(-semidiameter, 3)
+				expect(moonAltitudeAt(event.time, point.x, point.y, cachedSunMoonPosition)).toBeCloseTo(-semidiameter, 3)
 			}
 		}
 	}, 8000)
@@ -206,7 +213,7 @@ describe('upper-limb visibility', () => {
 describe('high declination robustness', () => {
 	// A northern-declination total eclipse: the sublunar point is far north, exercising a near-polar circle.
 	test('curve stays finite and within latitude bounds', () => {
-		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition)
 		const max = geometry.events.find((e) => e.kind === 'MAX')!
 		for (const point of geometry.lines.moonRiseSet.MAX![0]) {
 			expect(Number.isFinite(point.x)).toBe(true)
@@ -218,7 +225,7 @@ describe('high declination robustness', () => {
 })
 
 describe('SVG serialization', () => {
-	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, cachedSunMoonPosition)
 	const projection = equirectangular(720, 360)
 	const svg = lunarEclipseMapToSvgPaths(geometry, projection)
 
@@ -245,7 +252,7 @@ describe('SVG serialization', () => {
 	})
 
 	test('penumbral eclipse omits umbral contact paths', () => {
-		const geo = computeLunarEclipseMapGeometry(PENUMBRAL, sunMoonPosition)
+		const geo = computeLunarEclipseMapGeometry(PENUMBRAL, fastSunMoonPosition)
 		const paths = lunarEclipseMapToSvgPaths(geo, projection)
 		expect(paths.moonRiseSet.P1.length).toBeGreaterThan(0)
 		expect(paths.moonRiseSet.U1).toBe('')
@@ -292,7 +299,7 @@ function pointInPath(px: number, py: number, path: string): boolean {
 }
 
 describe('fill region polygons', () => {
-	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, cachedSunMoonPosition)
 	const projection = equirectangular(720, 360)
 
 	test('fill replaces the open curves with closed polygons', () => {
@@ -334,7 +341,7 @@ describe('fill region polygons', () => {
 	// pole-edge closure is wrong; the ring-topology path must still put the sublunar point inside the cap.
 	test('near-equatorial eclipse: aboveHorizon fill contains the sublunar point', () => {
 		const eclipse = nearestLunarEclipse(timeYMDHMS(2016, 3, 1), true)
-		const geo = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition)
+		const geo = computeLunarEclipseMapGeometry(eclipse, fastSunMoonPosition)
 		const max = geo.events.find((e) => e.kind === 'MAX')!
 		// 2016-03-23 penumbral eclipse: MAX declination ~ -0.31 deg, smaller than the ~0.95 deg lunar parallax.
 		expect(Math.abs(max.declination)).toBeLessThan(deg(0.95))
@@ -353,7 +360,7 @@ describe('fill region polygons', () => {
 	// the antipode is inside it, the sublunar point is not (with the required even-odd fill rule).
 	test('near-equatorial eclipse: belowHorizon fill is the cap complement', () => {
 		const eclipse = nearestLunarEclipse(timeYMDHMS(2016, 3, 1), true)
-		const geo = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition)
+		const geo = computeLunarEclipseMapGeometry(eclipse, fastSunMoonPosition)
 		const max = geo.events.find((e) => e.kind === 'MAX')!
 		const below = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'belowHorizon' }).moonRiseSet.MAX
 		const sub = projection.project(max.sublunar.x, max.sublunar.y)!
@@ -368,7 +375,7 @@ describe('fill region polygons', () => {
 	// aboveHorizon must fill the complement of that ring, not the ring (which would invert the regions).
 	test('near-equatorial eclipse with a lowered horizon fills the larger-than-hemisphere cap', () => {
 		const eclipse = nearestLunarEclipse(timeYMDHMS(2016, 3, 1), true)
-		const geo = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition, { horizonAltitude: deg(-2) })
+		const geo = computeLunarEclipseMapGeometry(eclipse, fastSunMoonPosition, { horizonAltitude: deg(-2) })
 		const max = geo.events.find((e) => e.kind === 'MAX')!
 		const above = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'aboveHorizon' }).moonRiseSet.MAX
 		const below = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'belowHorizon' }).moonRiseSet.MAX
@@ -390,7 +397,7 @@ describe('fill region polygons', () => {
 	// hemisphere but encloses just one pole, the ring winds that pole and the polar branch handles it; the two
 	// conditions "ring winds a pole" and "both poles above the threshold" cannot hold together.)
 	test('lowered horizon on a near-equatorial eclipse: both poles are inside aboveHorizon', () => {
-		const geo = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { horizonAltitude: deg(-5) })
+		const geo = computeLunarEclipseMapGeometry(TOTAL, fastSunMoonPosition, { horizonAltitude: deg(-5) })
 		const max = geo.events.find((e) => e.kind === 'MAX')!
 		const above = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'aboveHorizon' }).moonRiseSet.MAX
 		const northPole = projection.project(0, PIOVERTWO - 1e-6)!

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -335,4 +335,25 @@ describe('fill region polygons', () => {
 		expect(pointInPath(anti.x, anti.y, below)).toBe(true)
 		expect(pointInPath(sub.x, sub.y, below)).toBe(false)
 	})
+
+	// A sufficiently negative horizon makes the visibility cap larger than a hemisphere: the above-horizon region
+	// contains the sublunar point AND both poles, and the bounded ring is the small antipodal below-horizon hole.
+	// aboveHorizon must fill the complement of that ring, not the ring (which would invert the regions).
+	test('near-equatorial eclipse with a lowered horizon fills the larger-than-hemisphere cap', () => {
+		const eclipse = nearestLunarEclipse(timeYMDHMS(2016, 3, 1), true)
+		const geo = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition, { horizonAltitude: deg(-2) })
+		const max = geo.events.find((e) => e.kind === 'MAX')!
+		const above = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'aboveHorizon' }).moonRiseSet.MAX
+		const below = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'belowHorizon' }).moonRiseSet.MAX
+		const sub = projection.project(max.sublunar.x, max.sublunar.y)!
+		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - Math.PI : max.sublunar.x + Math.PI
+		const anti = projection.project(antiLon, -max.sublunar.y)!
+
+		// Above-horizon contains the sublunar point and excludes its antipode.
+		expect(pointInPath(sub.x, sub.y, above)).toBe(true)
+		expect(pointInPath(anti.x, anti.y, above)).toBe(false)
+		// Below-horizon is the antipodal hole: the antipode is inside, the sublunar point outside.
+		expect(pointInPath(anti.x, anti.y, below)).toBe(true)
+		expect(pointInPath(sub.x, sub.y, below)).toBe(false)
+	})
 })

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import type { Angle } from '../src/angle'
+import { deg, type Angle } from '../src/angle'
 import { PIOVERTWO, TAU } from '../src/constants'
 import * as elpmpp02 from '../src/elpmpp02'
 import { nearestLunarEclipse } from '../src/moon'
+import { moonAltitudeAt } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry, lunarEclipseEvents, lunarEclipseMapToSvgPaths, type LunarEclipseContactKind } from '../src/moon.eclipse.map'
 import { PlateCarree } from '../src/projection'
 import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
@@ -60,7 +61,7 @@ describe('events by type', () => {
 describe('horizon curve geometry', () => {
 	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
 
-	test('every curve point has Moon altitude on the horizon', () => {
+	test('every curve point is finite and within latitude bounds', () => {
 		for (const event of geometry.events) {
 			const curve = geometry.lines.moonRiseSet[event.kind]!
 			expect(curve.length).toBeGreaterThan(0)
@@ -71,9 +72,22 @@ describe('horizon curve geometry', () => {
 					expect(point.x).toBeGreaterThanOrEqual(-Math.PI - 1e-9)
 					expect(point.x).toBeLessThanOrEqual(Math.PI + 1e-9)
 					expect(Math.abs(point.y)).toBeLessThanOrEqual(PIOVERTWO + 1e-9)
-					const alt = moonAltitude(event.rightAscension, event.declination, event.gast, point.x, point.y)
-					expect(alt).toBeCloseTo(0, 5)
 				}
+			}
+		}
+	})
+
+	test('every curve point has topocentric Moon altitude on the horizon', () => {
+		// Rise/set is a topocentric condition. The parallax-reduced circle must put the topocentric Moon center
+		// on the horizon (h0 = 0); the bare geocentric circle would leave it ~one horizontal parallax (~0.95 deg)
+		// above the boundary. The geocentric altitude (moonAltitude) at these points is now h0 + parallax, not h0.
+		for (const event of geometry.events) {
+			const branch = geometry.lines.moonRiseSet[event.kind]![0]
+			const stepN = Math.max(1, Math.floor(branch.length / 12))
+			for (let i = 0; i < branch.length; i += stepN) {
+				const point = branch[i]
+				const topocentricAltitude = moonAltitudeAt(event.time, point.x, point.y, sunMoonPosition)
+				expect(topocentricAltitude).toBeCloseTo(0, 3)
 			}
 		}
 	})
@@ -89,13 +103,15 @@ describe('horizon curve geometry', () => {
 		}
 	})
 
-	test('horizon altitude option shifts the curve to that altitude', () => {
-		const altOption: Angle = (10 / 180) * Math.PI
+	test('horizon altitude option shifts the curve to that topocentric altitude', () => {
+		const altOption: Angle = deg(10)
 		const geo = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { horizonAltitude: altOption })
 		const max = geo.events.find((e) => e.kind === 'MAX')!
-		for (const point of geo.lines.moonRiseSet.MAX![0]) {
-			const alt = moonAltitude(max.rightAscension, max.declination, max.gast, point.x, point.y)
-			expect(alt).toBeCloseTo(altOption, 5)
+		const branch = geo.lines.moonRiseSet.MAX![0]
+		const stepN = Math.max(1, Math.floor(branch.length / 12))
+		for (let i = 0; i < branch.length; i += stepN) {
+			const point = branch[i]
+			expect(moonAltitudeAt(max.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(altOption, 3)
 		}
 	})
 })

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -192,6 +192,18 @@ function pointInPolygon(px: number, py: number, polygon: { x: number; y: number 
 	return inside
 }
 
+// Even-odd point-in-path test across every "M ... Z" subpath, matching the fill-rule the polygons require.
+function pointInPath(px: number, py: number, path: string): boolean {
+	let inside = false
+	for (const part of path.split('M')) {
+		const trimmed = part.trim()
+		if (!trimmed) continue
+		const polygon = parsePolygon(`M${trimmed}`)
+		if (polygon.length >= 3 && pointInPolygon(px, py, polygon)) inside = !inside
+	}
+	return inside
+}
+
 describe('fill region polygons', () => {
 	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
 	const projection = equirectangular(720, 360)
@@ -229,5 +241,38 @@ describe('fill region polygons', () => {
 		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - Math.PI : max.sublunar.x + Math.PI
 		const anti = projection.project(antiLon, -max.sublunar.y)!
 		expect(pointInPolygon(anti.x, anti.y, parsePolygon(above.moonRiseSet.MAX))).toBe(false)
+	})
+
+	// Near the celestial equator (|declination| below the lunar parallax) the cap encloses neither pole, so the
+	// pole-edge closure is wrong; the ring-topology path must still put the sublunar point inside the cap.
+	test('near-equatorial eclipse: aboveHorizon fill contains the sublunar point', () => {
+		const eclipse = nearestLunarEclipse(timeYMDHMS(2016, 3, 1), true)
+		const geo = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition)
+		const max = geo.events.find((e) => e.kind === 'MAX')!
+		// 2016-03-23 penumbral eclipse: MAX declination ~ -0.31 deg, smaller than the ~0.95 deg lunar parallax.
+		expect(Math.abs(max.declination)).toBeLessThan(deg(0.95))
+
+		const above = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'aboveHorizon' }).moonRiseSet.MAX
+		const sub = projection.project(max.sublunar.x, max.sublunar.y)!
+		expect(pointInPath(sub.x, sub.y, above)).toBe(true)
+
+		// The antipodal point is below the horizon, so it must be outside the cap.
+		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - Math.PI : max.sublunar.x + Math.PI
+		const anti = projection.project(antiLon, -max.sublunar.y)!
+		expect(pointInPath(anti.x, anti.y, above)).toBe(false)
+	})
+
+	// The belowHorizon complement of a near-equatorial cap is the map rectangle with the cap punched out:
+	// the antipode is inside it, the sublunar point is not (with the required even-odd fill rule).
+	test('near-equatorial eclipse: belowHorizon fill is the cap complement', () => {
+		const eclipse = nearestLunarEclipse(timeYMDHMS(2016, 3, 1), true)
+		const geo = computeLunarEclipseMapGeometry(eclipse, sunMoonPosition)
+		const max = geo.events.find((e) => e.kind === 'MAX')!
+		const below = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'belowHorizon' }).moonRiseSet.MAX
+		const sub = projection.project(max.sublunar.x, max.sublunar.y)!
+		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - Math.PI : max.sublunar.x + Math.PI
+		const anti = projection.project(antiLon, -max.sublunar.y)!
+		expect(pointInPath(anti.x, anti.y, below)).toBe(true)
+		expect(pointInPath(sub.x, sub.y, below)).toBe(false)
 	})
 })

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -370,4 +370,23 @@ describe('fill region polygons', () => {
 		expect(pointInPath(anti.x, anti.y, below)).toBe(true)
 		expect(pointInPath(sub.x, sub.y, below)).toBe(false)
 	})
+
+	// A lowered horizon on a near-equatorial eclipse makes the cap exceed a hemisphere AND enclose BOTH poles
+	// (the ring then winds neither pole, winding ~ 0). aboveHorizon must contain both poles - the Moon is above
+	// the threshold there - and exclude only the small antipodal below-horizon hole. (When the cap exceeds a
+	// hemisphere but encloses just one pole, the ring winds that pole and the polar branch handles it; the two
+	// conditions "ring winds a pole" and "both poles above the threshold" cannot hold together.)
+	test('lowered horizon on a near-equatorial eclipse: both poles are inside aboveHorizon', () => {
+		const geo = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { horizonAltitude: deg(-5) })
+		const max = geo.events.find((e) => e.kind === 'MAX')!
+		const above = lunarEclipseMapToSvgPaths(geo, projection, { fill: true, fillRegion: 'aboveHorizon' }).moonRiseSet.MAX
+		const northPole = projection.project(0, PIOVERTWO - 1e-6)!
+		const southPole = projection.project(0, -(PIOVERTWO - 1e-6))!
+		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - Math.PI : max.sublunar.x + Math.PI
+		const anti = projection.project(antiLon, -max.sublunar.y)!
+
+		expect(pointInPath(northPole.x, northPole.y, above)).toBe(true)
+		expect(pointInPath(southPole.x, southPole.y, above)).toBe(true)
+		expect(pointInPath(anti.x, anti.y, above)).toBe(false)
+	})
 })

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -4,7 +4,7 @@ import { PIOVERTWO, TAU } from '../src/constants'
 import * as elpmpp02 from '../src/elpmpp02'
 import { nearestLunarEclipse } from '../src/moon'
 import { moonAltitudeAt } from '../src/moon.eclipse.local'
-import { computeLunarEclipseMapGeometry, lunarEclipseEvents, lunarEclipseMapToSvgPaths, type LunarEclipseContactKind } from '../src/moon.eclipse.map'
+import { computeLunarEclipseMapGeometry, lunarEclipseEvents, lunarEclipseMapToSvgPaths, MOON_RADIUS_EARTH_RADII, type LunarEclipseContactKind } from '../src/moon.eclipse.map'
 import { PlateCarree } from '../src/projection'
 import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
 import { type Time, timeYMDHMS } from '../src/time'
@@ -114,6 +114,28 @@ describe('horizon curve geometry', () => {
 			expect(moonAltitudeAt(max.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(altOption, 3)
 		}
 	}, 2000)
+})
+
+describe('upper-limb visibility', () => {
+	// TOTAL is the 1997-07 eclipse, near perigee: its apparent semidiameter (~0.279 deg) is distinctly larger
+	// than the mean (~0.259 deg), so the upper-limb curve must use the per-event semidiameter from the distance.
+	test('upper-limb curve uses the per-event semidiameter from the Moon distance', () => {
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { limbVisibility: 'upperLimb' })
+		for (const event of geometry.events) {
+			const semidiameter = Math.asin(MOON_RADIUS_EARTH_RADII / event.distance)
+			// Near perigee, distinctly above the 0.259 deg mean a fixed lift would have used.
+			expect(semidiameter).toBeGreaterThan(deg(0.27))
+			// The effective horizon is one semidiameter below the true horizon (upper limb on the horizon).
+			expect(event.horizonAltitude).toBeCloseTo(-semidiameter, 9)
+			// Sampled curve points have topocentric Moon-center altitude = -asin(moonRadius / distance).
+			const branch = geometry.lines.moonRiseSet[event.kind]![0]
+			const stepN = Math.max(1, Math.floor(branch.length / 8))
+			for (let i = 0; i < branch.length; i += stepN) {
+				const point = branch[i]
+				expect(moonAltitudeAt(event.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(-semidiameter, 3)
+			}
+		}
+	}, 8000)
 })
 
 describe('high declination robustness', () => {

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import { deg, type Angle } from '../src/angle'
 import { PI, PIOVERTWO, TAU } from '../src/constants'
+import { sunMoonPosition } from '../src/eclipse'
 import { nearestLunarEclipse } from '../src/moon'
 import { moonAltitudeAt } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry, lunarEclipseEvents, lunarEclipseMapToSvgPaths, MOON_RADIUS_EARTH_RADII, type LunarEclipseContactKind } from '../src/moon.eclipse.map'
 import { PlateCarree } from '../src/projection'
 import { greenwichApparentSiderealTime, type Time, timeYMDHMS } from '../src/time'
-import { cachedSunMoonPosition } from './eclipse.util'
 
 // Cheap deterministic position provider for tests that exercise local-circumstance plumbing rather than the
 // analytical VSOP87/ELP ephemerides. The Moon stays high for FAST_LONGITUDE/FAST_LATITUDE, keeping visibility
@@ -191,7 +191,7 @@ describe('upper-limb visibility', () => {
 	// TOTAL is the 1997-07 eclipse, near perigee: its apparent semidiameter (~0.279 deg) is distinctly larger
 	// than the mean (~0.259 deg), so the upper-limb curve must use the per-event semidiameter from the distance.
 	test('upper-limb curve uses the per-event semidiameter from the Moon distance', () => {
-		const geometry = computeLunarEclipseMapGeometry(TOTAL, cachedSunMoonPosition, { limbVisibility: 'upperLimb' })
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { limbVisibility: 'upperLimb' })
 		for (const event of geometry.events) {
 			const semidiameter = Math.asin(MOON_RADIUS_EARTH_RADII / event.distance)
 			// Near perigee, distinctly above the 0.259 deg mean a fixed lift would have used.
@@ -204,7 +204,7 @@ describe('upper-limb visibility', () => {
 
 			for (let i = 0; i < branch.length; i += stepN) {
 				const point = branch[i]
-				expect(moonAltitudeAt(event.time, point.x, point.y, cachedSunMoonPosition)).toBeCloseTo(-semidiameter, 3)
+				expect(moonAltitudeAt(event.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(-semidiameter, 3)
 			}
 		}
 	}, 8000)
@@ -225,7 +225,7 @@ describe('high declination robustness', () => {
 })
 
 describe('SVG serialization', () => {
-	const geometry = computeLunarEclipseMapGeometry(TOTAL, cachedSunMoonPosition)
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
 	const projection = equirectangular(720, 360)
 	const svg = lunarEclipseMapToSvgPaths(geometry, projection)
 
@@ -299,7 +299,7 @@ function pointInPath(px: number, py: number, path: string): boolean {
 }
 
 describe('fill region polygons', () => {
-	const geometry = computeLunarEclipseMapGeometry(TOTAL, cachedSunMoonPosition)
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
 	const projection = equirectangular(720, 360)
 
 	test('fill replaces the open curves with closed polygons', () => {

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { deg, type Angle } from '../src/angle'
-import { PIOVERTWO, TAU } from '../src/constants'
+import { PI, PIOVERTWO, TAU } from '../src/constants'
 import * as elpmpp02 from '../src/elpmpp02'
 import { nearestLunarEclipse } from '../src/moon'
 import { moonAltitudeAt } from '../src/moon.eclipse.local'
@@ -388,5 +388,26 @@ describe('fill region polygons', () => {
 		expect(pointInPath(northPole.x, northPole.y, above)).toBe(true)
 		expect(pointInPath(southPole.x, southPole.y, above)).toBe(true)
 		expect(pointInPath(anti.x, anti.y, above)).toBe(false)
+	})
+
+	// The fill must follow the projection's central meridian exactly like the open curves: a polar cap ordered and
+	// closed in raw [-PI, PI] longitude (ignoring the central meridian) fills the wrong side. With a map centered on
+	// 180 deg, the MAX cap of the 1997-09-16 total eclipse must still place the sublunar point inside aboveHorizon,
+	// its antipode outside, and the enclosed pole inside.
+	test('a non-zero central meridian fills the same side of the curve', () => {
+		const centered = new PlateCarree(undefined, { scale: 720 / TAU, falseEasting: 360, falseNorthing: 180, yAxisDirection: 'southUp', centralMeridian: PI, longitudeWrapMode: 'pi', maxLatitude: PIOVERTWO })
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		const above = lunarEclipseMapToSvgPaths(geometry, centered, { fill: true, fillRegion: 'aboveHorizon' }).moonRiseSet.MAX
+
+		const sub = centered.project(max.sublunar.x, max.sublunar.y)!
+		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - PI : max.sublunar.x + PI
+		const anti = centered.project(antiLon, -max.sublunar.y)!
+		// Project the enclosed pole at the central meridian so it lands in the map interior, not on the +-PI edge
+		// where a point-in-polygon test would be ambiguous.
+		const enclosedPole = centered.project(PI, max.declination >= 0 ? PIOVERTWO - 1e-6 : -(PIOVERTWO - 1e-6))!
+
+		expect(pointInPath(sub.x, sub.y, above)).toBe(true)
+		expect(pointInPath(anti.x, anti.y, above)).toBe(false)
+		expect(pointInPath(enclosedPole.x, enclosedPole.y, above)).toBe(true)
 	})
 })

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -166,6 +166,19 @@ describe('horizon curve geometry', () => {
 			expect(moonAltitudeAt(max.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(altOption, 3)
 		}
 	}, 2000)
+
+	test('negative horizon altitude option lowers the topocentric curve', () => {
+		const altOption: Angle = deg(-2)
+		const geo = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { horizonAltitude: altOption })
+		const max = geo.events.find((e) => e.kind === 'MAX')!
+		const branch = geo.lines.moonRiseSet.MAX![0]
+		const stepN = Math.max(1, Math.floor(branch.length / 12))
+		expect(max.horizonAltitude).toBeCloseTo(altOption, 12)
+		for (let i = 0; i < branch.length; i += stepN) {
+			const point = branch[i]
+			expect(moonAltitudeAt(max.time, point.x, point.y, sunMoonPosition)).toBeCloseTo(altOption, 3)
+		}
+	}, 2000)
 })
 
 describe('upper-limb visibility', () => {

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -150,3 +150,68 @@ describe('SVG serialization', () => {
 		expect(paths.moonRiseSet.MAX.length).toBeGreaterThan(0)
 	})
 })
+
+// Parses an "M x y L x y ... Z" path into its vertices.
+function parsePolygon(path: string): { x: number; y: number }[] {
+	const points: { x: number; y: number }[] = []
+	for (const token of path.replaceAll('Z', '').split(/[ML]/)) {
+		const trimmed = token.trim()
+		if (!trimmed) continue
+		const [x, y] = trimmed.split(/\s+/).map(Number)
+		if (Number.isFinite(x) && Number.isFinite(y)) points.push({ x, y })
+	}
+	return points
+}
+
+// Ray-casting point-in-polygon test.
+function pointInPolygon(px: number, py: number, polygon: { x: number; y: number }[]): boolean {
+	let inside = false
+	for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+		const xi = polygon[i].x
+		const yi = polygon[i].y
+		const xj = polygon[j].x
+		const yj = polygon[j].y
+		if (yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) inside = !inside
+	}
+	return inside
+}
+
+describe('fill region polygons', () => {
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+	const projection = equirectangular(720, 360)
+
+	test('fill replaces the open curves with closed polygons', () => {
+		// Without fill the curves are open polylines; with fill moonRiseSet holds closed region polygons.
+		expect(lunarEclipseMapToSvgPaths(geometry, projection).moonRiseSet.MAX.endsWith('Z')).toBe(false)
+		expect(lunarEclipseMapToSvgPaths(geometry, projection, { fill: true }).moonRiseSet.MAX.endsWith('Z')).toBe(true)
+	})
+
+	test('each region polygon is closed and finite', () => {
+		const paths = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true })
+		for (const kind of ['P1', 'U1', 'U2', 'MAX', 'U3', 'U4', 'P4'] as LunarEclipseContactKind[]) {
+			const path = paths.moonRiseSet[kind]
+			expect(path.startsWith('M')).toBe(true)
+			expect(path.endsWith('Z')).toBe(true)
+			expect(path).not.toContain('NaN')
+			expect(path).not.toContain('Infinity')
+		}
+	})
+
+	test('aboveHorizon fill contains the sublunar point and belowHorizon does not', () => {
+		const above = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true, fillRegion: 'aboveHorizon' })
+		const below = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true, fillRegion: 'belowHorizon' })
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		const sub = projection.project(max.sublunar.x, max.sublunar.y)!
+
+		expect(pointInPolygon(sub.x, sub.y, parsePolygon(above.moonRiseSet.MAX))).toBe(true)
+		expect(pointInPolygon(sub.x, sub.y, parsePolygon(below.moonRiseSet.MAX))).toBe(false)
+	})
+
+	test('aboveHorizon fill excludes the antipodal (below-horizon) point', () => {
+		const above = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true, fillRegion: 'aboveHorizon' })
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - Math.PI : max.sublunar.x + Math.PI
+		const anti = projection.project(antiLon, -max.sublunar.y)!
+		expect(pointInPolygon(anti.x, anti.y, parsePolygon(above.moonRiseSet.MAX))).toBe(false)
+	})
+})

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'bun:test'
+import type { Angle } from '../src/angle'
+import { PIOVERTWO, TAU } from '../src/constants'
+import * as elpmpp02 from '../src/elpmpp02'
+import { nearestLunarEclipse } from '../src/moon'
+import { computeLunarEclipseMapGeometry, lunarEclipseEvents, lunarEclipseMapToSvgPaths, type LunarEclipseContactKind } from '../src/moon.eclipse.map'
+import { PlateCarree } from '../src/projection'
+import { computeSunMoonPositionAt } from '../src/sun.eclipse.map'
+import { type Time, timeYMDHMS } from '../src/time'
+import * as vsop87e from '../src/vsop87e'
+
+// Apparent Sun/Moon position provider from the analytical VSOP87E + ELP/MPP02 ephemerides (no fixtures).
+function sunMoonPosition(t: Time) {
+	return computeSunMoonPositionAt(t, vsop87e.sun, vsop87e.earth, elpmpp02.moon)
+}
+
+// Known eclipses (see tests/moon.test.ts): types verified against timeanddate.com.
+const PENUMBRAL = nearestLunarEclipse(timeYMDHMS(1973, 6, 1), true)
+const TOTAL = nearestLunarEclipse(timeYMDHMS(1997, 7, 1), true)
+const PARTIAL = nearestLunarEclipse(timeYMDHMS(1994, 5, 25), true)
+
+// Moon altitude (radians) at a geographic point, from a map event's apparent RA/Dec and GAST.
+function moonAltitude(rightAscension: Angle, declination: Angle, gast: Angle, longitude: Angle, latitude: Angle): Angle {
+	const H = gast + longitude - rightAscension
+	const sinAlt = Math.sin(latitude) * Math.sin(declination) + Math.cos(latitude) * Math.cos(declination) * Math.cos(H)
+	return Math.asin(Math.max(-1, Math.min(1, sinAlt)))
+}
+
+function equirectangular(width: number, height: number) {
+	return new PlateCarree(undefined, {
+		scale: width / TAU,
+		falseEasting: width / 2,
+		falseNorthing: height / 2,
+		yAxisDirection: 'southUp',
+		centralMeridian: 0,
+		longitudeWrapMode: 'pi',
+		maxLatitude: PIOVERTWO,
+	})
+}
+
+describe('events by type', () => {
+	test('penumbral has P1, MAX, P4', () => {
+		expect(lunarEclipseEvents(PENUMBRAL).map((e) => e.kind)).toEqual(['P1', 'MAX', 'P4'])
+	})
+
+	test('partial has P1, U1, MAX, U4, P4', () => {
+		expect(lunarEclipseEvents(PARTIAL).map((e) => e.kind)).toEqual(['P1', 'U1', 'MAX', 'U4', 'P4'])
+	})
+
+	test('total has all seven contacts', () => {
+		expect(lunarEclipseEvents(TOTAL).map((e) => e.kind)).toEqual(['P1', 'U1', 'U2', 'MAX', 'U3', 'U4', 'P4'])
+	})
+
+	test('contact times are ascending', () => {
+		const events = lunarEclipseEvents(TOTAL)
+		for (let i = 1; i < events.length; i++) expect(events[i].jd).toBeGreaterThan(events[i - 1].jd)
+	})
+})
+
+describe('horizon curve geometry', () => {
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+
+	test('every curve point has Moon altitude on the horizon', () => {
+		for (const event of geometry.events) {
+			const curve = geometry.lines.moonRiseSet[event.kind]!
+			expect(curve.length).toBeGreaterThan(0)
+			for (const branch of curve) {
+				for (const point of branch) {
+					expect(Number.isFinite(point.x)).toBe(true)
+					expect(Number.isFinite(point.y)).toBe(true)
+					expect(point.x).toBeGreaterThanOrEqual(-Math.PI - 1e-9)
+					expect(point.x).toBeLessThanOrEqual(Math.PI + 1e-9)
+					expect(Math.abs(point.y)).toBeLessThanOrEqual(PIOVERTWO + 1e-9)
+					const alt = moonAltitude(event.rightAscension, event.declination, event.gast, point.x, point.y)
+					expect(alt).toBeCloseTo(0, 5)
+				}
+			}
+		}
+	})
+
+	test('sublunar point sees the Moon at the zenith and its antipode below the horizon', () => {
+		for (const event of geometry.events) {
+			const sub = event.sublunar
+			const altSub = moonAltitude(event.rightAscension, event.declination, event.gast, sub.x, sub.y)
+			expect(altSub).toBeCloseTo(PIOVERTWO, 6)
+			const antipodeLon = sub.x > 0 ? sub.x - Math.PI : sub.x + Math.PI
+			const altAnti = moonAltitude(event.rightAscension, event.declination, event.gast, antipodeLon, -sub.y)
+			expect(altAnti).toBeCloseTo(-PIOVERTWO, 6)
+		}
+	})
+
+	test('horizon altitude option shifts the curve to that altitude', () => {
+		const altOption: Angle = (10 / 180) * Math.PI
+		const geo = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { horizonAltitude: altOption })
+		const max = geo.events.find((e) => e.kind === 'MAX')!
+		for (const point of geo.lines.moonRiseSet.MAX![0]) {
+			const alt = moonAltitude(max.rightAscension, max.declination, max.gast, point.x, point.y)
+			expect(alt).toBeCloseTo(altOption, 5)
+		}
+	})
+})
+
+describe('high declination robustness', () => {
+	// A northern-declination total eclipse: the sublunar point is far north, exercising a near-polar circle.
+	test('curve stays finite and within latitude bounds', () => {
+		const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		for (const point of geometry.lines.moonRiseSet.MAX![0]) {
+			expect(Number.isFinite(point.x)).toBe(true)
+			expect(Number.isFinite(point.y)).toBe(true)
+			expect(Math.abs(point.y)).toBeLessThanOrEqual(PIOVERTWO + 1e-9)
+		}
+		expect(Math.abs(max.declination)).toBeLessThanOrEqual(PIOVERTWO)
+	})
+})
+
+describe('SVG serialization', () => {
+	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
+	const projection = equirectangular(720, 360)
+	const svg = lunarEclipseMapToSvgPaths(geometry, projection)
+
+	test('emits a path per existing contact and no NaN/Infinity', () => {
+		for (const kind of ['P1', 'U1', 'U2', 'MAX', 'U3', 'U4', 'P4'] as LunarEclipseContactKind[]) {
+			const path = svg.moonRiseSet[kind]
+			expect(path.length).toBeGreaterThan(0)
+			expect(path).not.toContain('NaN')
+			expect(path).not.toContain('Infinity')
+			expect(path.startsWith('M')).toBe(true)
+		}
+	})
+
+	test('antimeridian wrap splits into multiple subpaths instead of one spanning line', () => {
+		// A horizon circle spans all longitudes, so it must cross the antimeridian and split into >= 2 subpaths.
+		const subpaths = svg.moonRiseSet.MAX.split('M').length - 1
+		expect(subpaths).toBeGreaterThanOrEqual(2)
+	})
+
+	test('projects the sublunar points', () => {
+		expect(svg.sublunarPoints.MAX).toBeDefined()
+		expect(Number.isFinite(svg.sublunarPoints.MAX!.x)).toBe(true)
+		expect(Number.isFinite(svg.sublunarPoints.MAX!.y)).toBe(true)
+	})
+
+	test('penumbral eclipse omits umbral contact paths', () => {
+		const geo = computeLunarEclipseMapGeometry(PENUMBRAL, sunMoonPosition)
+		const paths = lunarEclipseMapToSvgPaths(geo, projection)
+		expect(paths.moonRiseSet.P1.length).toBeGreaterThan(0)
+		expect(paths.moonRiseSet.U1).toBe('')
+		expect(paths.moonRiseSet.U2).toBe('')
+		expect(paths.moonRiseSet.MAX.length).toBeGreaterThan(0)
+	})
+})

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -56,6 +56,23 @@ describe('events by type', () => {
 		const events = lunarEclipseEvents(TOTAL)
 		for (let i = 1; i < events.length; i++) expect(events[i].jd).toBeGreaterThan(events[i - 1].jd)
 	})
+
+	// Before JD 0 the contact Time.day values are negative; the absent-contact sentinel is day 0 AND fraction 0,
+	// so real ancient contacts must not be dropped (a positive-day test would discard them all).
+	test('eclipse before JD 0 keeps its contacts', () => {
+		const ancient = nearestLunarEclipse(timeYMDHMS(-5000, 1, 1), true)
+		expect(ancient.type).toBe('PARTIAL')
+		const events = lunarEclipseEvents(ancient)
+		expect(events.map((e) => e.kind)).toEqual(['P1', 'U1', 'MAX', 'U4', 'P4'])
+		// The resolved contacts have negative days (real), while the absent totality contact keeps the sentinel.
+		expect(events[0].time.day).toBeLessThan(0)
+		expect(ancient.totalBeginTime.day).toBe(0)
+		expect(ancient.totalBeginTime.fraction).toBe(0)
+		// Map geometry is built for the ancient eclipse rather than reporting nothing.
+		const geometry = computeLunarEclipseMapGeometry(ancient, sunMoonPosition)
+		expect(geometry.events).toHaveLength(events.length)
+		expect(geometry.lines.moonRiseSet.MAX![0].length).toBeGreaterThan(0)
+	})
 })
 
 describe('maxAngularStep validation', () => {

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -94,6 +94,20 @@ describe('maxAngularStep validation', () => {
 		const byDefault = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition).lines.moonRiseSet.MAX![0]
 		expect(fallback.length).toBe(byDefault.length)
 	}, 4000)
+
+	// A pathologically small but finite maxAngularStep passes the finite-positive check, yet would derive an
+	// unsafe array length and throw a RangeError; the per-curve point count must be capped instead.
+	test('a tiny maxAngularStep is capped instead of throwing', () => {
+		for (const tiny of [Number.MIN_VALUE, 1e-300, 1e-12]) {
+			const geometry = computeLunarEclipseMapGeometry(PENUMBRAL, sunMoonPosition, { maxAngularStep: tiny })
+			const branch = geometry.lines.moonRiseSet.MAX![0]
+			// Many points (a fine curve), but bounded by the safety ceiling (+ the repeated closing vertex).
+			expect(branch.length).toBeGreaterThan(1000)
+			expect(branch.length).toBeLessThanOrEqual(100001)
+			expect(Number.isFinite(branch[0].x)).toBe(true)
+			expect(Number.isFinite(branch.at(-1)!.y)).toBe(true)
+		}
+	}, 8000)
 })
 
 describe('horizon curve geometry', () => {

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -7,6 +7,7 @@ import { moonAltitudeAt } from '../src/moon.eclipse.local'
 import { computeLunarEclipseMapGeometry, lunarEclipseEvents, lunarEclipseMapToSvgPaths, MOON_RADIUS_EARTH_RADII, type LunarEclipseContactKind } from '../src/moon.eclipse.map'
 import { PlateCarree } from '../src/projection'
 import { greenwichApparentSiderealTime, type Time, timeYMDHMS } from '../src/time'
+import { longestProjectedSegment } from './eclipse.util'
 
 // Cheap deterministic position provider for tests that exercise local-circumstance plumbing rather than the
 // analytical VSOP87/ELP ephemerides. The Moon stays high for FAST_LONGITUDE/FAST_LATITUDE, keeping visibility
@@ -243,6 +244,17 @@ describe('SVG serialization', () => {
 		// A horizon circle spans all longitudes, so it must cross the antimeridian and split into >= 2 subpaths.
 		const subpaths = svg.moonRiseSet.MAX.split('M').length - 1
 		expect(subpaths).toBeGreaterThanOrEqual(2)
+	})
+
+	// With a non-zero central meridian supplied via projectionOptions, the open curve must split on the shifted
+	// seam (central meridian +- PI), not raw +- PI; otherwise a segment crossing the real seam is drawn as a
+	// full-width horizontal line across the map. The longest projected segment must stay well under the map width.
+	test('open curves follow a non-zero central meridian without a map-spanning segment', () => {
+		const centered = lunarEclipseMapToSvgPaths(geometry, projection, { projectionOptions: { centralMeridian: PI } }).moonRiseSet.MAX
+		expect(centered.length).toBeGreaterThan(0)
+		expect(longestProjectedSegment(centered)).toBeLessThan(720 / 2)
+		// It still crosses the (shifted) seam, so it splits into multiple subpaths.
+		expect(centered.split('M').length - 1).toBeGreaterThanOrEqual(2)
 	})
 
 	test('projects the sublunar points', () => {

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -58,6 +58,27 @@ describe('events by type', () => {
 	})
 })
 
+describe('maxAngularStep validation', () => {
+	// An invalid spacing must fall back to the default, not make the per-curve sample count non-finite and throw
+	// a RangeError from new Array(...).
+	test('invalid maxAngularStep falls back to the default instead of throwing', () => {
+		for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { maxAngularStep: bad })
+			const branch = geometry.lines.moonRiseSet.MAX![0]
+			expect(branch.length).toBeGreaterThan(1)
+			for (const point of branch) {
+				expect(Number.isFinite(point.x)).toBe(true)
+				expect(Number.isFinite(point.y)).toBe(true)
+			}
+		}
+
+		// The fallback produces exactly the default-spacing curve.
+		const fallback = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition, { maxAngularStep: 0 }).lines.moonRiseSet.MAX![0]
+		const byDefault = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition).lines.moonRiseSet.MAX![0]
+		expect(fallback.length).toBe(byDefault.length)
+	}, 4000)
+})
+
 describe('horizon curve geometry', () => {
 	const geometry = computeLunarEclipseMapGeometry(TOTAL, sunMoonPosition)
 

--- a/tests/moon.eclipse.map.test.ts
+++ b/tests/moon.eclipse.map.test.ts
@@ -430,4 +430,27 @@ describe('fill region polygons', () => {
 		expect(pointInPath(anti.x, anti.y, above)).toBe(false)
 		expect(pointInPath(enclosedPole.x, enclosedPole.y, above)).toBe(true)
 	})
+
+	// Same requirement, but with the central meridian supplied through options.projectionOptions (the documented
+	// call-time channel) on a projection built at meridian 0. The fill must resolve the central meridian the same
+	// way the open curves and sublunar points do, so the shadow follows them; the bug left the fill at the
+	// projection's own meridian (0) while the sublunar point shifted, so the shadow excluded it.
+	test('central meridian from options.projectionOptions still fills the same side', () => {
+		const projectionOptions = { centralMeridian: PI }
+		const max = geometry.events.find((e) => e.kind === 'MAX')!
+		const paths = lunarEclipseMapToSvgPaths(geometry, projection, { fill: true, fillRegion: 'aboveHorizon', projectionOptions })
+		const above = paths.moonRiseSet.MAX
+
+		const sub = projection.project(max.sublunar.x, max.sublunar.y, undefined, projectionOptions)!
+		const antiLon = max.sublunar.x > 0 ? max.sublunar.x - PI : max.sublunar.x + PI
+		const anti = projection.project(antiLon, -max.sublunar.y, undefined, projectionOptions)!
+		const enclosedPole = projection.project(PI, max.declination >= 0 ? PIOVERTWO - 1e-6 : -(PIOVERTWO - 1e-6), undefined, projectionOptions)!
+
+		// The sublunar point (projected with the call-time options) shifts with the central meridian, and the fill
+		// must shift with it.
+		expect(paths.sublunarPoints.MAX).toEqual(sub)
+		expect(pointInPath(sub.x, sub.y, above)).toBe(true)
+		expect(pointInPath(anti.x, anti.y, above)).toBe(false)
+		expect(pointInPath(enclosedPole.x, enclosedPole.y, above)).toBe(true)
+	})
 })

--- a/tests/sun.eclipse.local.test.ts
+++ b/tests/sun.eclipse.local.test.ts
@@ -7,7 +7,7 @@ import { computePolynomialBesselianElements, type PolynomialBesselianElements } 
 import { computeLocalSolarEclipseViewGeometry, buildLocalViewHorizonGeometry, computeGreatestDurationCircumstances, computeGreatestEclipseCircumstances, computeLocalSolarEclipseCircumstances, findLocalContactRoots, findLocalMaximumTime, listLocalSolarEclipses, type LocalFundamentalState, type LocalSolarEclipseCircumstancesOptions, type LocalSolarEclipseEvent, type LocalSolarEclipseViewOptions, type LocalSolarEclipseCircumstances, } from '../src/sun.eclipse.local'
 import { sphericalSeparation } from '../src/geometry'
 import { timeToDate, timeYMD, toJulianDay, type Time } from '../src/time'
-import { sunMoonPosition } from './sun.eclipse.util'
+import { cachedSunMoonPosition as sunMoonPosition } from './eclipse.util'
 
 function viewOptions(overrides: Partial<LocalSolarEclipseViewOptions> = {}): LocalSolarEclipseViewOptions {
 	return { width: 450, height: 160, selectedEvent: 'MAX', orientationMode: 'zenith', solarRadiusPx: 34, includeGhostDisks: true, includeHorizon: true, horizonBandPaddingPx: 4, ...overrides }

--- a/tests/sun.eclipse.local.test.ts
+++ b/tests/sun.eclipse.local.test.ts
@@ -5,9 +5,9 @@ import { nearestSolarEclipse } from '../src/sun'
 import { computePolynomialBesselianElements, type PolynomialBesselianElements } from '../src/sun.eclipse.map'
 // oxfmt-ignore
 import { computeLocalSolarEclipseViewGeometry, buildLocalViewHorizonGeometry, computeGreatestDurationCircumstances, computeGreatestEclipseCircumstances, computeLocalSolarEclipseCircumstances, findLocalContactRoots, findLocalMaximumTime, listLocalSolarEclipses, type LocalFundamentalState, type LocalSolarEclipseCircumstancesOptions, type LocalSolarEclipseEvent, type LocalSolarEclipseViewOptions, type LocalSolarEclipseCircumstances, } from '../src/sun.eclipse.local'
+import { sunMoonPosition } from '../src/eclipse'
 import { sphericalSeparation } from '../src/geometry'
 import { timeToDate, timeYMD, toJulianDay, type Time } from '../src/time'
-import { cachedSunMoonPosition as sunMoonPosition } from './eclipse.util'
 
 function viewOptions(overrides: Partial<LocalSolarEclipseViewOptions> = {}): LocalSolarEclipseViewOptions {
 	return { width: 450, height: 160, selectedEvent: 'MAX', orientationMode: 'zenith', solarRadiusPx: 34, includeGhostDisks: true, includeHorizon: true, horizonBandPaddingPx: 4, ...overrides }

--- a/tests/sun.eclipse.map.test.ts
+++ b/tests/sun.eclipse.map.test.ts
@@ -2,12 +2,13 @@ import { expect, test, describe } from 'bun:test'
 import { deg, parseAngle, type Angle } from '../src/angle'
 import { nearestSolarEclipse, type SolarEclipse, type SolarEclipseType } from '../src/sun'
 // oxfmt-ignore
-import { BRANCH_MAX_DRAWABLE_GAP, centralAxisIntersectsEarth, computePolynomialBesselianElements, computeRiseSetCurves, computeSolarEclipseMapGeometry, DELTA_T_LONGITUDE_FACTOR, derivativeEarthLimbOmega, EARTH_E2, earthLimbCircleIntersections, earthLimbExtremes, earthLimbOmega, earthLimbPoint, evaluateBesselian, findCentralLineExtremePoint, findCircleIntersections, findCurvePoints, findEclipseCurvePoint, findMaximumPoint, findPenumbraContactPoints, geoPolylinesToSvgPathData, hourAngleFromLongitude, intermediateGreatCircle, longitudeFromHourAngle, pointsToSvgPathData, projectClosestEarthLimbPoint, projectFundamentalPoint, solarAltitudeAtPoint, solarEclipseMapToSvgPaths, splitAtMaxAbsLatitude, splitCentralLineByKind, splitDisconnectedPolylines, splitPolygonAtAntimeridian, splitPolylineAtAntimeridian, type GeoBranch, type GeoPoint, type PolynomialBesselianElements, type SolarEclipseMapGeometry, type SunMoonPosition } from '../src/sun.eclipse.map'
+import { BRANCH_MAX_DRAWABLE_GAP, centralAxisIntersectsEarth, computePolynomialBesselianElements, computeRiseSetCurves, computeSolarEclipseMapGeometry, evaluateBesselian, findCentralLineExtremePoint, findCircleIntersections, findCurvePoints, findEclipseCurvePoint, findMaximumPoint, findPenumbraContactPoints, intermediateGreatCircle, projectClosestEarthLimbPoint, projectFundamentalPoint, solarAltitudeAtPoint, solarEclipseMapToSvgPaths, splitAtMaxAbsLatitude, splitCentralLineByKind, splitDisconnectedPolylines, type SolarEclipseGeoBranch, type SolarEclipseGeoPoint, type PolynomialBesselianElements, type SolarEclipseMapGeometry } from '../src/sun.eclipse.map'
 import { DEG2RAD, PI, PIOVERTWO, TAU } from '../src/constants'
+import { DELTA_T_LONGITUDE_FACTOR, EARTH_E2, earthLimbExtremes, earthLimbOmega, type SunMoonPosition } from '../src/eclipse'
 import { sphericalSeparation } from '../src/geometry'
-import { PlateCarree, type Projection, type ProjectionOptions } from '../src/projection'
+import { PlateCarree, type ProjectionOptions } from '../src/projection'
 import { time, Timescale, timeSubtract, timeYMD, toJulianDay } from '../src/time'
-import { catalogBranchRetraces, countKinks, endpointRetraces, geometryFor, interpolateAtJulianDay, limitTangencyResidual, longestProjectedSegment, maxBranchSegment, sunMoonPosition } from './sun.eclipse.util'
+import { catalogBranchRetraces, countKinks, endpointRetraces, geometryFor, interpolateAtJulianDay, limitTangencyResidual, longestProjectedSegment, maxBranchSegment, cachedSunMoonPosition as sunMoonPosition } from './eclipse.util'
 
 const JD0 = 2460409.25
 const TIME0 = time(JD0)
@@ -191,7 +192,7 @@ function eclipse(type: SolarEclipseType, gamma: number = 0): SolarEclipse {
 	return { lunation: 300, maximalTime: TIME0, magnitude: type === 'partial' ? 0.8 : 1.05, gamma, u: type === 'total' ? -0.01 : 0.01, type }
 }
 
-function expectGeoPoint(point: GeoPoint) {
+function expectGeoPoint(point: SolarEclipseGeoPoint) {
 	expect(Number.isFinite(point.x)).toBe(true)
 	expect(Number.isFinite(point.y)).toBe(true)
 	expect(point.x).toBeGreaterThanOrEqual(-PI)
@@ -200,7 +201,7 @@ function expectGeoPoint(point: GeoPoint) {
 	expect(point.y).toBeLessThanOrEqual(PIOVERTWO)
 }
 
-function expectGeoPointClose(point: GeoPoint | undefined, longitude: number, latitude: number, jd?: number) {
+function expectGeoPointClose(point: SolarEclipseGeoPoint | undefined, longitude: number, latitude: number, jd?: number) {
 	expect(point).toBeDefined()
 	expectGeoPoint(point!)
 	expect(point!.x).toBeCloseTo(longitude, 10)
@@ -208,17 +209,17 @@ function expectGeoPointClose(point: GeoPoint | undefined, longitude: number, lat
 	if (jd !== undefined) expect(Math.abs(point!.jd! - jd)).toBeLessThan(1e-8)
 }
 
-function expectIncreasingJd(branch: GeoBranch) {
-	for (let i = 1; i < branch.length; i++) expect(branch[i].jd!).toBeGreaterThan(branch[i - 1].jd!)
+function expectIncreasingJd(branch: SolarEclipseGeoBranch) {
+	for (let i = 1; i < branch.length; i++) expect(branch[i].jd).toBeGreaterThan(branch[i - 1].jd!)
 }
 
 // Rise/set branches may hold two distinct points at the same instant (a tangency cusp anchored at a
 // contact plus the first sampled crossing), so time only needs to be non-decreasing along them.
-function expectNonDecreasingJd(branch: GeoBranch) {
-	for (let i = 1; i < branch.length; i++) expect(branch[i].jd!).toBeGreaterThanOrEqual(branch[i - 1].jd!)
+function expectNonDecreasingJd(branch: SolarEclipseGeoBranch) {
+	for (let i = 1; i < branch.length; i++) expect(branch[i].jd).toBeGreaterThanOrEqual(branch[i - 1].jd!)
 }
 
-function expectMaxAngularStep(branch: GeoBranch, maxStep: number) {
+function expectMaxAngularStep(branch: SolarEclipseGeoBranch, maxStep: number) {
 	for (let i = 1; i < branch.length; i++) expect(sphericalSeparation(branch[i - 1].x, branch[i - 1].y, branch[i].x, branch[i].y)).toBeLessThanOrEqual(maxStep)
 }
 
@@ -256,7 +257,7 @@ function expectTimeNearSeconds(actualJd: number, expectedJd: number, toleranceSe
 	expect(Math.abs((actualJd - expectedJd) * 86400)).toBeLessThanOrEqual(toleranceSeconds)
 }
 
-function expectGeoNear(actual: GeoPoint | undefined, lat: Angle, lon: Angle, toleranceArcmin: number) {
+function expectGeoNear(actual: SolarEclipseGeoPoint | undefined, lat: Angle, lon: Angle, toleranceArcmin: number) {
 	expect(actual).toBeDefined()
 	expectGeoPoint(actual!)
 	expect(sphericalSeparation(actual!.x, actual!.y, lon, lat)).toBeLessThanOrEqual(deg(toleranceArcmin / 60))
@@ -265,31 +266,19 @@ function expectGeoNear(actual: GeoPoint | undefined, lat: Angle, lon: Angle, tol
 const CENTRAL_FIXTURES = NASA_ECLIPSES.filter((fixture) => fixture.central)
 
 // Asserts a geographic point is within toleranceArcmin arcminutes of a NASA reference coordinate.
-function expectNearNasa(point: GeoPoint | undefined, latitudeDeg: number, longitudeDeg: number, toleranceArcmin: number) {
+function expectNearNasa(point: SolarEclipseGeoPoint | undefined, latitudeDeg: number, longitudeDeg: number, toleranceArcmin: number) {
 	expect(point).toBeDefined()
 	expectGeoPoint(point!)
 	expect(sphericalSeparation(point!.x, point!.y, deg(longitudeDeg), deg(latitudeDeg))).toBeLessThan(deg(toleranceArcmin / 60))
 }
 
 test('geographic angular helpers handle antimeridian and great-circle interpolation', () => {
-	const a: GeoPoint = { x: deg(179.5), y: 0 }
-	const b: GeoPoint = { x: deg(-179.5), y: 0 }
+	const a: SolarEclipseGeoPoint = { x: deg(179.5), y: 0 }
+	const b: SolarEclipseGeoPoint = { x: deg(-179.5), y: 0 }
 	const mid = intermediateGreatCircle(a, b, 0.5)
 
 	expect(Math.abs(Math.abs(mid.x) - PI)).toBeLessThan(1e-10)
 	expect(mid.y).toBeCloseTo(0, 12)
-})
-
-test('longitude convention is east-positive and centralized in the hour-angle helpers', () => {
-	const mu = deg(100)
-	const correction = deg(0.0817)
-	const H = deg(40)
-	const longitude = longitudeFromHourAngle(H, mu, correction)
-
-	// lambda = H - mu + correction, east-positive (Astrarium's west-positive mirror negated).
-	expect(longitude).toBeCloseTo(deg(40 - 100 + 0.0817), 12)
-	// The inverse helper round-trips exactly when no TAU wrap is involved.
-	expect(hourAngleFromLongitude(longitude, mu, correction)).toBeCloseTo(H, 12)
 })
 
 test('evalBesselian uses Horner coefficients, derivatives, and mu wrapping', () => {
@@ -651,102 +640,14 @@ test('findCircleIntersections is a unit-circle utility (spherical limb), not the
 	expect(findCircleIntersections(0, 0, 0.5)).toHaveLength(0)
 })
 
-describe('earth-limb ellipse geometry', () => {
-	const E2 = EARTH_E2
-
-	function omega(d: number) {
-		return 1 / Math.sqrt(1 - E2 * Math.cos(d) * Math.cos(d))
-	}
-
-	test('earthLimbOmega and its derivative are consistent (finite difference)', () => {
-		for (const d of [deg(-80), deg(-20), 0, deg(15), deg(60), deg(85)]) {
-			expect(earthLimbOmega(d)).toBeCloseTo(omega(d), 12)
-			const h = 1e-6
-			const numeric = (earthLimbOmega(d + h) - earthLimbOmega(d - h)) / (2 * h)
-			expect(derivativeEarthLimbOmega(d)).toBeCloseTo(numeric, 6)
-		}
-		// At the equator (d = 0) the flattening scale is maximal, so its derivative vanishes.
-		expect(derivativeEarthLimbOmega(0)).toBeCloseTo(0, 12)
-	})
-
-	test('earthLimbPoint lies exactly on the limb ellipse x^2 + (omega y)^2 = 1', () => {
-		const w = omega(deg(23))
-		for (const theta of [0, 0.5, 1.3, PI, 4.2, 6]) {
-			const [x, y] = earthLimbPoint(theta, w)
-			expect(x * x + (w * y) ** 2).toBeCloseTo(1, 12)
-		}
-	})
-
-	test('earthLimbExtremes finds the true nearest and farthest limb points', () => {
-		const w = omega(deg(40))
-		// A point inside the ellipse.
-		const inside = earthLimbExtremes(0.2, -0.1, w)
-		expect(inside.inside).toBe(true)
-		expect(inside.minDistance).toBeLessThan(inside.maxDistance)
-		// A point outside the ellipse.
-		const outside = earthLimbExtremes(1.6, 0.9, w)
-		expect(outside.inside).toBe(false)
-
-		// The reported nearest/farthest distances are the global extrema over a dense theta scan.
-		for (const sample of [inside, outside]) {
-			const cx = sample === inside ? 0.2 : 1.6
-			const cy = sample === inside ? -0.1 : 0.9
-			let min = Infinity
-			let max = -Infinity
-			for (let k = 0; k < 2000; k++) {
-				const [x, y] = earthLimbPoint((k / 2000) * TAU, w)
-				const dist = Math.hypot(x - cx, y - cy)
-				min = Math.min(min, dist)
-				max = Math.max(max, dist)
-			}
-			expect(sample.minDistance).toBeLessThanOrEqual(min + 1e-6)
-			expect(sample.maxDistance).toBeGreaterThanOrEqual(max - 1e-6)
-			// The nearest point sits on the ellipse.
-			const [nx, ny] = earthLimbPoint(sample.nearestTheta, w)
-			expect(nx * nx + (w * ny) ** 2).toBeCloseTo(1, 10)
-		}
-	})
-
-	test('earthLimbCircleIntersections solves the circle-ellipse system (two, tangent, none)', () => {
-		const w = omega(deg(35))
-		const cx = 0.3
-		const cy = -0.2
-
-		// Radius chosen so the shadow circle cuts the limb twice.
-		const radius = 0.9
-		const crossings = earthLimbCircleIntersections(cx, cy, w, radius)
-		expect(crossings.length).toBeGreaterThanOrEqual(2)
-		// Ordered by descending y, and each crossing satisfies BOTH equations.
-		for (let i = 1; i < crossings.length; i++) expect(crossings[i - 1][1]).toBeGreaterThanOrEqual(crossings[i][1])
-		for (const [x, y] of crossings) {
-			expect(x * x + (w * y) ** 2).toBeCloseTo(1, 6)
-			expect(Math.hypot(x - cx, y - cy)).toBeCloseTo(radius, 6)
-		}
-
-		// A radius larger than the farthest limb distance from a far-outside center: no intersection.
-		expect(earthLimbCircleIntersections(5, 0, w, 0.5)).toHaveLength(0)
-	})
-
-	test('earthLimbCircleIntersections handles a high-declination (more flattened) limb near the pole', () => {
-		const w = omega(deg(85))
-		// Center near the pole region of the fundamental plane.
-		const crossings = earthLimbCircleIntersections(0, 0.8, w, 0.6)
-		expect(crossings.length).toBeGreaterThanOrEqual(2)
-		for (const [x, y] of crossings) {
-			expect(x * x + (w * y) ** 2).toBeCloseTo(1, 6)
-			expect(Math.hypot(x - 0, y - 0.8)).toBeCloseTo(0.6, 6)
-		}
-	})
-
-	test('projectFundamentalPoint rejects points outside the limb ellipse (no clamp)', () => {
-		const be = evaluateBesselian(pbe({ d: [deg(20)], mu: [deg(50)] }), TIME0)
-		const w = earthLimbOmega(be.d)
-		// A point strictly outside the ellipse is rejected.
-		expect(0.9 * 0.9 + (w * 0.9) ** 2).toBeGreaterThan(1)
-		expect(projectFundamentalPoint(be, 0.9, 0.9)).toBeUndefined()
-		// Its closest limb projection exists and is finite.
-		expectGeoPoint(projectClosestEarthLimbPoint(be, 0.9, 0.9)!)
-	})
+test('projectFundamentalPoint rejects points outside the limb ellipse (no clamp)', () => {
+	const be = evaluateBesselian(pbe({ d: [deg(20)], mu: [deg(50)] }), TIME0)
+	const w = earthLimbOmega(be.d)
+	// A point strictly outside the ellipse is rejected.
+	expect(0.9 * 0.9 + (w * 0.9) ** 2).toBeGreaterThan(1)
+	expect(projectFundamentalPoint(be, 0.9, 0.9)).toBeUndefined()
+	// Its closest limb projection exists and is finite.
+	expectGeoPoint(projectClosestEarthLimbPoint(be, 0.9, 0.9)!)
 })
 
 test('findCurvePoints returns bounded finite points for a synthetic partial limit', () => {
@@ -775,28 +676,8 @@ test('findCurvePoints refines exit boundaries away from the last valid longitude
 	expect(Math.abs((maxLon / deg(30)) % 1)).toBeGreaterThan(1e-3)
 })
 
-test('split helpers avoid direct antimeridian joins', () => {
-	const line: GeoBranch = [
-		{ x: deg(170), y: deg(10) },
-		{ x: deg(-170), y: deg(12) },
-		{ x: deg(-160), y: deg(15) },
-	]
-
-	const segments = splitPolylineAtAntimeridian(line)
-	const rings = splitPolygonAtAntimeridian(line)
-
-	expect(segments.length).toBeGreaterThan(1)
-	expect(rings.length).toBeGreaterThan(1)
-	expect(segments[0].at(-1)!.x).toBe(PI)
-	expect(segments[1][0].x).toBe(-PI)
-
-	const point = [{ x: 0, y: 0 }]
-	expect(splitPolylineAtAntimeridian(point)).toHaveLength(0)
-	expect(splitPolygonAtAntimeridian(point)).toHaveLength(0)
-})
-
 test('splitDisconnectedPolylines breaks a curve at gaps and drops undrawable pieces', () => {
-	const points: GeoBranch = [
+	const points: SolarEclipseGeoBranch = [
 		{ x: 0, y: 0 },
 		{ x: deg(1), y: 0 },
 		{ x: deg(2), y: 0 },
@@ -1025,28 +906,6 @@ test('computeSolarEclipseMapGeometry is deterministic for identical inputs', () 
 	expect(JSON.stringify(second)).toBe(JSON.stringify(first))
 })
 
-test('antimeridian splitting keeps segments within a hemisphere and continuous across the seam', () => {
-	const line: GeoBranch = [
-		{ x: deg(150), y: deg(5) },
-		{ x: deg(178), y: deg(8) },
-		{ x: deg(-176), y: deg(11) },
-		{ x: deg(-150), y: deg(14) },
-	]
-
-	const segments = splitPolylineAtAntimeridian(line)
-	expect(segments).toHaveLength(2)
-
-	for (const segment of segments) for (let i = 1; i < segment.length; i++) expect(Math.abs(segment[i].x - segment[i - 1].x)).toBeLessThanOrEqual(PI)
-
-	const seamEnd = segments[0].at(-1)!
-	const seamStart = segments[1][0]
-	expect(Math.abs(seamEnd.x)).toBeCloseTo(PI, 10)
-	expect(Math.abs(seamStart.x)).toBeCloseTo(PI, 10)
-	expect(seamEnd.x).toBe(-seamStart.x)
-	// Latitude is continuous across the inserted seam point.
-	expect(seamEnd.y).toBeCloseTo(seamStart.y, 10)
-})
-
 // NASA/GSFC umbral path table for the 2024 Apr 08 total eclipse (delta T = 70.6 s).
 // https://eclipse.gsfc.nasa.gov/SEpath/SEpath2001/SE2024Apr08Tpath.html
 const APR8_2024_UT_MIDNIGHT = 2460408.5 // 2024 Apr 08 00:00 UT
@@ -1130,64 +989,6 @@ test('central meridian shifts the projected longitudes', () => {
 	expect(projection.project(deg(90), 0)!.x).toBeCloseTo(180, 9)
 })
 
-test('pointsToSvgPathData emits one M..L.. subpath per piece and closes polygons', () => {
-	const open = pointsToSvgPathData([
-		[
-			{ x: 1, y: 2 },
-			{ x: 3, y: 4 },
-			{ x: 5, y: 6 },
-		],
-	])
-
-	expect(open).toBe('M1 2L3 4L5 6')
-
-	const closed = pointsToSvgPathData(
-		[
-			[
-				{ x: 0, y: 0 },
-				{ x: 10, y: 0 },
-				{ x: 10, y: 10 },
-			],
-		],
-		true,
-	)
-
-	expect(closed.startsWith('M0 0')).toBe(true)
-	expect(closed.endsWith('Z')).toBe(true)
-
-	// Two pieces produce two subpaths; degenerate pieces are dropped; empty input yields an empty string.
-	expect(
-		pointsToSvgPathData([
-			[
-				{ x: 0, y: 0 },
-				{ x: 1, y: 1 },
-			],
-			[
-				{ x: 2, y: 2 },
-				{ x: 3, y: 3 },
-			],
-		]).match(/M/g),
-	).toHaveLength(2)
-
-	expect(pointsToSvgPathData([[{ x: 0, y: 0 }]])).toBe('')
-	expect(pointsToSvgPathData([])).toBe('')
-})
-
-test('pointsToSvgPathData rounds coordinates to the requested precision', () => {
-	expect(
-		pointsToSvgPathData(
-			[
-				[
-					{ x: 1.23456, y: 2.98765 },
-					{ x: 3.1, y: 4 },
-				],
-			],
-			false,
-			3,
-		),
-	).toBe('M1.235 2.988L3.1 4')
-})
-
 test('solarEclipseMapToSvgPaths serializes lines and skips empty features', () => {
 	const map = geometry(
 		{
@@ -1229,29 +1030,6 @@ test('antimeridian-crossing lines split into multiple subpaths', () => {
 	const secondStartX = Number(subpaths[1].trim().split('L')[0].split(' ')[0])
 	expect(firstEndX).toBeCloseTo(360, 3)
 	expect(secondStartX).toBeCloseTo(0, 3)
-})
-
-test('projected path serialization breaks at projection gaps', () => {
-	const clippedProjection: Projection = {
-		project(longitude, latitude) {
-			return Math.abs(latitude) > deg(80) ? undefined : { x: longitude / deg(1), y: latitude / deg(1) }
-		},
-		unproject() {
-			return undefined
-		},
-	}
-	const path = geoPolylinesToSvgPathData(
-		[
-			[
-				{ x: deg(-10), y: deg(70) },
-				{ x: 0, y: deg(85) },
-				{ x: deg(10), y: deg(70) },
-			],
-		],
-		clippedProjection,
-	)
-
-	expect(path).toBe('')
 })
 
 // NASA/GSFC Besselian elements for the 2024 Apr 08 total eclipse.
@@ -1465,7 +1243,7 @@ describe('branch-aware curve topology', () => {
 		expect(expected!.y).toBeLessThan(deg(70))
 
 		let nearest = Infinity
-		let branchWithLowerArc: GeoBranch | undefined
+		let branchWithLowerArc: SolarEclipseGeoBranch | undefined
 
 		for (const branch of geometry.lines.penumbraNorth) {
 			for (const point of branch) {
@@ -1912,47 +1690,6 @@ describe('hybrid central line classification', () => {
 		const kinds = new Set(geometry.lines.centerLine.map((point) => point.kind))
 		expect(kinds.has('annular')).toBe(false)
 		expect(kinds.has('total')).toBe(true)
-	})
-})
-
-describe('circle-ellipse intersection multiplicity and tangency', () => {
-	// A circle and an ellipse can meet in four points; the solver must return all of them.
-	// Synthetic flattened limb x^2 + (2y)^2 = 1 (omega = 2) and a concentric circle of radius 0.7 cut at
-	// the four points (+-0.566, +-0.412).
-	test('earthLimbCircleIntersections returns four crossings when the geometry has four', () => {
-		const omega = 2
-		const radius = 0.7
-		const crossings = earthLimbCircleIntersections(0, 0, omega, radius)
-
-		expect(crossings).toHaveLength(4)
-		// Ordered by descending y, and each crossing lies on BOTH the ellipse and the circle.
-		for (let i = 1; i < crossings.length; i++) expect(crossings[i - 1][1]).toBeGreaterThanOrEqual(crossings[i][1])
-		for (const [x, y] of crossings) {
-			expect(x * x + (omega * y) ** 2).toBeCloseTo(1, 6)
-			expect(Math.hypot(x, y)).toBeCloseTo(radius, 6)
-		}
-	})
-
-	// A grazing (tangential) contact is a double root that never changes sign; placed off the 2-degree scan
-	// grid it would be missed without explicit tangency detection.
-	test('earthLimbCircleIntersections detects an off-grid tangency with no sign change', () => {
-		const omega = 2
-		const theta0 = 0.05
-		const px = Math.cos(theta0)
-		const py = Math.sin(theta0) / omega
-		// Outward ellipse normal at P = grad(x^2 + (omega y)^2) = (2x, 2 omega^2 y), normalized.
-		const gradientX = 2 * px
-		const gradientY = 2 * omega * omega * py
-		const gradientLength = Math.hypot(gradientX, gradientY)
-		// Radius below the local radius of curvature (~0.25 near the vertex) so the circle is tangent from
-		// outside at exactly one point rather than cutting the ellipse twice.
-		const radius = 0.15
-		const cx = px + (radius * gradientX) / gradientLength
-		const cy = py + (radius * gradientY) / gradientLength
-
-		const crossings = earthLimbCircleIntersections(cx, cy, omega, radius)
-		expect(crossings).toHaveLength(1)
-		expect(Math.hypot(crossings[0][0] - px, crossings[0][1] - py)).toBeLessThan(0.02)
 	})
 })
 

--- a/tests/sun.eclipse.map.test.ts
+++ b/tests/sun.eclipse.map.test.ts
@@ -4,11 +4,11 @@ import { nearestSolarEclipse, type SolarEclipse, type SolarEclipseType } from '.
 // oxfmt-ignore
 import { BRANCH_MAX_DRAWABLE_GAP, centralAxisIntersectsEarth, computePolynomialBesselianElements, computeRiseSetCurves, computeSolarEclipseMapGeometry, evaluateBesselian, findCentralLineExtremePoint, findCircleIntersections, findCurvePoints, findEclipseCurvePoint, findMaximumPoint, findPenumbraContactPoints, intermediateGreatCircle, projectClosestEarthLimbPoint, projectFundamentalPoint, solarAltitudeAtPoint, solarEclipseMapToSvgPaths, splitAtMaxAbsLatitude, splitCentralLineByKind, splitDisconnectedPolylines, type SolarEclipseGeoBranch, type SolarEclipseGeoPoint, type PolynomialBesselianElements, type SolarEclipseMapGeometry } from '../src/sun.eclipse.map'
 import { DEG2RAD, PI, PIOVERTWO, TAU } from '../src/constants'
-import { DELTA_T_LONGITUDE_FACTOR, EARTH_E2, earthLimbExtremes, earthLimbOmega, type SunMoonPosition } from '../src/eclipse'
+import { DELTA_T_LONGITUDE_FACTOR, EARTH_E2, earthLimbExtremes, earthLimbOmega, sunMoonPosition, type SunMoonPosition } from '../src/eclipse'
 import { sphericalSeparation } from '../src/geometry'
 import { PlateCarree, type ProjectionOptions } from '../src/projection'
 import { time, Timescale, timeSubtract, timeYMD, toJulianDay } from '../src/time'
-import { catalogBranchRetraces, countKinks, endpointRetraces, geometryFor, interpolateAtJulianDay, limitTangencyResidual, longestProjectedSegment, maxBranchSegment, cachedSunMoonPosition as sunMoonPosition } from './eclipse.util'
+import { catalogBranchRetraces, countKinks, endpointRetraces, geometryFor, interpolateAtJulianDay, limitTangencyResidual, longestProjectedSegment, maxBranchSegment } from './eclipse.util'
 
 const JD0 = 2460409.25
 const TIME0 = time(JD0)


### PR DESCRIPTION
<img width="2520" height="1260" alt="lunar eclipse" src="https://github.com/user-attachments/assets/2cb5d429-1e10-4c7c-8c51-702f5b294b5d" />

Tabela de‑para entre o que `computeLocalLunarEclipseCircumstances` / `computeLocalLunarEclipseViewGeometry` retornam e cada elemento da tela do Astrarium. Conclusão antecipada: **está tudo coberto** (a nossa API é, na verdade, um superconjunto). O único ponto de atenção é o **fuso do horário** (devolvemos TT/JD; o Astrarium exibe UTC — a conversão é do consumidor).

## 1. Cabeçalho do painel

| Astrarium | Nebulosa | Obs. |
|---|---|---|
| `Locked point (19°48′28″S 28°28′35″E)` | `circumstances.location.longitude` / `.latitude` | radianos, longitude leste‑positiva |
| `visible` (status) | `circumstances.visibility.text` (+ `kind`, `hasObservableEclipse`) | nosso `text` é mais descritivo (`Partial (umbral) phase visible`, etc.) |
| — | `circumstances.visibility.hasGeometricEclipse` | extra (eclipse existe independente do horizonte) |

## 2. Tabela "Local Details" (colunas Instant / Time / Alt / P / Z)

| Coluna Astrarium | Nebulosa (`events[kind]`) | Obs. |
|---|---|---|
| Instant (`P1: Penumbral begins`, `U1: Partial begins`, `U2: Total begins`, `Max`, `U3`, `U4`, `P4`) | `events[kind].kind` | o rótulo textual é da UI; nós damos o `kind`. Contatos ausentes (U2/U3 num parcial) → chave `undefined` → linha em branco ✔ |
| Time (`01:25:08 UTC`) | `events[kind].time` (TT) + `events[kind].jd` | ⚠️ devolvemos **TT**; o Astrarium mostra **UTC** → converter TT→UTC na exibição |
| Alt (`+39.0°`) | `events[kind].altitude` | topocêntrica (paralaxe aplicada) ✔ |
| P (`261.5°`) | `events[kind].positionAngle` | ângulo do ponto de contato, N→E, com flip em U2/U3 ✔ |
| Z (`153.8°`) | `events[kind].zenithAngle` | `Z = P − ângulo paraláctico` ✔ |
| — | `events[kind].azimuth` | **extra** (a tabela do print não tem Az) |
| — | `events[kind].observable` | **extra** (acima/abaixo do horizonte no contato) |
| — | `events[kind].umbralMagnitude` / `penumbralMagnitude` | **extra** (magnitude por contato) |

## 3. Resumo de magnitudes/durações (parte do painel "Local Details", fora do recorte do print)

| Conceito Astrarium | Nebulosa (`details`) | Obs. |
|---|---|---|
| Magnitude umbral (eclipse mag.) | `details.maximalUmbralMagnitude` | `null` para penumbral ✔ |
| Magnitude penumbral | `details.maximalPenumbralMagnitude` | ✔ |
| Duração penumbral (P4−P1) | `details.penumbralPhaseDuration` | segundos |
| Duração parcial (U4−U1) | `details.partialPhaseDuration` | `null` se não houver fase umbral |
| Duração total (U3−U2) | `details.totalPhaseDuration` | `null` se não houver totalidade |
| — | `details.observableDuration` | **extra** (tempo com a Lua acima do horizonte) |

## 4. "Local View" (diagrama)

| Elemento Astrarium | Nebulosa (`computeLocalLunarEclipseViewGeometry`) | Obs. |
|---|---|---|
| Seletor `P1…P4` | `requestedEvent` / `selectedEvent` (opção `selectedEvent`) | ✔ |
| Toggle `Z` / `N` | opção `orientationMode: 'zenith' \| 'north'` | ✔ |
| Anel da penumbra (externo) | shape `role: 'penumbra'` | raio de `eclipse.rho` |
| Anel da umbra (interno) | shape `role: 'umbra'` | âncora de escala |
| Disco da Lua selecionado (Max, vermelho) | shape `role: 'moonDisk'` (com `event`) | ✔ |
| Discos "fantasma" (P1/U1/U4/P4 cinza) | shape `role: 'ghostMoonDisk'` | opção `includeGhostDisks` |
| Linha da trajetória da Lua | shape `role: 'trajectoryPath'` | ✔ |
| Faixa verde (abaixo do horizonte) | shape `role: 'horizonBand'` | opção `includeHorizon` |
| Linha do horizonte | shape `role: 'horizonLine'` | posicionada por `horizonAltitude` ✔ |
| — | opção `handedness: 'eastRight' \| 'eastLeft'` | **extra** (convenção céu/mapa) |

## Conclusão

- **Cobertura completa** de tudo que a tela do Astrarium exibe (cabeçalho, tabela Instant/Time/Alt/P/Z, diagrama com anéis/discos/horizonte/orientação).
- **Único ajuste de consumo:** os horários saem em **TT** (`time`/`jd`); para reproduzir a coluna "UTC" do Astrarium, o chamador converte TT→UTC.
- **Extras nossos** (não mostrados nesse print, úteis como referência): `azimuth`, `observable` e magnitudes por contato, `observableDuration`, `handedness`, e classificações de visibilidade mais granulares.
