### PR TITLE
Focuser Backlash Calibration

### DIFF
--- a/src/devices/indi/simulator/camera.ts
+++ b/src/devices/indi/simulator/camera.ts
@@ -26,6 +26,7 @@ import { findOnSwitch, makeBlobVector, makeNumberVector, makeSwitchVector, makeT
 import type { ClientSimulator } from './client'
 import { CAMERA_AMBIENT_TEMPERATURE, CAMERA_BLOB_PADDING, CAMERA_DEFAULT_TARGET_TEMPERATURE, CAMERA_MAX_BIN, CAMERA_MAX_EXPOSURE, CAMERA_MIN_EXPOSURE, CAMERA_PIXEL_SIZE, CAMERA_SCENE_SEED, CAMERA_SENSOR_HEIGHT, CAMERA_SENSOR_WIDTH, GENERAL_INFO, MAIN_CONTROL, SIMULATION, TICK_INTERVAL_MS } from './constants'
 import { DeviceSimulator } from './device'
+import { FocuserSimulator } from './focuser'
 import type { CatalogSource, CatalogSourceStar, CatalogSourceType, DeviceSimulatorOptions, ReadoutMode, SimulatorProperty, TransferFormat } from './types'
 import { applyExclusiveSwitchValues, applyMultiSwitchValues, applyNumberVectorValues } from './util'
 
@@ -232,6 +233,14 @@ export class CameraSimulator extends DeviceSimulator {
 	get activeFocuser() {
 		const focuser = this.#focuserManager?.get(this.client, this.snoopDevices.elements.ACTIVE_FOCUSER.value)
 		return focuser?.connected ? focuser : undefined
+	}
+
+	// Resolves the optical position for a simulated focuser, falling back to its reported motor position.
+	#focusPosition() {
+		const focuser = this.activeFocuser
+		if (!focuser) return undefined
+		const simulator = this.client.get(focuser.name)
+		return simulator instanceof FocuserSimulator ? simulator.effectivePosition : focuser.position.value
 	}
 
 	get activeRotator() {
@@ -726,7 +735,7 @@ export class CameraSimulator extends DeviceSimulator {
 		const pattern = this.#collimationPattern.elements
 		const shape = this.#aberrationShape.elements
 		const focusRange = this.#aberrationFocus.elements.FOCUS_RANGE.value
-		const currentFocus = this.activeFocuser?.position.value ?? this.#plotOptions.elements.FOCUS_STEP.value
+		const currentFocus = this.#focusPosition() ?? this.#plotOptions.elements.FOCUS_STEP.value
 		const bestFocus = this.#plotOptions.elements.BEST_FOCUS.value
 		const globalDefocus = bestFocus === 0 ? 0 : clamp(Math.abs(currentFocus - bestFocus) / focusRange, 0, 1)
 		const obstructionRatio = pattern.OBSTRUCTION_RATIO.value
@@ -975,7 +984,7 @@ export class CameraSimulator extends DeviceSimulator {
 		return {
 			background: this.#plotOptions.elements.BACKGROUND.value,
 			saturationLevel: this.#plotFlags.elements.SATURATION_ENABLED.value ? this.#plotOptions.elements.SATURATION_LEVEL.value : undefined,
-			focusStep: this.activeFocuser?.position.value ?? this.#plotOptions.elements.FOCUS_STEP.value,
+			focusStep: this.#focusPosition() ?? this.#plotOptions.elements.FOCUS_STEP.value,
 			bestFocus: this.#plotOptions.elements.BEST_FOCUS.value,
 			maxFocusStep: this.activeFocuser?.position.max || undefined,
 			peakScale: this.#plotOptions.elements.PEAK_SCALE.value,
@@ -1048,7 +1057,7 @@ export class CameraSimulator extends DeviceSimulator {
 		const sinAngle = rotate ? Math.sin(rotatorAngle) : 0
 		const cosAngle = rotate ? Math.cos(rotatorAngle) : 1
 		const aberration = this.#makeAberrationConfig()
-		const currentFocus = this.activeFocuser?.position.value ?? this.#plotOptions.elements.FOCUS_STEP.value
+		const currentFocus = this.#focusPosition() ?? this.#plotOptions.elements.FOCUS_STEP.value
 		const bestFocus = this.#plotOptions.elements.BEST_FOCUS.value
 		const annularRadius = this.#plotPsfModel.elements.ANNULAR.value ? this.#collimationPattern.elements.MAX_RADIUS.value : 0
 		const annularSoftness = this.#plotPsfModel.elements.ANNULAR.value ? this.#collimationPattern.elements.EDGE_SOFTNESS.value * 8 : 0

--- a/src/devices/indi/simulator/client.ts
+++ b/src/devices/indi/simulator/client.ts
@@ -38,6 +38,11 @@ export class ClientSimulator implements Client {
 		for (const device of this.#devices.values()) device.name === vector.device && device.sendSwitch(vector)
 	}
 
+	// Returns the simulator registered under a device name, when available.
+	get(name: string) {
+		return this.#devices.get(name)
+	}
+
 	// Registers/unregisters a device simulator under its name.
 	register(device: DeviceSimulator) {
 		this.#devices.set(device.name, device)

--- a/src/devices/indi/simulator/focuser.ts
+++ b/src/devices/indi/simulator/focuser.ts
@@ -1,19 +1,31 @@
 import { TAU } from '../../../core/constants'
+import { validateInRange } from '../../../core/validation'
 import { clamp } from '../../../math/numerical/math'
 import { normalizeAngle } from '../../../math/units/angle'
 import type { IndiClientHandler } from '../client'
 import { DeviceInterfaceType } from '../device'
 import { makeNumberVector, makeSwitchVector, type NewNumberVector, type NewSwitchVector } from '../types'
 import type { ClientSimulator } from './client'
-import { CAMERA_AMBIENT_TEMPERATURE, FOCUSER_INITIAL_POSITION, FOCUSER_MAX_POSITION, FOCUSER_MOVE_RATE, FOCUSER_TEMPERATURE_AMPLITUDE, FOCUSER_TEMPERATURE_COMPENSATION_HYSTERESIS, FOCUSER_TEMPERATURE_COMPENSATION_STEPS, FOCUSER_TEMPERATURE_PERIOD_SECONDS, MAIN_CONTROL, TICK_INTERVAL_MS } from './constants'
+import { CAMERA_AMBIENT_TEMPERATURE, FOCUSER_INITIAL_POSITION, FOCUSER_MAX_POSITION, FOCUSER_MOVE_RATE, FOCUSER_TEMPERATURE_AMPLITUDE, FOCUSER_TEMPERATURE_COMPENSATION_HYSTERESIS, FOCUSER_TEMPERATURE_COMPENSATION_STEPS, FOCUSER_TEMPERATURE_PERIOD_SECONDS, MAIN_CONTROL, SIMULATION, TICK_INTERVAL_MS } from './constants'
 import { DeviceSimulator } from './device'
 import type { DeviceSimulatorOptions, SimulatorProperty } from './types'
-import { applyExclusiveSwitchValues } from './util'
+import { applyExclusiveSwitchValues, applyNumberVectorValues } from './util'
 
-// Simulated focuser motion, ambient temperature, and temperature compensation.
+// Simulated focuser motion, mechanical backlash, ambient temperature, and temperature compensation.
+
+// Direction of motor travel, with zero denoting a mechanism that has not yet engaged either side.
+type FocuserAxisDirection = -1 | 0 | 1
+
+// Configures persistence and direction-dependent lost motion for a simulated focuser.
+export interface FocuserSimulatorOptions extends DeviceSimulatorOptions {
+	// Motor travel in steps consumed before effective motion resumes in the inward/decreasing direction.
+	readonly backlashIn?: number
+	// Motor travel in steps consumed before effective motion resumes in the outward/increasing direction.
+	readonly backlashOut?: number
+}
 
 // Simulated focuser. Models absolute/relative moves at a fixed rate, reverse, a sinusoidal temperature,
-// and temperature compensation, advancing the position each tick.
+// direction-dependent backlash, and temperature compensation, advancing the position each tick.
 export class FocuserSimulator extends DeviceSimulator {
 	readonly type = 'focuser'
 
@@ -25,23 +37,29 @@ export class FocuserSimulator extends DeviceSimulator {
 	readonly #sync = makeNumberVector('', 'FOCUS_SYNC', 'Sync', MAIN_CONTROL, 'rw', ['FOCUS_SYNC_VALUE', 'Position', FOCUSER_INITIAL_POSITION, 0, FOCUSER_MAX_POSITION, 1, '%.0f'])
 	readonly #temperature = makeNumberVector('', 'FOCUS_TEMPERATURE', 'Temperature', MAIN_CONTROL, 'ro', ['TEMPERATURE', 'Temperature', CAMERA_AMBIENT_TEMPERATURE, -50, 70, 0.1, '%6.2f'])
 	readonly #temperatureCompensation = makeSwitchVector('', 'FOCUS_TEMPERATURE_COMPENSATION', 'Temperature Compensation', MAIN_CONTROL, 'OneOfMany', 'rw', ['INDI_ENABLED', 'On', false], ['INDI_DISABLED', 'Off', true])
+	readonly #backlash = makeNumberVector('', 'SIMULATOR_BACKLASH', 'Backlash', SIMULATION, 'rw', ['BACKLASH_IN', 'In (steps)', 0, 0, FOCUSER_MAX_POSITION, 1, '%.0f'], ['BACKLASH_OUT', 'Out (steps)', 0, 0, FOCUSER_MAX_POSITION, 1, '%.0f'])
 
-	protected readonly properties: readonly SimulatorProperty[] = [this.#position, this.#relativePosition, this.#motion, this.#abort, this.#reverse, this.#sync, this.#temperature, this.#temperatureCompensation]
-	protected propertiesToNotSave: readonly SimulatorProperty[] = this.properties.filter((e) => e !== this.#reverse && e !== this.#motion)
+	protected readonly properties: readonly SimulatorProperty[] = [this.#position, this.#relativePosition, this.#motion, this.#abort, this.#reverse, this.#sync, this.#temperature, this.#temperatureCompensation, this.#backlash]
+	protected propertiesToNotSave: readonly SimulatorProperty[] = this.properties.filter((e) => e !== this.#reverse && e !== this.#motion && e !== this.#backlash)
 
 	#timer?: NodeJS.Timeout
 	#lastTick = 0
 	#targetPosition?: number
+	#effectivePosition = FOCUSER_INITIAL_POSITION
+	#engagedDirection: FocuserAxisDirection = 0
+	#slackTravel = 0
 	#temperaturePhase = 0
 	#lastCompensationTemperature = CAMERA_AMBIENT_TEMPERATURE
 
 	constructor(
 		name: string,
 		client: ClientSimulator,
-		readonly options?: DeviceSimulatorOptions,
+		readonly options?: FocuserSimulatorOptions,
 		handler: IndiClientHandler = client.handler,
 	) {
 		super(name, client, handler, DeviceInterfaceType.FOCUSER)
+		this.#backlash.elements.BACKLASH_IN.value = validateInRange(options?.backlashIn ?? 0, 0, FOCUSER_MAX_POSITION)
+		this.#backlash.elements.BACKLASH_OUT.value = validateInRange(options?.backlashOut ?? 0, 0, FOCUSER_MAX_POSITION)
 
 		for (const property of this.properties) {
 			property.device = name
@@ -53,6 +71,21 @@ export class FocuserSimulator extends DeviceSimulator {
 	// Current absolute position (steps).
 	get position() {
 		return this.#position.elements.FOCUS_ABSOLUTE_POSITION.value
+	}
+
+	// Current effective optical position after mechanical backlash is applied, in steps.
+	get effectivePosition() {
+		return this.#effectivePosition
+	}
+
+	// Configured lost motion before effective inward/decreasing travel resumes, in steps.
+	get backlashIn() {
+		return this.#backlash.elements.BACKLASH_IN.value
+	}
+
+	// Configured lost motion before effective outward/increasing travel resumes, in steps.
+	get backlashOut() {
+		return this.#backlash.elements.BACKLASH_OUT.value
 	}
 
 	// Whether a move is in progress.
@@ -81,6 +114,13 @@ export class FocuserSimulator extends DeviceSimulator {
 				return
 			case 'FOCUS_SYNC':
 				if (vector.elements.FOCUS_SYNC_VALUE !== undefined) this.syncTo(vector.elements.FOCUS_SYNC_VALUE)
+				return
+			case 'SIMULATOR_BACKLASH':
+				if (applyNumberVectorValues(this.#backlash, vector.elements)) {
+					this.#engagedDirection = 0
+					this.#slackTravel = 0
+					this.notify(this.#backlash)
+				}
 		}
 	}
 
@@ -173,6 +213,9 @@ export class FocuserSimulator extends DeviceSimulator {
 		position = clamp(position, this.#position.elements.FOCUS_ABSOLUTE_POSITION.min, this.#position.elements.FOCUS_ABSOLUTE_POSITION.max)
 		this.#sync.elements.FOCUS_SYNC_VALUE.value = position
 		this.#position.elements.FOCUS_ABSOLUTE_POSITION.value = position
+		this.#effectivePosition = position
+		this.#engagedDirection = 0
+		this.#slackTravel = 0
 		this.#relativePosition.elements.FOCUS_RELATIVE_POSITION.value = 0
 		this.stop(false)
 		this.notify(this.#sync)
@@ -211,6 +254,7 @@ export class FocuserSimulator extends DeviceSimulator {
 		const step = FOCUSER_MOVE_RATE * dtSeconds
 
 		if (Math.abs(delta) <= step) {
+			this.#advanceEffectivePosition(delta)
 			this.#position.elements.FOCUS_ABSOLUTE_POSITION.value = this.#targetPosition
 			this.#relativePosition.elements.FOCUS_RELATIVE_POSITION.value = 0
 			this.#targetPosition = undefined
@@ -221,10 +265,45 @@ export class FocuserSimulator extends DeviceSimulator {
 		}
 
 		const next = current + Math.sign(delta) * step
+		this.#advanceEffectivePosition(next - current)
 		this.#position.elements.FOCUS_ABSOLUTE_POSITION.value = next
 		this.#relativePosition.elements.FOCUS_RELATIVE_POSITION.value = Math.abs(this.#targetPosition - next)
 		this.notify(this.#position)
 		this.notify(this.#relativePosition)
+	}
+
+	// Applies signed motor travel to the effective position while preserving partially consumed slack.
+	#advanceEffectivePosition(travel: number) {
+		if (travel === 0) return
+
+		const direction = Math.sign(travel) as Exclude<FocuserAxisDirection, 0>
+		let remaining = Math.abs(travel)
+
+		if (this.#engagedDirection === 0) {
+			this.#engagedDirection = direction
+			this.#effectivePosition = clamp(this.#effectivePosition + travel, this.#position.elements.FOCUS_ABSOLUTE_POSITION.min, this.#position.elements.FOCUS_ABSOLUTE_POSITION.max)
+			return
+		}
+
+		if (direction === this.#engagedDirection) {
+			const recovered = Math.min(remaining, this.#slackTravel)
+			this.#slackTravel -= recovered
+			remaining -= recovered
+			if (remaining > 0) this.#effectivePosition += direction * remaining
+		} else {
+			const backlash = direction < 0 ? this.backlashIn : this.backlashOut
+			const consumed = Math.min(remaining, Math.max(0, backlash - this.#slackTravel))
+			this.#slackTravel += consumed
+			remaining -= consumed
+
+			if (this.#slackTravel >= backlash) {
+				this.#engagedDirection = direction
+				this.#slackTravel = 0
+				if (remaining > 0) this.#effectivePosition += direction * remaining
+			}
+		}
+
+		this.#effectivePosition = clamp(this.#effectivePosition, this.#position.elements.FOCUS_ABSOLUTE_POSITION.min, this.#position.elements.FOCUS_ABSOLUTE_POSITION.max)
 	}
 
 	// Updates the moving state reflected by both focuser motion vectors.

--- a/src/observation/focus/backlash.calibration.ts
+++ b/src/observation/focus/backlash.calibration.ts
@@ -755,6 +755,7 @@ export class BacklashCalibration {
 
 		const delta = position - this.#currentPosition
 		if (delta === 0 || Math.sign(delta) !== directionSign(pending.direction)) return this.#fail('axisStalled')
+		if (Math.abs(delta) > Math.abs(pending.relative)) return this.#fail('invalidPosition')
 
 		this.#currentPosition = position
 		if (this.#state === 'preloading') this.#preloadTraveled += Math.abs(delta)

--- a/src/observation/focus/backlash.calibration.ts
+++ b/src/observation/focus/backlash.calibration.ts
@@ -1,0 +1,921 @@
+import { medianAbsoluteDeviationOf, medianOf, percentileOf } from '../../core/util'
+import { validateFinite, validatePositiveFinite, validatePositiveInteger } from '../../core/validation'
+import { robustLinearLeastSquares, type RobustLinearLeastSquaresResult } from '../../math/numerical/least.squares'
+import { goldenSectionSearch } from '../../math/numerical/optimization'
+import type { BacklashCompensation, BacklashCompensationMode } from './backlash'
+
+// Deterministic focuser-backlash calibration from caller-supplied positions and scalar measurements.
+// The module contains only synchronous numerical fitting and command/event state transitions. Positions,
+// movement distances, breakpoints, and uncertainties are focuser steps; metric units are caller-defined.
+
+// Direction of focuser counter travel, independent of driver-specific IN/OUT naming.
+export type FocusAxisDirection = 'increasing' | 'decreasing'
+
+// Observable phase of a backlash-calibration run.
+export type BacklashCalibrationState = 'idle' | 'preloading' | 'probing' | 'completed' | 'failed' | 'cancelled'
+
+// Typed operational or numerical reason for a failed calibration or directional run.
+export type BacklashCalibrationFailureReason = 'invalidEvent' | 'invalidPosition' | 'invalidSample' | 'positionLimit' | 'axisStalled' | 'insufficientSlope' | 'breakpointNotFound' | 'maximumDistanceReached' | 'insufficientValidRuns' | 'unstableResult'
+
+// Caller-facing configuration for directional preload, sampling, fitting, repetition, and limits.
+export interface BacklashCalibrationOptions {
+	// Requested movement increment, in focuser steps.
+	readonly probeStep: number
+	// Distance traveled opposite the measured direction before each reversal, in steps.
+	readonly preloadDistance: number
+	// Maximum counter travel after one reversal, in steps.
+	readonly maximumProbeDistance: number
+	// Minimum accepted absolute metric slope per focuser step.
+	readonly minimumSlope: number
+	// Number of runs per direction; defaults to 3 and must be at least 3.
+	readonly repeats?: number
+	// Measurements aggregated at each position; defaults to 3.
+	readonly samplesPerPosition?: number
+	// Tail preload points used to verify local slope; defaults to 4.
+	readonly minimumPreloadPoints?: number
+	// Points at or before a positive breakpoint, including the baseline; defaults to 2.
+	readonly minimumPlateauPoints?: number
+	// Points required beyond a breakpoint; defaults to 3.
+	readonly minimumPostBreakPoints?: number
+	// Maximum spread of a stable breakpoint window, in steps; defaults to probeStep.
+	readonly breakpointTolerance?: number
+	// Consecutive valid fits required for early completion; defaults to 3.
+	readonly stabilityCount?: number
+	// Dimensionless Huber tuning constant forwarded to robust least squares; defaults to 1.345.
+	readonly huberTuning?: number
+	// Optional inclusive lower focuser limit, in steps.
+	readonly minimumPosition?: number
+	// Optional inclusive upper focuser limit, in steps.
+	readonly maximumPosition?: number
+	// Multiplier used for the shared overshoot recommendation; defaults to 1.5.
+	readonly safetyFactor?: number
+}
+
+// One position-level aggregate used by the breakpoint fit.
+export interface BacklashProbePoint {
+	// Actual counter position reported by the caller, in focuser steps.
+	readonly position: number
+	// Absolute counter travel from the reversal position, in steps.
+	readonly traveled: number
+	// Median scalar metric at this position.
+	readonly value: number
+	// Non-normalized MAD of the samples at this position, in metric units.
+	readonly dispersion: number
+	// Number of raw measurements represented by this point.
+	readonly sampleCount: number
+}
+
+// Numerical requirements for fitting the continuous hinge model.
+export interface BacklashFitOptions {
+	// Nominal sampling resolution, in focuser steps.
+	readonly probeStep: number
+	// Points required at or before a positive breakpoint.
+	readonly minimumPlateauPoints: number
+	// Points required after the breakpoint.
+	readonly minimumPostBreakPoints: number
+	// Minimum accepted absolute metric slope per focuser step.
+	readonly minimumSlope: number
+	// Dimensionless Huber tuning constant.
+	readonly huberTuning: number
+}
+
+// Outcome of fitting m(x) = intercept + slope * max(0, x - breakpoint).
+export interface BacklashFit {
+	// Whether all reported numeric fields form an accepted fit.
+	readonly valid: boolean
+	// Numerical failure category when valid is false.
+	readonly reason?: 'insufficientData' | 'insufficientSlope' | 'singularFit'
+	// Estimated backlash, in focuser steps.
+	readonly breakpoint?: number
+	// Plateau metric value.
+	readonly intercept?: number
+	// Post-breakpoint metric change per focuser step.
+	readonly slope?: number
+	// Mean normalized Huber loss.
+	readonly loss?: number
+	// Robust weighted RMSE normalized by the response scale.
+	readonly nrmse?: number
+	// Profile-loss breakpoint uncertainty, in focuser steps.
+	readonly uncertainty?: number
+	// Number of consolidated points at or before the breakpoint.
+	readonly plateauPointCount: number
+	// Number of consolidated points after the breakpoint.
+	readonly postBreakpointPointCount: number
+}
+
+// Result of one preload-and-reversal measurement in a single direction.
+export interface BacklashRunResult {
+	// Direction measured after the reversal.
+	readonly direction: FocusAxisDirection
+	// Whether the run produced an accepted stable breakpoint.
+	readonly valid: boolean
+	// Run-local failure when valid is false.
+	readonly failureReason?: BacklashCalibrationFailureReason
+	// Unrounded fitted backlash, in focuser steps.
+	readonly steps?: number
+	// Breakpoint uncertainty, in focuser steps.
+	readonly uncertainty?: number
+	// Post-breakpoint metric slope per focuser step.
+	readonly slope?: number
+	// Metric slope per focuser step measured during the opposite-direction preload.
+	readonly preloadSlope?: number
+	// Normalized robust fit error.
+	readonly nrmse?: number
+	// Probe points retained for diagnostics; the first point is the reversal baseline.
+	readonly points: readonly BacklashProbePoint[]
+}
+
+// Robust aggregate of all attempted runs for one direction.
+export interface BacklashDirectionResult {
+	// Aggregated direction.
+	readonly direction: FocusAxisDirection
+	// Rounded median backlash, in focuser steps.
+	readonly steps: number
+	// Non-normalized MAD of valid run breakpoints, in steps.
+	readonly dispersion: number
+	// Combined within-run and between-run uncertainty, in steps.
+	readonly uncertainty: number
+	// Number of accepted runs.
+	readonly validRunCount: number
+	// Number of attempted runs.
+	readonly totalRunCount: number
+	// All attempted runs in execution order.
+	readonly runs: readonly BacklashRunResult[]
+}
+
+// Final two-direction calibration and its conservative shared overshoot recommendation.
+export interface BacklashCalibrationResult {
+	// Aggregate for reversals into increasing counter positions.
+	readonly increasing: BacklashDirectionResult
+	// Aggregate for reversals into decreasing counter positions.
+	readonly decreasing: BacklashDirectionResult
+	// Shared overshoot recommendation, in integer focuser steps.
+	readonly recommendedOvershoot: number
+	// Combined confidence in the range [0, 1].
+	readonly confidence: number
+	// Quality tier derived exclusively from confidence.
+	readonly quality: 'good' | 'marginal' | 'poor'
+}
+
+// Command emitted by the synchronous calibration machine.
+export type BacklashCalibrationCommand =
+	| { readonly type: 'move'; readonly relative: number; readonly direction: FocusAxisDirection }
+	| { readonly type: 'measure'; readonly sampleIndex: number; readonly sampleCount: number }
+	| { readonly type: 'completed'; readonly result: BacklashCalibrationResult }
+	| { readonly type: 'failed'; readonly reason: BacklashCalibrationFailureReason; readonly direction?: FocusAxisDirection }
+	| { readonly type: 'cancelled' }
+
+// Event supplied after executing the latest command.
+export type BacklashCalibrationEvent = { readonly type: 'moved'; readonly position: number } | { readonly type: 'measured'; readonly position: number; readonly value: number } | { readonly type: 'cancel' }
+
+// Fully resolved options used internally after public defaults and validation.
+interface NormalizedBacklashCalibrationOptions {
+	// Requested movement increment, in focuser steps.
+	readonly probeStep: number
+	// Opposite-direction preload distance, in focuser steps.
+	readonly preloadDistance: number
+	// Maximum post-reversal travel, in focuser steps.
+	readonly maximumProbeDistance: number
+	// Minimum accepted absolute metric slope per step.
+	readonly minimumSlope: number
+	// Runs attempted per direction.
+	readonly repeats: number
+	// Measurements aggregated at each position.
+	readonly samplesPerPosition: number
+	// Preload tail points used for slope validation.
+	readonly minimumPreloadPoints: number
+	// Minimum points at or before a positive breakpoint.
+	readonly minimumPlateauPoints: number
+	// Minimum points after a breakpoint.
+	readonly minimumPostBreakPoints: number
+	// Stable-window spread tolerance, in steps.
+	readonly breakpointTolerance: number
+	// Breakpoints retained in the stable window.
+	readonly stabilityCount: number
+	// Dimensionless Huber tuning constant.
+	readonly huberTuning: number
+	// Optional inclusive lower counter limit, in steps.
+	readonly minimumPosition?: number
+	// Optional inclusive upper counter limit, in steps.
+	readonly maximumPosition?: number
+	// Overshoot recommendation multiplier.
+	readonly safetyFactor: number
+}
+
+// Internal accepted fit including residual data needed for selection and uncertainty.
+interface CandidateFit {
+	// Evaluated breakpoint, in focuser steps.
+	readonly breakpoint: number
+	// Plateau metric value.
+	readonly intercept: number
+	// Post-breakpoint metric slope per step.
+	readonly slope: number
+	// Mean normalized Huber loss.
+	readonly loss: number
+	// Robust weighted normalized RMSE.
+	readonly nrmse: number
+	// Points at or before the breakpoint.
+	readonly plateauPointCount: number
+	// Points after the breakpoint.
+	readonly postBreakpointPointCount: number
+}
+
+// Reason an individual breakpoint candidate could not be accepted.
+type CandidateFailure = 'insufficientData' | 'insufficientSlope' | 'singularFit'
+
+// Candidate evaluation used to retain failure information without non-finite sentinels.
+type CandidateEvaluation = { readonly fit: CandidateFit } | { readonly failure: CandidateFailure }
+
+// Default runs attempted per direction.
+const DEFAULT_REPEATS = 3
+
+// Default raw measurements aggregated at each position.
+const DEFAULT_SAMPLES_PER_POSITION = 3
+
+// Default preload tail length for slope validation.
+const DEFAULT_MINIMUM_PRELOAD_POINTS = 4
+
+// Default plateau support for positive-breakpoint models.
+const DEFAULT_MINIMUM_PLATEAU_POINTS = 2
+
+// Default post-breakpoint support.
+const DEFAULT_MINIMUM_POST_BREAK_POINTS = 3
+
+// Default stable breakpoint window length.
+const DEFAULT_STABILITY_COUNT = 3
+
+// Standard Huber tuning constant for approximately Gaussian residuals.
+const DEFAULT_HUBER_TUNING = 1.345
+
+// Default conservative multiplier for a shared overshoot recommendation.
+const DEFAULT_SAFETY_FACTOR = 1.5
+
+// Gaussian-consistent multiplier for a raw median absolute deviation.
+const NORMALIZED_MAD_SCALE = 1.4826
+
+// Number of equal profile-loss intervals sampled for breakpoint uncertainty.
+const UNCERTAINTY_PROFILE_INTERVALS = 32
+
+// Returns an invalid fit without fabricating numeric output fields.
+function invalidFit(reason: BacklashFit['reason'], plateauPointCount = 0, postBreakpointPointCount = 0): BacklashFit {
+	return { valid: false, reason, plateauPointCount, postBreakpointPointCount }
+}
+
+// Consolidates valid equal-distance points without mutating caller-owned arrays.
+function consolidateProbePoints(points: readonly BacklashProbePoint[]) {
+	const valid: BacklashProbePoint[] = []
+
+	for (let i = 0; i < points.length; i++) {
+		const point = points[i]
+		if (Number.isFinite(point.position) && Number.isFinite(point.traveled) && point.traveled >= 0 && Number.isFinite(point.value) && Number.isFinite(point.dispersion) && point.dispersion >= 0 && Number.isInteger(point.sampleCount) && point.sampleCount > 0) {
+			valid.push(point)
+		}
+	}
+
+	valid.sort((a, b) => a.traveled - b.traveled || a.position - b.position)
+	const consolidated: BacklashProbePoint[] = []
+
+	for (let start = 0; start < valid.length;) {
+		let end = start + 1
+		while (end < valid.length && valid[end].traveled === valid[start].traveled) end++
+
+		if (end - start === 1) {
+			consolidated.push({ ...valid[start] })
+		} else {
+			const count = end - start
+			const positions = new Float64Array(count)
+			const values = new Float64Array(count)
+			const dispersions = new Float64Array(count)
+			let sampleCount = 0
+
+			for (let i = 0; i < count; i++) {
+				const point = valid[start + i]
+				positions[i] = point.position
+				values[i] = point.value
+				dispersions[i] = point.dispersion
+				sampleCount += point.sampleCount
+			}
+
+			positions.sort()
+			values.sort()
+			dispersions.sort()
+			const value = medianOf(values)
+			const betweenPointMad = medianAbsoluteDeviationOf(values, value, false)
+			consolidated.push({ position: medianOf(positions), traveled: valid[start].traveled, value, dispersion: Math.max(betweenPointMad, medianOf(dispersions)), sampleCount })
+		}
+
+		start = end
+	}
+
+	return consolidated
+}
+
+// Validates the standalone fitting contract before allocating candidate matrices.
+function validateFitOptions(options: Readonly<BacklashFitOptions>) {
+	validatePositiveFinite(options.probeStep)
+	validatePositiveInteger(options.minimumPlateauPoints)
+	validatePositiveInteger(options.minimumPostBreakPoints)
+	validatePositiveFinite(options.minimumSlope)
+	validatePositiveFinite(options.huberTuning)
+}
+
+// Computes mean Huber loss against one response scale shared by every breakpoint candidate.
+function normalizedHuberLoss(result: RobustLinearLeastSquaresResult, tuning: number, responseScale: number) {
+	let loss = 0
+
+	for (let i = 0; i < result.residuals.length; i++) {
+		const normalized = Math.abs(result.residuals[i]) / responseScale
+		loss += normalized <= tuning ? 0.5 * normalized * normalized : tuning * (normalized - 0.5 * tuning)
+	}
+
+	return loss / result.residuals.length
+}
+
+// Evaluates one fixed-breakpoint hinge model with the shared robust least-squares primitive.
+function evaluateBreakpoint(points: readonly BacklashProbePoint[], breakpoint: number, options: Readonly<BacklashFitOptions>): CandidateEvaluation {
+	let plateauPointCount = 0
+	let postBreakpointPointCount = 0
+
+	for (let i = 0; i < points.length; i++) {
+		if (points[i].traveled <= breakpoint) plateauPointCount++
+		else postBreakpointPointCount++
+	}
+
+	if (postBreakpointPointCount < options.minimumPostBreakPoints || (breakpoint > 0 && plateauPointCount < options.minimumPlateauPoints)) return { failure: 'insufficientData' }
+
+	const design: [number, number][] = new Array(points.length)
+	const values = new Float64Array(points.length)
+
+	for (let i = 0; i < points.length; i++) {
+		design[i] = [1, Math.max(0, points[i].traveled - breakpoint)]
+		values[i] = points[i].value
+	}
+
+	let result: RobustLinearLeastSquaresResult
+
+	try {
+		result = robustLinearLeastSquares(design, values, { method: 'huber', tuning: options.huberTuning })
+	} catch {
+		return { failure: 'singularFit' }
+	}
+
+	const intercept = result.coefficients[0]
+	const slope = result.coefficients[1]
+	if (result.rankDeficient || !Number.isFinite(intercept) || !Number.isFinite(slope)) return { failure: 'singularFit' }
+	if (Math.abs(slope) < options.minimumSlope) return { failure: 'insufficientSlope' }
+
+	let weightedSquaredError = 0
+	let weightSum = 0
+
+	for (let i = 0; i < result.residuals.length; i++) {
+		const weight = result.weights[i]
+		weightedSquaredError += weight * result.residuals[i] * result.residuals[i]
+		weightSum += weight
+	}
+
+	values.sort()
+	const interquartileRange = percentileOf(values, 0.75) - percentileOf(values, 0.25)
+	const lossScale = Math.max(interquartileRange, options.minimumSlope * options.probeStep, Number.EPSILON)
+	const responseScale = Math.max(interquartileRange, Math.abs(slope) * options.probeStep, Number.EPSILON)
+	const loss = normalizedHuberLoss(result, options.huberTuning, lossScale)
+	const nrmse = Math.sqrt(weightedSquaredError / weightSum) / responseScale
+	if (!Number.isFinite(loss) || !Number.isFinite(nrmse)) return { failure: 'singularFit' }
+
+	return { fit: { breakpoint, intercept, slope, loss, nrmse, plateauPointCount, postBreakpointPointCount } }
+}
+
+// Compares finite candidate losses with a deterministic smaller-breakpoint tie break.
+function isBetterCandidate(candidate: CandidateFit, best: CandidateFit | undefined) {
+	if (best === undefined) return true
+	const tolerance = Number.EPSILON * 16 * Math.max(1, Math.abs(candidate.loss), Math.abs(best.loss))
+	return candidate.loss < best.loss - tolerance || (Math.abs(candidate.loss - best.loss) <= tolerance && candidate.breakpoint < best.breakpoint)
+}
+
+// Requires a loss reduction beyond floating-point comparison noise for optional refinement.
+function improvesCandidateLoss(candidate: CandidateFit, best: CandidateFit) {
+	const tolerance = Number.EPSILON * 16 * Math.max(1, Math.abs(candidate.loss), Math.abs(best.loss))
+	return candidate.loss < best.loss - tolerance
+}
+
+// Samples a bounded local loss profile and returns its half-width above the minimum.
+function breakpointUncertainty(points: readonly BacklashProbePoint[], fit: CandidateFit, min: number, max: number, options: Readonly<BacklashFitOptions>) {
+	const threshold = fit.loss + 1 / points.length
+	let lower = fit.breakpoint
+	let upper = fit.breakpoint
+
+	if (max > min) {
+		for (let i = 0; i <= UNCERTAINTY_PROFILE_INTERVALS; i++) {
+			const breakpoint = min + ((max - min) * i) / UNCERTAINTY_PROFILE_INTERVALS
+			const evaluation = evaluateBreakpoint(points, breakpoint, options)
+			if ('fit' in evaluation && evaluation.fit.loss <= threshold) {
+				lower = Math.min(lower, breakpoint)
+				upper = Math.max(upper, breakpoint)
+			}
+		}
+	}
+
+	return Math.max(options.probeStep * 0.5, (upper - lower) * 0.5)
+}
+
+// Fits a robust continuous plateau-plus-line breakpoint without mutating input points.
+export function fitBacklashBreakpoint(points: readonly BacklashProbePoint[], options: Readonly<BacklashFitOptions>): BacklashFit {
+	validateFitOptions(options)
+	const consolidated = consolidateProbePoints(points)
+	if (consolidated.length < options.minimumPostBreakPoints + 1) return invalidFit('insufficientData')
+
+	const breakpoints: number[] = [0]
+	for (let i = 0; i < consolidated.length - 1; i++) {
+		const traveled = consolidated[i].traveled
+		if (traveled > 0 && traveled !== breakpoints.at(-1)) breakpoints.push(traveled)
+	}
+
+	let best: CandidateFit | undefined
+	let sawInsufficientSlope = false
+	let sawSingularFit = false
+
+	for (let i = 0; i < breakpoints.length; i++) {
+		const evaluation = evaluateBreakpoint(consolidated, breakpoints[i], options)
+		if ('fit' in evaluation) {
+			if (isBetterCandidate(evaluation.fit, best)) best = evaluation.fit
+		} else if (evaluation.failure === 'insufficientSlope') {
+			sawInsufficientSlope = true
+		} else if (evaluation.failure === 'singularFit') {
+			sawSingularFit = true
+		}
+	}
+
+	if (best === undefined) return invalidFit(sawInsufficientSlope ? 'insufficientSlope' : sawSingularFit ? 'singularFit' : 'insufficientData')
+
+	const bestIndex = breakpoints.indexOf(best.breakpoint)
+	const bracketMin = bestIndex > 0 ? breakpoints[bestIndex - 1] : 0
+	const bracketMax = bestIndex + 1 < breakpoints.length ? breakpoints[bestIndex + 1] : consolidated.at(-1)!.traveled
+
+	if (bracketMax > bracketMin) {
+		try {
+			const refined = goldenSectionSearch(
+				(breakpoint) => {
+					const evaluation = evaluateBreakpoint(consolidated, breakpoint, options)
+					return 'fit' in evaluation ? evaluation.fit.loss : Number.MAX_VALUE
+				},
+				bracketMin,
+				bracketMax,
+				{ maxIterations: 64, tolerance: Math.max(Number.EPSILON, (bracketMax - bracketMin) * 1e-8) },
+			)
+
+			if (refined.converged) {
+				const evaluation = evaluateBreakpoint(consolidated, refined.minimum, options)
+				if ('fit' in evaluation && improvesCandidateLoss(evaluation.fit, best)) best = evaluation.fit
+			}
+		} catch {
+			// The discrete candidate remains valid when the optional bounded refinement cannot evaluate.
+		}
+	}
+
+	const uncertainty = breakpointUncertainty(consolidated, best, bracketMin, bracketMax, options)
+	return {
+		valid: true,
+		breakpoint: best.breakpoint,
+		intercept: best.intercept,
+		slope: best.slope,
+		loss: best.loss,
+		nrmse: best.nrmse,
+		uncertainty,
+		plateauPointCount: best.plateauPointCount,
+		postBreakpointPointCount: best.postBreakpointPointCount,
+	}
+}
+
+// Aggregates a non-empty, single-direction run list when a strict majority is valid.
+export function aggregateBacklashRuns(runs: readonly BacklashRunResult[]): BacklashDirectionResult | undefined {
+	if (runs.length === 0) return undefined
+	const direction = runs[0].direction
+	for (let i = 1; i < runs.length; i++) if (runs[i].direction !== direction) return undefined
+
+	const valid = runs.filter(
+		(run) =>
+			run.valid &&
+			run.steps !== undefined &&
+			run.uncertainty !== undefined &&
+			run.slope !== undefined &&
+			run.preloadSlope !== undefined &&
+			run.nrmse !== undefined &&
+			Number.isFinite(run.steps) &&
+			run.steps >= 0 &&
+			Number.isFinite(run.uncertainty) &&
+			run.uncertainty >= 0 &&
+			Number.isFinite(run.slope) &&
+			Number.isFinite(run.preloadSlope) &&
+			Number.isFinite(run.nrmse) &&
+			run.nrmse >= 0,
+	)
+	if (valid.length < Math.floor(runs.length / 2) + 1) return undefined
+
+	const steps = new Float64Array(valid.length)
+	const uncertainties = new Float64Array(valid.length)
+	for (let i = 0; i < valid.length; i++) {
+		steps[i] = valid[i].steps!
+		uncertainties[i] = valid[i].uncertainty!
+	}
+
+	steps.sort()
+	uncertainties.sort()
+	const medianSteps = medianOf(steps)
+	const dispersion = medianAbsoluteDeviationOf(steps, medianSteps, false)
+	return {
+		direction,
+		steps: Math.round(medianSteps),
+		dispersion,
+		uncertainty: Math.max(medianOf(uncertainties), NORMALIZED_MAD_SCALE * dispersion),
+		validRunCount: valid.length,
+		totalRunCount: runs.length,
+		runs: runs.slice(),
+	}
+}
+
+// Maps counter directions to the existing IN/OUT backlash-compensation contract.
+export function backlashCompensationFromCalibration(result: BacklashCalibrationResult, mode: BacklashCompensationMode = 'OVERSHOOT'): BacklashCompensation {
+	return { mode, backlashIn: result.decreasing.steps, backlashOut: result.increasing.steps }
+}
+
+// Expands public defaults and rejects combinations that cannot produce a stable fit.
+function normalizeCalibrationOptions(options: BacklashCalibrationOptions): NormalizedBacklashCalibrationOptions {
+	validatePositiveFinite(options.probeStep)
+	validatePositiveFinite(options.preloadDistance)
+	validatePositiveFinite(options.maximumProbeDistance)
+	validatePositiveFinite(options.minimumSlope)
+
+	const repeats = options.repeats ?? DEFAULT_REPEATS
+	const samplesPerPosition = options.samplesPerPosition ?? DEFAULT_SAMPLES_PER_POSITION
+	const minimumPreloadPoints = options.minimumPreloadPoints ?? DEFAULT_MINIMUM_PRELOAD_POINTS
+	const minimumPlateauPoints = options.minimumPlateauPoints ?? DEFAULT_MINIMUM_PLATEAU_POINTS
+	const minimumPostBreakPoints = options.minimumPostBreakPoints ?? DEFAULT_MINIMUM_POST_BREAK_POINTS
+	const breakpointTolerance = options.breakpointTolerance ?? options.probeStep
+	const stabilityCount = options.stabilityCount ?? DEFAULT_STABILITY_COUNT
+	const huberTuning = options.huberTuning ?? DEFAULT_HUBER_TUNING
+	const safetyFactor = options.safetyFactor ?? DEFAULT_SAFETY_FACTOR
+
+	validatePositiveInteger(repeats)
+	validatePositiveInteger(samplesPerPosition)
+	validatePositiveInteger(minimumPreloadPoints)
+	validatePositiveInteger(minimumPlateauPoints)
+	validatePositiveInteger(minimumPostBreakPoints)
+	validatePositiveInteger(stabilityCount)
+	validatePositiveFinite(breakpointTolerance)
+	validatePositiveFinite(huberTuning)
+	validatePositiveFinite(safetyFactor)
+
+	if (repeats < 3) throw new RangeError('repeats must be at least 3')
+	if (minimumPreloadPoints < 2) throw new RangeError('minimumPreloadPoints must be at least 2')
+	if (minimumPostBreakPoints < 2) throw new RangeError('minimumPostBreakPoints must be at least 2')
+	if (safetyFactor < 1) throw new RangeError('safetyFactor must be at least 1')
+	if (Math.ceil(options.preloadDistance / options.probeStep) < minimumPreloadPoints) throw new RangeError('preloadDistance cannot provide minimumPreloadPoints')
+	if (Math.floor(options.maximumProbeDistance / options.probeStep) + 1 < minimumPlateauPoints + minimumPostBreakPoints + stabilityCount - 1) throw new RangeError('maximumProbeDistance cannot provide a stable breakpoint fit')
+
+	const { minimumPosition, maximumPosition } = options
+	if (minimumPosition !== undefined) validateFinite(minimumPosition)
+	if (maximumPosition !== undefined) validateFinite(maximumPosition)
+	if (minimumPosition !== undefined && maximumPosition !== undefined && minimumPosition >= maximumPosition) throw new RangeError('minimumPosition must be less than maximumPosition')
+
+	return {
+		probeStep: options.probeStep,
+		preloadDistance: options.preloadDistance,
+		maximumProbeDistance: options.maximumProbeDistance,
+		minimumSlope: options.minimumSlope,
+		repeats,
+		samplesPerPosition,
+		minimumPreloadPoints,
+		minimumPlateauPoints,
+		minimumPostBreakPoints,
+		breakpointTolerance,
+		stabilityCount,
+		huberTuning,
+		minimumPosition,
+		maximumPosition,
+		safetyFactor,
+	}
+}
+
+// Returns the opposite counter direction.
+function oppositeDirection(direction: FocusAxisDirection): FocusAxisDirection {
+	return direction === 'increasing' ? 'decreasing' : 'increasing'
+}
+
+// Returns the signed multiplier for one counter direction.
+function directionSign(direction: FocusAxisDirection) {
+	return direction === 'increasing' ? 1 : -1
+}
+
+// Fits the metric slope over the measured tail of a preload.
+function fitPreloadSlope(points: readonly BacklashProbePoint[], minimumPoints: number, huberTuning: number) {
+	if (points.length < minimumPoints) return undefined
+	const start = points.length - minimumPoints
+	const design: [number, number][] = new Array(minimumPoints)
+	const values = new Float64Array(minimumPoints)
+	const origin = points[start].traveled
+
+	for (let i = 0; i < minimumPoints; i++) {
+		const point = points[start + i]
+		design[i] = [1, point.traveled - origin]
+		values[i] = point.value
+	}
+
+	try {
+		const fit = robustLinearLeastSquares(design, values, { method: 'huber', tuning: huberTuning })
+		const slope = fit.coefficients[1]
+		return !fit.rankDeficient && Number.isFinite(slope) ? slope : undefined
+	} catch {
+		return undefined
+	}
+}
+
+// Returns the geometric mean of bounded quality components.
+function geometricMean(values: readonly number[]) {
+	let logarithm = 0
+	for (let i = 0; i < values.length; i++) {
+		if (!Number.isFinite(values[i]) || values[i] <= 0) return 0
+		logarithm += Math.log(Math.min(1, values[i]))
+	}
+	return Math.min(1, Math.max(0, Math.exp(logarithm / values.length)))
+}
+
+// Scores one direction without allowing invalid runs to contribute fit diagnostics.
+function directionConfidence(result: BacklashDirectionResult, scale: number) {
+	const valid = result.runs.filter((run) => run.valid)
+	const nrmse = new Float64Array(valid.length)
+	const slopeAgreement = new Float64Array(valid.length)
+
+	for (let i = 0; i < valid.length; i++) {
+		const run = valid[i]
+		const preloadSlope = run.preloadSlope!
+		const slope = run.slope!
+		nrmse[i] = run.nrmse!
+		slopeAgreement[i] = preloadSlope * slope < 0 ? Math.min(Math.abs(preloadSlope), Math.abs(slope)) / Math.max(Math.abs(preloadSlope), Math.abs(slope)) : 0
+	}
+
+	nrmse.sort()
+	slopeAgreement.sort()
+	const coverage = result.validRunCount / result.totalRunCount
+	const dispersionScore = 1 / (1 + result.dispersion / scale)
+	const fitScore = 1 / (1 + medianOf(nrmse))
+	const uncertaintyScore = 1 / (1 + result.uncertainty / scale)
+	const slopeScore = medianOf(slopeAgreement)
+	return geometricMean([coverage, dispersionScore, fitScore, uncertaintyScore, slopeScore])
+}
+
+// Synchronous command/event state machine for repeated two-direction backlash calibration.
+export class BacklashCalibration {
+	readonly #config: NormalizedBacklashCalibrationOptions
+	#state: BacklashCalibrationState = 'idle'
+	#currentDirection?: FocusAxisDirection
+	#currentPosition = 0
+	#pending?: Extract<BacklashCalibrationCommand, { type: 'move' | 'measure' }>
+	#terminal?: Extract<BacklashCalibrationCommand, { type: 'completed' | 'failed' | 'cancelled' }>
+	#result?: BacklashCalibrationResult
+	#runIndex = 0
+	#preloadTraveled = 0
+	#reversalPosition = 0
+	#probeHadValidFit = false
+	#preloadSlope?: number
+	readonly #preloadPoints: BacklashProbePoint[] = []
+	readonly #probePoints: BacklashProbePoint[] = []
+	readonly #stableBreakpoints: number[] = []
+	readonly #samples: Float64Array
+	#sampleCount = 0
+	readonly #increasingRuns: BacklashRunResult[] = []
+	readonly #decreasingRuns: BacklashRunResult[] = []
+
+	// Validates and stores immutable calibration options without starting movement.
+	constructor(readonly options: BacklashCalibrationOptions) {
+		this.#config = normalizeCalibrationOptions(options)
+		this.#samples = new Float64Array(this.#config.samplesPerPosition)
+	}
+
+	// Returns the current observable phase.
+	get state() {
+		return this.#state
+	}
+
+	// Returns the direction of the active run, or undefined outside a run.
+	get currentDirection() {
+		return this.#currentDirection
+	}
+
+	// Returns the completed result, or undefined before successful completion.
+	get result() {
+		return this.#result
+	}
+
+	// Starts the first directional preload from a finite in-range counter position.
+	start(position: number): BacklashCalibrationCommand {
+		if (this.#terminal !== undefined) return this.#terminal
+		if (this.#state !== 'idle') return this.#fail('invalidEvent')
+		if (!Number.isFinite(position)) return this.#fail('invalidPosition')
+		if (!this.#positionInRange(position)) return this.#fail('positionLimit')
+
+		this.#currentPosition = position
+		return this.#beginRun()
+	}
+
+	// Consumes the event corresponding to the pending command and emits the next command.
+	next(event: BacklashCalibrationEvent): BacklashCalibrationCommand {
+		if (this.#terminal !== undefined) return this.#terminal
+		if (event.type === 'cancel') return this.#cancel()
+		if (this.#pending === undefined || this.#state === 'idle') return this.#fail('invalidEvent')
+
+		if (this.#pending.type === 'move') {
+			if (event.type !== 'moved') return this.#fail('invalidEvent')
+			return this.#handleMoved(event.position)
+		}
+
+		if (event.type !== 'measured') return this.#fail('invalidEvent')
+		return this.#handleMeasured(event.position, event.value)
+	}
+
+	// Selects the alternating direction schedule and initializes one run.
+	#beginRun(): BacklashCalibrationCommand {
+		const repeat = Math.floor(this.#runIndex / 2)
+		const first: FocusAxisDirection = repeat % 2 === 0 ? 'increasing' : 'decreasing'
+		this.#currentDirection = this.#runIndex % 2 === 0 ? first : oppositeDirection(first)
+		this.#state = 'preloading'
+		this.#preloadTraveled = 0
+		this.#preloadSlope = undefined
+		this.#probeHadValidFit = false
+		this.#preloadPoints.length = 0
+		this.#probePoints.length = 0
+		this.#stableBreakpoints.length = 0
+		return this.#queueMove(oppositeDirection(this.#currentDirection), Math.min(this.#config.probeStep, this.#config.preloadDistance))
+	}
+
+	// Validates actual movement direction and queues measurements at the reported position.
+	#handleMoved(position: number): BacklashCalibrationCommand {
+		const pending = this.#pending!
+		if (pending.type !== 'move') return this.#fail('invalidEvent')
+		if (!Number.isFinite(position)) return this.#fail('invalidPosition')
+		if (!this.#positionInRange(position)) return this.#fail('positionLimit')
+
+		const delta = position - this.#currentPosition
+		if (delta === 0 || Math.sign(delta) !== directionSign(pending.direction)) return this.#fail('axisStalled')
+
+		this.#currentPosition = position
+		if (this.#state === 'preloading') this.#preloadTraveled += Math.abs(delta)
+		this.#pending = undefined
+		this.#sampleCount = 0
+		return this.#queueMeasure()
+	}
+
+	// Validates and aggregates one metric sample without accepting mismatched positions.
+	#handleMeasured(position: number, value: number): BacklashCalibrationCommand {
+		if (!Number.isFinite(position) || position !== this.#currentPosition) return this.#fail('invalidPosition')
+		if (!Number.isFinite(value)) return this.#fail('invalidSample')
+
+		this.#samples[this.#sampleCount++] = value
+		this.#pending = undefined
+		if (this.#sampleCount < this.#config.samplesPerPosition) return this.#queueMeasure()
+
+		const sorted = this.#samples.slice().sort()
+		const median = medianOf(sorted)
+		const point: BacklashProbePoint = {
+			position: this.#currentPosition,
+			traveled: this.#state === 'preloading' ? this.#preloadTraveled : Math.abs(this.#currentPosition - this.#reversalPosition),
+			value: median,
+			dispersion: medianAbsoluteDeviationOf(sorted, median, false),
+			sampleCount: this.#config.samplesPerPosition,
+		}
+
+		return this.#state === 'preloading' ? this.#advancePreload(point) : this.#advanceProbe(point)
+	}
+
+	// Continues preload travel or validates its tail slope and reverses into the probe.
+	#advancePreload(point: BacklashProbePoint): BacklashCalibrationCommand {
+		this.#preloadPoints.push(point)
+		if (this.#preloadTraveled < this.#config.preloadDistance) {
+			return this.#queueMove(oppositeDirection(this.#currentDirection!), Math.min(this.#config.probeStep, this.#config.preloadDistance - this.#preloadTraveled))
+		}
+
+		this.#preloadSlope = fitPreloadSlope(this.#preloadPoints, this.#config.minimumPreloadPoints, this.#config.huberTuning)
+		if (this.#preloadSlope === undefined || Math.abs(this.#preloadSlope) < this.#config.minimumSlope) return this.#finishRun(false, 'insufficientSlope')
+
+		this.#state = 'probing'
+		this.#reversalPosition = this.#currentPosition
+		this.#probePoints.push({ ...point, traveled: 0 })
+		return this.#queueMove(this.#currentDirection!, Math.min(this.#config.probeStep, this.#config.maximumProbeDistance))
+	}
+
+	// Refits after one probe point and either completes a stable run or advances travel.
+	#advanceProbe(point: BacklashProbePoint): BacklashCalibrationCommand {
+		this.#probePoints.push(point)
+		const fit = fitBacklashBreakpoint(this.#probePoints, this.#fitOptions())
+
+		if (fit.valid) {
+			this.#probeHadValidFit = true
+			this.#stableBreakpoints.push(fit.breakpoint!)
+			if (this.#stableBreakpoints.length > this.#config.stabilityCount) this.#stableBreakpoints.shift()
+
+			if (this.#stableBreakpoints.length === this.#config.stabilityCount && fit.postBreakpointPointCount >= this.#config.minimumPostBreakPoints) {
+				let minimum = this.#stableBreakpoints[0]
+				let maximum = minimum
+				for (let i = 1; i < this.#stableBreakpoints.length; i++) {
+					minimum = Math.min(minimum, this.#stableBreakpoints[i])
+					maximum = Math.max(maximum, this.#stableBreakpoints[i])
+				}
+
+				if (maximum - minimum <= this.#config.breakpointTolerance) return this.#finishRun(true, undefined, fit)
+			}
+		}
+
+		if (point.traveled >= this.#config.maximumProbeDistance) return this.#finishRun(false, this.#probeHadValidFit ? 'maximumDistanceReached' : 'breakpointNotFound')
+		return this.#queueMove(this.#currentDirection!, Math.min(this.#config.probeStep, this.#config.maximumProbeDistance - point.traveled))
+	}
+
+	// Records one run and advances, aggregates, or fails when a majority is impossible.
+	#finishRun(valid: boolean, failureReason?: BacklashCalibrationFailureReason, fit?: BacklashFit): BacklashCalibrationCommand {
+		const direction = this.#currentDirection!
+		const run: BacklashRunResult = valid
+			? { direction, valid: true, steps: fit!.breakpoint, uncertainty: fit!.uncertainty, slope: fit!.slope, preloadSlope: this.#preloadSlope, nrmse: fit!.nrmse, points: this.#probePoints.slice() }
+			: { direction, valid: false, failureReason, preloadSlope: this.#preloadSlope, points: this.#probePoints.slice() }
+
+		this.#runs(direction).push(run)
+		this.#runIndex++
+		if (!this.#majorityStillPossible('increasing') || !this.#majorityStillPossible('decreasing')) return this.#fail('insufficientValidRuns', direction)
+		if (this.#runIndex >= this.#config.repeats * 2) return this.#complete()
+		return this.#beginRun()
+	}
+
+	// Aggregates both directions, validates dispersion, and creates the terminal result.
+	#complete(): BacklashCalibrationCommand {
+		const increasing = aggregateBacklashRuns(this.#increasingRuns)
+		const decreasing = aggregateBacklashRuns(this.#decreasingRuns)
+		if (increasing === undefined || decreasing === undefined) return this.#fail('insufficientValidRuns')
+
+		const scale = Math.max(this.#config.probeStep, this.#config.breakpointTolerance)
+		if (increasing.dispersion > scale || decreasing.dispersion > scale) return this.#fail('unstableResult')
+
+		const confidence = Math.min(directionConfidence(increasing, scale), directionConfidence(decreasing, scale))
+		const quality: BacklashCalibrationResult['quality'] = confidence >= 0.8 ? 'good' : confidence >= 0.5 ? 'marginal' : 'poor'
+		this.#result = { increasing, decreasing, recommendedOvershoot: Math.ceil(Math.max(increasing.steps, decreasing.steps) * this.#config.safetyFactor), confidence, quality }
+		this.#state = 'completed'
+		this.#currentDirection = undefined
+		this.#pending = undefined
+		this.#terminal = { type: 'completed', result: this.#result }
+		return this.#terminal
+	}
+
+	// Emits an in-range finite relative movement and remembers it as the sole pending command.
+	#queueMove(direction: FocusAxisDirection, distance: number): BacklashCalibrationCommand {
+		const relative = directionSign(direction) * distance
+		const target = this.#currentPosition + relative
+		if (!Number.isFinite(relative) || relative === 0 || !Number.isFinite(target)) return this.#fail('invalidPosition')
+		if (!this.#positionInRange(target)) return this.#fail('positionLimit')
+		this.#pending = { type: 'move', relative, direction }
+		return this.#pending
+	}
+
+	// Emits the next zero-based sample request at the current confirmed position.
+	#queueMeasure(): BacklashCalibrationCommand {
+		this.#pending = { type: 'measure', sampleIndex: this.#sampleCount, sampleCount: this.#config.samplesPerPosition }
+		return this.#pending
+	}
+
+	// Returns fitting options shared by every probe update.
+	#fitOptions(): BacklashFitOptions {
+		return { probeStep: this.#config.probeStep, minimumPlateauPoints: this.#config.minimumPlateauPoints, minimumPostBreakPoints: this.#config.minimumPostBreakPoints, minimumSlope: this.#config.minimumSlope, huberTuning: this.#config.huberTuning }
+	}
+
+	// Returns the mutable run bucket for one direction.
+	#runs(direction: FocusAxisDirection) {
+		return direction === 'increasing' ? this.#increasingRuns : this.#decreasingRuns
+	}
+
+	// Checks whether completed plus remaining runs can still form a strict majority.
+	#majorityStillPossible(direction: FocusAxisDirection) {
+		const runs = this.#runs(direction)
+		let valid = 0
+		for (let i = 0; i < runs.length; i++) if (runs[i].valid) valid++
+		return valid + (this.#config.repeats - runs.length) >= Math.floor(this.#config.repeats / 2) + 1
+	}
+
+	// Tests an inclusive optional position interval.
+	#positionInRange(position: number) {
+		return (this.#config.minimumPosition === undefined || position >= this.#config.minimumPosition) && (this.#config.maximumPosition === undefined || position <= this.#config.maximumPosition)
+	}
+
+	// Enters a typed failed terminal state and clears partial public results.
+	#fail(reason: BacklashCalibrationFailureReason, direction = this.#currentDirection): Extract<BacklashCalibrationCommand, { type: 'failed' }> {
+		this.#state = 'failed'
+		this.#result = undefined
+		this.#pending = undefined
+		this.#currentDirection = direction
+		this.#terminal = direction === undefined ? { type: 'failed', reason } : { type: 'failed', reason, direction }
+		return this.#terminal
+	}
+
+	// Enters an idempotent cancelled state without exposing partial calibration data.
+	#cancel(): Extract<BacklashCalibrationCommand, { type: 'cancelled' }> {
+		this.#state = 'cancelled'
+		this.#result = undefined
+		this.#pending = undefined
+		this.#currentDirection = undefined
+		this.#terminal = { type: 'cancelled' }
+		return this.#terminal
+	}
+}

--- a/src/observation/focus/backlash.calibration.ts
+++ b/src/observation/focus/backlash.calibration.ts
@@ -296,12 +296,9 @@ function consolidateProbePoints(points: readonly BacklashProbePoint[]) {
 				sampleCount += point.sampleCount
 			}
 
-			positions.sort()
-			values.sort()
-			dispersions.sort()
-			const value = medianOf(values)
+			const value = medianOf(values.sort())
 			const betweenPointMad = medianAbsoluteDeviationOf(values, value, false)
-			consolidated.push({ position: medianOf(positions), traveled: valid[start].traveled, value, dispersion: Math.max(betweenPointMad, medianOf(dispersions)), sampleCount })
+			consolidated.push({ position: medianOf(positions.sort()), traveled: valid[start].traveled, value, dispersion: Math.max(betweenPointMad, medianOf(dispersions.sort())), sampleCount })
 		}
 
 		start = end
@@ -517,15 +514,13 @@ export function aggregateBacklashRuns(runs: readonly BacklashRunResult[]): Backl
 		uncertainties[i] = valid[i].uncertainty!
 	}
 
-	steps.sort()
-	uncertainties.sort()
-	const medianSteps = medianOf(steps)
+	const medianSteps = medianOf(steps.sort())
 	const dispersion = medianAbsoluteDeviationOf(steps, medianSteps, false)
 	return {
 		direction,
 		steps: Math.round(medianSteps),
 		dispersion,
-		uncertainty: Math.max(medianOf(uncertainties), NORMALIZED_MAD_SCALE * dispersion),
+		uncertainty: Math.max(medianOf(uncertainties.sort()), NORMALIZED_MAD_SCALE * dispersion),
 		validRunCount: valid.length,
 		totalRunCount: runs.length,
 		runs: runs.slice(),
@@ -652,13 +647,11 @@ function directionConfidence(result: BacklashDirectionResult, scale: number) {
 		slopeAgreement[i] = preloadSlope * slope < 0 ? Math.min(Math.abs(preloadSlope), Math.abs(slope)) / Math.max(Math.abs(preloadSlope), Math.abs(slope)) : 0
 	}
 
-	nrmse.sort()
-	slopeAgreement.sort()
 	const coverage = result.validRunCount / result.totalRunCount
 	const dispersionScore = 1 / (1 + result.dispersion / scale)
-	const fitScore = 1 / (1 + medianOf(nrmse))
+	const fitScore = 1 / (1 + medianOf(nrmse.sort()))
 	const uncertaintyScore = 1 / (1 + result.uncertainty / scale)
-	const slopeScore = medianOf(slopeAgreement)
+	const slopeScore = medianOf(slopeAgreement.sort())
 	return geometricMean([coverage, dispersionScore, fitScore, uncertaintyScore, slopeScore])
 }
 
@@ -773,7 +766,7 @@ export class BacklashCalibration {
 		this.#pending = undefined
 		if (this.#sampleCount < this.#config.samplesPerPosition) return this.#queueMeasure()
 
-		const sorted = this.#samples.slice().sort()
+		const sorted = this.#samples.toSorted()
 		const median = medianOf(sorted)
 		const point: BacklashProbePoint = {
 			position: this.#currentPosition,

--- a/tests/devices/indi/simulator/camera.test.ts
+++ b/tests/devices/indi/simulator/camera.test.ts
@@ -1,43 +1,22 @@
 import { describe, expect, test } from 'bun:test'
 import { IndiClientHandlerSet } from '../../../../src/devices/indi/client'
-import type { Camera, GuideOutput, Thermometer } from '../../../../src/devices/indi/device'
-import { CameraManager, type DeviceHandler, type DeviceProvider, FocuserManager, GuideOutputManager, MountManager, RotatorManager, ThermometerManager } from '../../../../src/devices/indi/manager'
+import type { GuideOutput, Thermometer } from '../../../../src/devices/indi/device'
+import { CameraManager, type DeviceProvider, FocuserManager, GuideOutputManager, MountManager, RotatorManager, ThermometerManager } from '../../../../src/devices/indi/manager'
 import { CameraSimulator } from '../../../../src/devices/indi/simulator/camera'
 import { ClientSimulator } from '../../../../src/devices/indi/simulator/client'
 import { FocuserSimulator } from '../../../../src/devices/indi/simulator/focuser'
 import { MountSimulator } from '../../../../src/devices/indi/simulator/mount'
 import { RotatorSimulator } from '../../../../src/devices/indi/simulator/rotator'
 import type { CatalogSource } from '../../../../src/devices/indi/simulator/types'
-import type { BlobEncoding, PropertyState } from '../../../../src/devices/indi/types'
 import { readImageFromBuffer } from '../../../../src/imaging/model/image'
 import type { ImageRawType } from '../../../../src/imaging/model/types'
 import { mulberry32 } from '../../../../src/math/numerical/random'
 import { deg, formatDEC, formatRA, hour } from '../../../../src/math/units/angle'
-import { isTimeConsumingTestSkipped, waitUntil } from '../../../util'
+import { CameraFrameReceiver, isTimeConsumingTestSkipped, waitUntil } from '../../../util'
 
 // Integration coverage for simulated camera acquisition, rendering, metadata, and related devices.
 
 const SKIP = isTimeConsumingTestSkipped()
-
-class CameraFrameReceiver implements DeviceHandler<Camera> {
-	readonly #frames: Buffer[] = []
-
-	added(device: Camera) {}
-	updated(device: Camera, property: keyof Camera & string, state?: PropertyState) {}
-	removed(device: Camera) {}
-
-	blobReceived(device: Camera, data: Buffer, encoding: BlobEncoding) {
-		this.#frames.push(data)
-	}
-
-	get length() {
-		return this.#frames.length
-	}
-
-	get lastFrame() {
-		return this.#frames.at(-1)!
-	}
-}
 
 describe.skipIf(SKIP)('camera simulator', () => {
 	test('integrates with camera manager and exposes synthetic image controls', async () => {

--- a/tests/devices/indi/simulator/focuser.test.ts
+++ b/tests/devices/indi/simulator/focuser.test.ts
@@ -5,7 +5,7 @@ import { ClientSimulator } from '../../../../src/devices/indi/simulator/client'
 import { FocuserSimulator } from '../../../../src/devices/indi/simulator/focuser'
 import { isTimeConsumingTestSkipped, waitUntil } from '../../../util'
 
-// Integration coverage for simulated focuser movement, temperature, and manager projection.
+// Integration coverage for simulated focuser movement, backlash, temperature, and manager projection.
 
 const SKIP = isTimeConsumingTestSkipped()
 
@@ -38,6 +38,7 @@ describe.skipIf(SKIP)('focuser simulator', () => {
 		const properties = focuserManager.properties.get(focuser)!
 		expect(properties.FOCUS_TEMPERATURE).toBeDefined()
 		expect(properties.FOCUS_TEMPERATURE_COMPENSATION).toBeDefined()
+		expect(properties.SIMULATOR_BACKLASH).toBeDefined()
 
 		const initialTemperature = Number(properties.FOCUS_TEMPERATURE.elements.TEMPERATURE.value)
 		await waitUntil(() => Math.abs(Number(properties.FOCUS_TEMPERATURE.elements.TEMPERATURE.value) - initialTemperature) >= 0.05, 3000)
@@ -79,4 +80,64 @@ describe.skipIf(SKIP)('focuser simulator', () => {
 		expect(focuserManager.properties.length).toBe(0)
 		expect(thermometerManager.properties.length).toBe(0)
 	}, 7000)
+
+	test('simulates asymmetric backlash with persistent partial slack', async () => {
+		using client = new ClientSimulator('focuser', new IndiClientHandlerSet())
+		using simulator = new FocuserSimulator('Focuser Simulator', client)
+
+		simulator.connect()
+		client.sendNumber({ device: simulator.name, name: 'SIMULATOR_BACKLASH', elements: { BACKLASH_IN: 100, BACKLASH_OUT: 200 } })
+		expect(simulator.backlashIn).toBe(100)
+		expect(simulator.backlashOut).toBe(200)
+		simulator.syncTo(50000)
+
+		simulator.moveTo(51000)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.position).toBe(51000)
+		expect(simulator.effectivePosition).toBeCloseTo(51000, 6)
+
+		// A partial inward reversal consumes slack without moving the optical mechanism.
+		simulator.moveTo(50960)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.position).toBe(50960)
+		expect(simulator.effectivePosition).toBeCloseTo(51000, 6)
+
+		// Returning toward the engaged side first recovers the partially consumed slack.
+		simulator.moveTo(50980)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.effectivePosition).toBeCloseTo(51000, 6)
+		simulator.moveTo(51020)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.effectivePosition).toBeCloseTo(51020, 6)
+
+		// Each direction has an independent lost-motion distance.
+		simulator.moveTo(50920)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.effectivePosition).toBeCloseTo(51020, 6)
+		simulator.moveTo(50870)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.effectivePosition).toBeCloseTo(50970, 6)
+		simulator.moveTo(51020)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.effectivePosition).toBeCloseTo(50970, 6)
+		simulator.moveTo(51120)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.position).toBe(51120)
+		expect(simulator.effectivePosition).toBeCloseTo(51020, 6)
+
+		// Sync establishes a new optical reference and clears the engagement history.
+		simulator.syncTo(30000)
+		expect(simulator.effectivePosition).toBeCloseTo(30000, 6)
+		simulator.moveTo(29950)
+		await waitUntil(() => !simulator.isMoving)
+		expect(simulator.effectivePosition).toBeCloseTo(29950, 6)
+	})
+})
+
+test('rejects invalid focuser backlash configuration', () => {
+	using client = new ClientSimulator('focuser', new IndiClientHandlerSet())
+
+	expect(() => new FocuserSimulator('Negative Backlash', client, { backlashIn: -1 })).toThrow(RangeError)
+	expect(() => new FocuserSimulator('Non-finite Backlash', client, { backlashOut: Number.POSITIVE_INFINITY })).toThrow(TypeError)
+	expect(() => new FocuserSimulator('Excessive Backlash', client, { backlashOut: 100001 })).toThrow(RangeError)
 })

--- a/tests/observation/focus/backlash.calibration.test.ts
+++ b/tests/observation/focus/backlash.calibration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { medianOf, NumberComparator } from '../../../src/core/util'
 import { IndiClientHandlerSet } from '../../../src/devices/indi/client'
+import type { Camera, Focuser } from '../../../src/devices/indi/device'
 import { CameraManager, FocuserManager } from '../../../src/devices/indi/manager'
 import { CameraSimulator } from '../../../src/devices/indi/simulator/camera'
 import { ClientSimulator } from '../../../src/devices/indi/simulator/client'
@@ -47,6 +48,57 @@ async function measureMedianHfd(camera: CameraSimulator, receiver: CameraFrameRe
 	const stars = detectStars(image, { maxStars: 100 })
 	if (stars.length < 5) throw new Error(`expected at least five detected stars, received ${stars.length}`)
 	return medianOf(stars.map((star) => star.hfd).sort(NumberComparator))
+}
+
+// Configures a compact deterministic star field whose HFD responds to the simulated optical position.
+function configureBacklashImagingScene(client: ClientSimulator, cameraManager: CameraManager, camera: Camera, bestFocus = 50000, focusRange = 4000) {
+	cameraManager.frame(camera, 512, 352, 256, 256)
+	client.sendSwitch({ device: camera.name, name: 'SIMULATOR_NOISE_FEATURES', elements: { SKY_ENABLED: false, MOON_ENABLED: false, LIGHT_POLLUTION_ENABLED: false, AMP_GLOW_ENABLED: false } })
+	client.sendNumber({ device: camera.name, name: 'SIMULATOR_NOISE_EXPOSURE', elements: { EXPOSURE_TIME: 0.05 } })
+	client.sendNumber({ device: camera.name, name: 'SIMULATOR_SCENE', elements: { SCENE_SEED: 0x5eed, STAR_DENSITY: 0.001, SEEING: 0, HFD_MIN: 1.5, HFD_MAX: 1.5, FLUX_MIN: 5, FLUX_MAX: 5 } })
+	client.sendNumber({ device: camera.name, name: 'SIMULATOR_NOISE_SENSOR', elements: { READ_NOISE: 0, BIAS_ELECTRONS: 0, BLACK_LEVEL_ELECTRONS: 0, DARK_CURRENT_AT_REFERENCE_TEMP: 0, DARK_SIGNAL_NON_UNIFORMITY: 0 } })
+	client.sendNumber({
+		device: camera.name,
+		name: 'SIMULATOR_NOISE_ARTIFACTS',
+		elements: { FIXED_PATTERN_NOISE_STRENGTH: 0, ROW_NOISE_STRENGTH: 0, COLUMN_NOISE_STRENGTH: 0, BANDING_STRENGTH: 0, HOT_PIXEL_RATE: 0, WARM_PIXEL_RATE: 0, DEAD_PIXEL_RATE: 0 },
+	})
+	client.sendNumber({ device: camera.name, name: 'SIMULATOR_STAR_PLOT_OPTIONS', elements: { BEST_FOCUS: bestFocus } })
+	client.sendSwitch({ device: camera.name, name: 'SIMULATOR_ABERRATION_FEATURES', elements: { SENSOR_TILT: true } })
+	client.sendNumber({ device: camera.name, name: 'SIMULATOR_ABERRATION_FOCUS', elements: { FOCUS_RANGE: focusRange, TILT: 10, TILT_ANGLE: 0 } })
+}
+
+// Command counts and terminal output produced by an asynchronous simulator-backed calibration.
+interface SimulatorCalibrationExecution {
+	// Terminal calibration command.
+	readonly command: BacklashCalibrationCommand
+	// Number of move commands applied through the focuser manager.
+	readonly moveCommandCount: number
+	// Number of measure commands fulfilled from camera HFD measurements.
+	readonly measureCommandCount: number
+}
+
+// Executes calibration commands through the real simulator managers until a terminal command is emitted.
+async function runCalibrationWithSimulators(calibration: BacklashCalibration, focuserManager: FocuserManager, focuser: Focuser, camera: CameraSimulator, receiver: CameraFrameReceiver): Promise<SimulatorCalibrationExecution> {
+	let command = calibration.start(focuser.position.value)
+	let moveCommandCount = 0
+	let measureCommandCount = 0
+
+	for (let commandCount = 0; commandCount < 500; commandCount++) {
+		if (command.type === 'move') {
+			moveCommandCount++
+			focuserManager.moveTo(focuser, focuser.position.value + command.relative)
+			await waitUntil(() => focuser.moving)
+			await waitUntil(() => !focuser.moving, 3000, 20)
+			command = calibration.next({ type: 'moved', position: focuser.position.value })
+		} else if (command.type === 'measure') {
+			measureCommandCount++
+			command = calibration.next({ type: 'measured', position: focuser.position.value, value: await measureMedianHfd(camera, receiver) })
+		} else {
+			return { command, moveCommandCount, measureCommandCount }
+		}
+	}
+
+	throw new Error('simulator-backed calibration did not reach a terminal command')
 }
 
 // Builds exact samples from the continuous plateau-plus-line model.
@@ -219,20 +271,7 @@ describe.skipIf(SKIP_TIME_CONSUMING)('backlash calibration simulator integration
 		focuserManager.connect(focuser)
 		await waitUntil(() => camera.connected && focuser.connected)
 		cameraManager.snoop(camera, undefined, focuser)
-
-		cameraManager.frame(camera, 512, 352, 256, 256)
-		client.sendSwitch({ device: camera.name, name: 'SIMULATOR_NOISE_FEATURES', elements: { SKY_ENABLED: false, MOON_ENABLED: false, LIGHT_POLLUTION_ENABLED: false, AMP_GLOW_ENABLED: false } })
-		client.sendNumber({ device: camera.name, name: 'SIMULATOR_NOISE_EXPOSURE', elements: { EXPOSURE_TIME: 0.05 } })
-		client.sendNumber({ device: camera.name, name: 'SIMULATOR_SCENE', elements: { SCENE_SEED: 0x5eed, STAR_DENSITY: 0.001, SEEING: 0, HFD_MIN: 1.5, HFD_MAX: 1.5, FLUX_MIN: 5, FLUX_MAX: 5 } })
-		client.sendNumber({ device: camera.name, name: 'SIMULATOR_NOISE_SENSOR', elements: { READ_NOISE: 0, BIAS_ELECTRONS: 0, BLACK_LEVEL_ELECTRONS: 0, DARK_CURRENT_AT_REFERENCE_TEMP: 0, DARK_SIGNAL_NON_UNIFORMITY: 0 } })
-		client.sendNumber({
-			device: camera.name,
-			name: 'SIMULATOR_NOISE_ARTIFACTS',
-			elements: { FIXED_PATTERN_NOISE_STRENGTH: 0, ROW_NOISE_STRENGTH: 0, COLUMN_NOISE_STRENGTH: 0, BANDING_STRENGTH: 0, HOT_PIXEL_RATE: 0, WARM_PIXEL_RATE: 0, DEAD_PIXEL_RATE: 0 },
-		})
-		client.sendNumber({ device: camera.name, name: 'SIMULATOR_STAR_PLOT_OPTIONS', elements: { BEST_FOCUS: 50000 } })
-		client.sendSwitch({ device: camera.name, name: 'SIMULATOR_ABERRATION_FEATURES', elements: { SENSOR_TILT: true } })
-		client.sendNumber({ device: camera.name, name: 'SIMULATOR_ABERRATION_FOCUS', elements: { FOCUS_RANGE: 4000, TILT: 10, TILT_ANGLE: 0 } })
+		configureBacklashImagingScene(client, cameraManager, camera)
 
 		await waitUntil(() => camera.frame.width.value === 256 && camera.frame.height.value === 256 && cameraSimulator.activeFocuser?.name === focuser.name)
 		focuserManager.syncTo(focuser, 50000)
@@ -259,6 +298,59 @@ describe.skipIf(SKIP_TIME_CONSUMING)('backlash calibration simulator integration
 		expect(points[0].value).toBeCloseTo(points[3].value, 6)
 		expect(points.at(-1)!.value).toBeLessThan(points[3].value)
 	}, 5000)
+
+	test('executes calibration move and measure commands through camera and focuser simulators', async () => {
+		const handler = new IndiClientHandlerSet()
+		const cameraManager = new CameraManager()
+		const focuserManager = new FocuserManager()
+		const frameReceiver = new CameraFrameReceiver()
+		handler.add(cameraManager)
+		handler.add(focuserManager)
+		cameraManager.addHandler(frameReceiver)
+
+		using client = new ClientSimulator('backlash.calibration.commands', handler)
+		using cameraSimulator = new CameraSimulator('Camera Simulator', client, { focuserManager })
+		using focuserSimulator = new FocuserSimulator('Focuser Simulator', client, { backlashIn: 300, backlashOut: 300 })
+		const camera = cameraManager.get(client, cameraSimulator.name)!
+		const focuser = focuserManager.get(client, focuserSimulator.name)!
+		cameraManager.connect(camera)
+		focuserManager.connect(focuser)
+		await waitUntil(() => camera.connected && focuser.connected)
+		cameraManager.snoop(camera, undefined, focuser)
+		configureBacklashImagingScene(client, cameraManager, camera, 52000, 8000)
+		await waitUntil(() => camera.frame.width.value === 256 && camera.frame.height.value === 256 && cameraSimulator.activeFocuser?.name === focuser.name)
+
+		focuserManager.syncTo(focuser, 50000)
+		await waitUntil(() => focuser.position.value === 50000)
+		const calibration = new BacklashCalibration({
+			probeStep: 150,
+			preloadDistance: 300,
+			maximumProbeDistance: 750,
+			minimumSlope: 1e-5,
+			repeats: 3,
+			samplesPerPosition: 1,
+			minimumPreloadPoints: 2,
+			minimumPlateauPoints: 2,
+			minimumPostBreakPoints: 2,
+			breakpointTolerance: 150,
+			stabilityCount: 1,
+			minimumPosition: 0,
+			maximumPosition: 100000,
+		})
+		const execution = await runCalibrationWithSimulators(calibration, focuserManager, focuser, cameraSimulator, frameReceiver)
+
+		expect(execution.command.type).toBe('completed')
+		if (execution.command.type !== 'completed') throw new Error(`expected completed calibration, received ${execution.command.type}`)
+		expect(execution.moveCommandCount).toBe(execution.measureCommandCount)
+		expect(execution.moveCommandCount).toBeGreaterThan(20)
+		expect(Math.abs(execution.command.result.increasing.steps - focuserSimulator.backlashOut)).toBeLessThanOrEqual(150)
+		expect(Math.abs(execution.command.result.decreasing.steps - focuserSimulator.backlashIn)).toBeLessThanOrEqual(150)
+		expect(execution.command.result.increasing.totalRunCount).toBe(3)
+		expect(execution.command.result.decreasing.totalRunCount).toBe(3)
+		expect(execution.command.result.increasing.validRunCount).toBeGreaterThanOrEqual(2)
+		expect(execution.command.result.decreasing.validRunCount).toBeGreaterThanOrEqual(2)
+		expect(calibration.result).toBe(execution.command.result)
+	}, 30000)
 })
 
 describe('backlash run aggregation', () => {

--- a/tests/observation/focus/backlash.calibration.test.ts
+++ b/tests/observation/focus/backlash.calibration.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from 'bun:test'
+import { mulberry32, type Random } from '../../../src/math/numerical/random'
+import {
+	aggregateBacklashRuns,
+	BacklashCalibration,
+	backlashCompensationFromCalibration,
+	fitBacklashBreakpoint,
+	type BacklashCalibrationCommand,
+	type BacklashCalibrationOptions,
+	type BacklashCalibrationResult,
+	type BacklashFitOptions,
+	type BacklashProbePoint,
+	type BacklashRunResult,
+	type FocusAxisDirection,
+} from '../../../src/observation/focus/backlash.calibration'
+
+// Deterministic numerical and state-machine coverage for bidirectional focuser-backlash calibration.
+
+// Standard pure-fit configuration for a 20-step synthetic probe.
+const FIT_OPTIONS: BacklashFitOptions = {
+	probeStep: 20,
+	minimumPlateauPoints: 2,
+	minimumPostBreakPoints: 3,
+	minimumSlope: 0.001,
+	huberTuning: 1.345,
+}
+
+// Standard FSM configuration with enough travel for a 140-step breakpoint and stable tail.
+const CALIBRATION_OPTIONS: BacklashCalibrationOptions = {
+	probeStep: 20,
+	preloadDistance: 240,
+	maximumProbeDistance: 320,
+	minimumSlope: 0.001,
+	breakpointTolerance: 10,
+	minimumPosition: 0,
+	maximumPosition: 20000,
+}
+
+// Builds exact samples from the continuous plateau-plus-line model.
+function makeProbePoints(backlash: number, slope = 0.02, intercept = 10, maximum = 280): BacklashProbePoint[] {
+	const points: BacklashProbePoint[] = []
+	for (let traveled = 0; traveled <= maximum; traveled += FIT_OPTIONS.probeStep) {
+		points.push({ position: 10000 + traveled, traveled, value: intercept + slope * Math.max(0, traveled - backlash), dispersion: 0, sampleCount: 3 })
+	}
+	return points
+}
+
+// Returns a valid run with configurable breakpoint diagnostics.
+function makeRun(direction: FocusAxisDirection, steps: number, valid = true): BacklashRunResult {
+	return valid ? { direction, valid: true, steps, uncertainty: 10, slope: direction === 'increasing' ? 0.02 : -0.02, preloadSlope: direction === 'increasing' ? -0.02 : 0.02, nrmse: 0.01, points: [] } : { direction, valid: false, failureReason: 'breakpointNotFound', points: [] }
+}
+
+// Mechanical axis whose counter moves through slack while the optical position remains fixed.
+class SyntheticFocusAxis {
+	position: number
+	opticalPosition: number
+	readonly #random: Random
+	#lastDirection?: FocusAxisDirection
+	#remainingSlack = 0
+	#measurementCount = 0
+
+	// Configures independent directional backlash and deterministic metric noise.
+	constructor(
+		position: number,
+		readonly increasingBacklash: number,
+		readonly decreasingBacklash: number,
+		readonly metricSlope = 0.01,
+		readonly noiseAmplitude = 0,
+		readonly outlierEvery = 0,
+		seed = 0x5eed,
+	) {
+		this.position = position
+		this.opticalPosition = position
+		this.#random = mulberry32(seed)
+	}
+
+	// Applies one relative counter move and consumes directional slack before optical motion resumes.
+	move(relative: number) {
+		const direction: FocusAxisDirection = relative > 0 ? 'increasing' : 'decreasing'
+		if (this.#lastDirection !== undefined && direction !== this.#lastDirection) {
+			this.#remainingSlack = direction === 'increasing' ? this.increasingBacklash : this.decreasingBacklash
+		}
+
+		const distance = Math.abs(relative)
+		const consumed = Math.min(distance, this.#remainingSlack)
+		this.#remainingSlack -= consumed
+		this.position += relative
+		this.opticalPosition += Math.sign(relative) * (distance - consumed)
+		this.#lastDirection = direction
+		return this.position
+	}
+
+	// Returns a scalar metric linear in optical position with optional seeded noise and outliers.
+	measure() {
+		this.#measurementCount++
+		const noise = (this.#random() * 2 - 1) * this.noiseAmplitude
+		const outlier = this.outlierEvery > 0 && this.#measurementCount % this.outlierEvery === 0 ? this.metricSlope * 100 : 0
+		return 10 + this.metricSlope * this.opticalPosition + noise + outlier
+	}
+}
+
+// Drives the synchronous machine until it emits a terminal command.
+function runCalibration(calibration: BacklashCalibration, axis: SyntheticFocusAxis, valueOf: () => number = () => axis.measure(), firstMoveScale = 1) {
+	let command = calibration.start(axis.position)
+	let previousState = 'idle'
+	const directions: FocusAxisDirection[] = []
+
+	for (let steps = 0; steps < 20000; steps++) {
+		if (calibration.state === 'preloading' && previousState !== 'preloading') directions.push(calibration.currentDirection!)
+		previousState = calibration.state
+
+		if (command.type === 'move') {
+			command = calibration.next({ type: 'moved', position: axis.move(command.relative * (steps === 0 ? firstMoveScale : 1)) })
+		} else if (command.type === 'measure') {
+			command = calibration.next({ type: 'measured', position: axis.position, value: valueOf() })
+		} else {
+			return { command, directions }
+		}
+	}
+
+	throw new Error('calibration did not reach a terminal command')
+}
+
+describe('backlash breakpoint fitting', () => {
+	test('fits an exact positive breakpoint without mutating points', () => {
+		const points = makeProbePoints(120)
+		const snapshot = structuredClone(points)
+		const fit = fitBacklashBreakpoint(points, FIT_OPTIONS)
+
+		expect(fit.valid).toBeTrue()
+		expect(fit.breakpoint).toBeCloseTo(120, 4)
+		expect(fit.slope).toBeCloseTo(0.02, 8)
+		expect(fit.nrmse).toBeCloseTo(0, 8)
+		expect(fit.uncertainty).toBeGreaterThanOrEqual(10)
+		expect(points).toEqual(snapshot)
+	})
+
+	test('supports zero backlash and a negative slope', () => {
+		const zero = fitBacklashBreakpoint(makeProbePoints(0), FIT_OPTIONS)
+		const negative = fitBacklashBreakpoint(makeProbePoints(80, -0.03), FIT_OPTIONS)
+
+		expect(zero.valid).toBeTrue()
+		expect(zero.breakpoint).toBeCloseTo(0, 8)
+		expect(negative.valid).toBeTrue()
+		expect(negative.breakpoint).toBeCloseTo(80, 4)
+		expect(negative.slope).toBeCloseTo(-0.03, 8)
+	})
+
+	test('refines a breakpoint between adjacent probe positions', () => {
+		const fit = fitBacklashBreakpoint(makeProbePoints(90), FIT_OPTIONS)
+
+		expect(fit.valid).toBeTrue()
+		expect(fit.breakpoint).toBeCloseTo(90, 3)
+		expect(fit.breakpoint).toBeGreaterThanOrEqual(80)
+		expect(fit.breakpoint).toBeLessThanOrEqual(100)
+	})
+
+	test('consolidates duplicates and tolerates isolated outliers', () => {
+		const points = makeProbePoints(100)
+		points.reverse()
+		points.push({ ...points[0], value: points[0].value + 5 })
+		points.push({ ...points[0], value: points[0].value })
+		points.push({ position: Number.NaN, traveled: 40, value: 10, dispersion: 0, sampleCount: 1 })
+		const outlierIndex = points.findIndex((point) => point.traveled === 200)
+		points[outlierIndex] = { ...points[outlierIndex], value: points[outlierIndex].value + 2 }
+
+		const fit = fitBacklashBreakpoint(points, FIT_OPTIONS)
+		expect(fit.valid).toBeTrue()
+		expect(Math.abs(fit.breakpoint! - 100)).toBeLessThanOrEqual(FIT_OPTIONS.probeStep)
+		expect(Number.isFinite(fit.loss)).toBeTrue()
+		expect(Number.isFinite(fit.nrmse)).toBeTrue()
+	})
+
+	test('returns typed invalid fits without non-finite sentinels', () => {
+		const insufficient = fitBacklashBreakpoint(makeProbePoints(120).slice(0, 3), FIT_OPTIONS)
+		const flat = fitBacklashBreakpoint(makeProbePoints(120, 0), FIT_OPTIONS)
+
+		expect(insufficient).toEqual({ valid: false, reason: 'insufficientData', plateauPointCount: 0, postBreakpointPointCount: 0 })
+		expect(flat.valid).toBeFalse()
+		expect(flat.reason).toBe('insufficientSlope')
+		expect(flat.breakpoint).toBeUndefined()
+	})
+
+	test('validates fitting options', () => {
+		expect(() => fitBacklashBreakpoint([], { ...FIT_OPTIONS, probeStep: 0 })).toThrow(RangeError)
+		expect(() => fitBacklashBreakpoint([], { ...FIT_OPTIONS, minimumPostBreakPoints: 1.5 })).toThrow(TypeError)
+	})
+})
+
+describe('backlash run aggregation', () => {
+	test('aggregates a strict valid majority by median and MAD', () => {
+		const runs = [makeRun('increasing', 100), makeRun('increasing', 120), makeRun('increasing', 100), makeRun('increasing', 100, false)]
+		const result = aggregateBacklashRuns(runs)!
+
+		expect(result.steps).toBe(100)
+		expect(result.dispersion).toBe(0)
+		expect(result.uncertainty).toBe(10)
+		expect(result.validRunCount).toBe(3)
+		expect(result.totalRunCount).toBe(4)
+	})
+
+	test('rejects mixed directions and lists without a majority', () => {
+		expect(aggregateBacklashRuns([makeRun('increasing', 100), makeRun('decreasing', 100)])).toBeUndefined()
+		expect(aggregateBacklashRuns([makeRun('increasing', 100), makeRun('increasing', 100, false), makeRun('increasing', 100, false)])).toBeUndefined()
+	})
+
+	test('maps calibration directions to the existing compensator contract', () => {
+		const increasing = aggregateBacklashRuns([makeRun('increasing', 80), makeRun('increasing', 80), makeRun('increasing', 80)])!
+		const decreasing = aggregateBacklashRuns([makeRun('decreasing', 140), makeRun('decreasing', 140), makeRun('decreasing', 140)])!
+		const result: BacklashCalibrationResult = { increasing, decreasing, recommendedOvershoot: 210, confidence: 1, quality: 'good' }
+
+		expect(backlashCompensationFromCalibration(result)).toEqual({ mode: 'OVERSHOOT', backlashIn: 140, backlashOut: 80 })
+		expect(backlashCompensationFromCalibration(result, 'ABSOLUTE')).toEqual({ mode: 'ABSOLUTE', backlashIn: 140, backlashOut: 80 })
+	})
+})
+
+describe('backlash calibration state machine', () => {
+	test('measures symmetric backlash and alternates the first direction', () => {
+		const calibration = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const axis = new SyntheticFocusAxis(10000, 120, 120)
+		const { command, directions } = runCalibration(calibration, axis)
+
+		expect(command).toMatchObject({ type: 'completed' })
+		if (command.type !== 'completed') throw new Error('expected completed calibration')
+		expect(command.result.increasing.steps).toBeCloseTo(120, -1)
+		expect(command.result.decreasing.steps).toBeCloseTo(120, -1)
+		expect(command.result.recommendedOvershoot).toBe(180)
+		expect(directions).toEqual(['increasing', 'decreasing', 'decreasing', 'increasing', 'increasing', 'decreasing'])
+		expect(calibration.result).toBe(command.result)
+	})
+
+	test('measures asymmetric backlash with seeded noise and outliers', () => {
+		const calibration = new BacklashCalibration({ ...CALIBRATION_OPTIONS, samplesPerPosition: 5, breakpointTolerance: 20 })
+		const axis = new SyntheticFocusAxis(10000, 80, 140, 0.01, 0.01, 19)
+		const { command } = runCalibration(calibration, axis)
+
+		expect(command.type).toBe('completed')
+		if (command.type !== 'completed') throw new Error('expected completed calibration')
+		expect(Math.abs(command.result.increasing.steps - 80)).toBeLessThanOrEqual(20)
+		expect(Math.abs(command.result.decreasing.steps - 140)).toBeLessThanOrEqual(20)
+		expect(command.result.increasing.uncertainty).toBeGreaterThanOrEqual(10)
+		expect(command.result.decreasing.uncertainty).toBeGreaterThanOrEqual(10)
+		expect(Number.isFinite(command.result.confidence)).toBeTrue()
+	})
+
+	test('supports zero backlash without negative output', () => {
+		const calibration = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const axis = new SyntheticFocusAxis(10000, 0, 0)
+		const { command } = runCalibration(calibration, axis)
+
+		expect(command.type).toBe('completed')
+		if (command.type !== 'completed') throw new Error('expected completed calibration')
+		expect(command.result.increasing.steps).toBe(0)
+		expect(command.result.decreasing.steps).toBe(0)
+		expect(command.result.recommendedOvershoot).toBe(0)
+	})
+
+	test('uses partial reported movement instead of the requested position', () => {
+		const calibration = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const axis = new SyntheticFocusAxis(10000, 80, 140)
+		const { command } = runCalibration(calibration, axis, () => axis.measure(), 0.5)
+
+		expect(command).toMatchObject({ type: 'completed' })
+		if (command.type !== 'completed') throw new Error('expected completed calibration')
+		expect(Math.abs(command.result.increasing.steps - 80)).toBeLessThanOrEqual(20)
+		expect(Math.abs(command.result.decreasing.steps - 140)).toBeLessThanOrEqual(20)
+	})
+
+	test('fails after constant metrics make a valid majority impossible', () => {
+		const calibration = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const axis = new SyntheticFocusAxis(10000, 100, 100)
+		const { command } = runCalibration(calibration, axis, () => 42)
+
+		expect(command).toMatchObject({ type: 'failed', reason: 'insufficientValidRuns' })
+		expect(calibration.result).toBeUndefined()
+	})
+
+	test('rejects out-of-order events and remains terminal', () => {
+		const calibration = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const first = calibration.start(10000)
+		expect(first.type).toBe('move')
+
+		const failed = calibration.next({ type: 'measured', position: 10000, value: 1 })
+		expect(failed).toMatchObject({ type: 'failed', reason: 'invalidEvent' })
+		expect(calibration.next({ type: 'cancel' })).toBe(failed)
+	})
+
+	test('detects stalled and out-of-range movement', () => {
+		const stalled = new BacklashCalibration(CALIBRATION_OPTIONS)
+		stalled.start(10000)
+		expect(stalled.next({ type: 'moved', position: 10000 })).toMatchObject({ type: 'failed', reason: 'axisStalled' })
+
+		const limited = new BacklashCalibration({ ...CALIBRATION_OPTIONS, minimumPosition: 9990 })
+		expect(limited.start(10000)).toMatchObject({ type: 'failed', reason: 'positionLimit' })
+	})
+
+	test('rejects non-finite samples and cancels from active preload', () => {
+		const invalid = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const move = invalid.start(10000)
+		if (move.type !== 'move') throw new Error('expected move command')
+		const measure = invalid.next({ type: 'moved', position: 10000 + move.relative })
+		expect(measure.type).toBe('measure')
+		expect(invalid.next({ type: 'measured', position: 10000 + move.relative, value: Number.NaN })).toMatchObject({ type: 'failed', reason: 'invalidSample' })
+
+		const cancelled = new BacklashCalibration(CALIBRATION_OPTIONS)
+		cancelled.start(10000)
+		const terminal = cancelled.next({ type: 'cancel' })
+		expect(terminal).toEqual({ type: 'cancelled' })
+		expect(cancelled.next({ type: 'moved', position: 9980 })).toBe(terminal)
+	})
+
+	test('rejects invalid positions and cancels during probing', () => {
+		const invalidStart = new BacklashCalibration(CALIBRATION_OPTIONS)
+		expect(invalidStart.start(Number.NaN)).toMatchObject({ type: 'failed', reason: 'invalidPosition' })
+
+		const mismatched = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const first = mismatched.start(10000)
+		if (first.type !== 'move') throw new Error('expected move command')
+		const actual = 10000 + first.relative
+		mismatched.next({ type: 'moved', position: actual })
+		expect(mismatched.next({ type: 'measured', position: actual + 1, value: 1 })).toMatchObject({ type: 'failed', reason: 'invalidPosition' })
+
+		const probing = new BacklashCalibration(CALIBRATION_OPTIONS)
+		const axis = new SyntheticFocusAxis(10000, 120, 120)
+		let command: BacklashCalibrationCommand = probing.start(axis.position)
+		for (let i = 0; i < 100 && probing.state !== 'probing'; i++) {
+			if (command.type === 'move') command = probing.next({ type: 'moved', position: axis.move(command.relative) })
+			else if (command.type === 'measure') command = probing.next({ type: 'measured', position: axis.position, value: axis.measure() })
+		}
+		expect(probing.state).toBe('probing')
+		expect(probing.next({ type: 'cancel' })).toEqual({ type: 'cancelled' })
+	})
+
+	test('validates option types, ranges, and stable-fit capacity', () => {
+		expect(() => new BacklashCalibration({ ...CALIBRATION_OPTIONS, repeats: 2 })).toThrow(RangeError)
+		expect(() => new BacklashCalibration({ ...CALIBRATION_OPTIONS, samplesPerPosition: 1.5 })).toThrow(TypeError)
+		expect(() => new BacklashCalibration({ ...CALIBRATION_OPTIONS, preloadDistance: 40 })).toThrow(RangeError)
+		expect(() => new BacklashCalibration({ ...CALIBRATION_OPTIONS, maximumProbeDistance: 100 })).toThrow(RangeError)
+		expect(() => new BacklashCalibration({ ...CALIBRATION_OPTIONS, minimumPosition: 10, maximumPosition: 10 })).toThrow(RangeError)
+	})
+})

--- a/tests/observation/focus/backlash.calibration.test.ts
+++ b/tests/observation/focus/backlash.calibration.test.ts
@@ -266,6 +266,39 @@ describe('backlash calibration state machine', () => {
 		expect(Math.abs(command.result.decreasing.steps - 140)).toBeLessThanOrEqual(20)
 	})
 
+	test('rejects an in-range probe move beyond the commanded maximum', () => {
+		const calibration = new BacklashCalibration({ ...CALIBRATION_OPTIONS, stabilityCount: 13 })
+		const axis = new SyntheticFocusAxis(10000, 120, 120)
+		let command: BacklashCalibrationCommand = calibration.start(axis.position)
+		let reversalPosition: number | undefined
+
+		for (let i = 0; i < 200; i++) {
+			if (command.type === 'move') {
+				if (calibration.state === 'probing') {
+					reversalPosition ??= axis.position
+					const traveled = Math.abs(axis.position - reversalPosition)
+
+					if (traveled + Math.abs(command.relative) >= CALIBRATION_OPTIONS.maximumProbeDistance) {
+						const overtravelRelative = command.relative + Math.sign(command.relative) * CALIBRATION_OPTIONS.probeStep
+						const overtravelPosition = axis.move(overtravelRelative)
+						expect(Math.abs(overtravelPosition - reversalPosition)).toBeGreaterThan(CALIBRATION_OPTIONS.maximumProbeDistance)
+						expect(overtravelPosition).toBeLessThanOrEqual(CALIBRATION_OPTIONS.maximumPosition!)
+						expect(calibration.next({ type: 'moved', position: overtravelPosition })).toMatchObject({ type: 'failed', reason: 'invalidPosition' })
+						return
+					}
+				}
+
+				command = calibration.next({ type: 'moved', position: axis.move(command.relative) })
+			} else if (command.type === 'measure') {
+				command = calibration.next({ type: 'measured', position: axis.position, value: axis.measure() })
+			} else {
+				throw new Error(`unexpected terminal command: ${command.type}`)
+			}
+		}
+
+		throw new Error('calibration did not issue the expected late probe move')
+	})
+
 	test('fails after constant metrics make a valid majority impossible', () => {
 		const calibration = new BacklashCalibration(CALIBRATION_OPTIONS)
 		const axis = new SyntheticFocusAxis(10000, 100, 100)

--- a/tests/observation/focus/backlash.calibration.test.ts
+++ b/tests/observation/focus/backlash.calibration.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, test } from 'bun:test'
+import { medianOf, NumberComparator } from '../../../src/core/util'
+import { IndiClientHandlerSet } from '../../../src/devices/indi/client'
+import { CameraManager, FocuserManager } from '../../../src/devices/indi/manager'
+import { CameraSimulator } from '../../../src/devices/indi/simulator/camera'
+import { ClientSimulator } from '../../../src/devices/indi/simulator/client'
+import { FocuserSimulator } from '../../../src/devices/indi/simulator/focuser'
+import { readImageFromBuffer } from '../../../src/imaging/model/image'
+import { detectStars } from '../../../src/imaging/stars/detector'
 import { mulberry32, type Random } from '../../../src/math/numerical/random'
-import {
-	aggregateBacklashRuns,
-	BacklashCalibration,
-	backlashCompensationFromCalibration,
-	fitBacklashBreakpoint,
-	type BacklashCalibrationCommand,
-	type BacklashCalibrationOptions,
-	type BacklashCalibrationResult,
-	type BacklashFitOptions,
-	type BacklashProbePoint,
-	type BacklashRunResult,
-	type FocusAxisDirection,
-} from '../../../src/observation/focus/backlash.calibration'
+// oxfmt-ignore
+import { aggregateBacklashRuns, BacklashCalibration, backlashCompensationFromCalibration, fitBacklashBreakpoint, type BacklashCalibrationCommand, type BacklashCalibrationOptions, type BacklashCalibrationResult, type BacklashFitOptions, type BacklashProbePoint, type BacklashRunResult, type FocusAxisDirection } from '../../../src/observation/focus/backlash.calibration'
+import { CameraFrameReceiver, isTimeConsumingTestSkipped, waitUntil } from '../../util'
 
 // Deterministic numerical and state-machine coverage for bidirectional focuser-backlash calibration.
 
@@ -34,6 +32,21 @@ const CALIBRATION_OPTIONS: BacklashCalibrationOptions = {
 	breakpointTolerance: 10,
 	minimumPosition: 0,
 	maximumPosition: 20000,
+}
+
+// Indicates whether integration tests involving timed simulator exposures are disabled.
+const SKIP_TIME_CONSUMING = isTimeConsumingTestSkipped()
+
+// Captures one deterministic frame and returns the median HFD of its detected stars, in pixels.
+async function measureMedianHfd(camera: CameraSimulator, receiver: CameraFrameReceiver) {
+	const previousFrameCount = receiver.length
+	camera.startExposure(0.05)
+	await waitUntil(() => receiver.length > previousFrameCount, 10000, 20)
+	const image = await readImageFromBuffer(receiver.lastFrame)
+	if (!image) throw new Error('camera simulator did not produce a readable image')
+	const stars = detectStars(image, { maxStars: 100 })
+	if (stars.length < 5) throw new Error(`expected at least five detected stars, received ${stars.length}`)
+	return medianOf(stars.map((star) => star.hfd).sort(NumberComparator))
 }
 
 // Builds exact samples from the continuous plateau-plus-line model.
@@ -185,6 +198,67 @@ describe('backlash breakpoint fitting', () => {
 		expect(() => fitBacklashBreakpoint([], { ...FIT_OPTIONS, probeStep: 0 })).toThrow(RangeError)
 		expect(() => fitBacklashBreakpoint([], { ...FIT_OPTIONS, minimumPostBreakPoints: 1.5 })).toThrow(TypeError)
 	})
+})
+
+describe.skipIf(SKIP_TIME_CONSUMING)('backlash calibration simulator integration', () => {
+	test('recovers focuser backlash from detected star HFD', async () => {
+		const handler = new IndiClientHandlerSet()
+		const cameraManager = new CameraManager()
+		const focuserManager = new FocuserManager()
+		const frameReceiver = new CameraFrameReceiver()
+		handler.add(cameraManager)
+		handler.add(focuserManager)
+		cameraManager.addHandler(frameReceiver)
+
+		using client = new ClientSimulator('backlash.calibration', handler)
+		using cameraSimulator = new CameraSimulator('Camera Simulator', client, { focuserManager })
+		using focuserSimulator = new FocuserSimulator('Focuser Simulator', client, { backlashOut: 300 })
+		const camera = cameraManager.get(client, cameraSimulator.name)!
+		const focuser = focuserManager.get(client, focuserSimulator.name)!
+		cameraManager.connect(camera)
+		focuserManager.connect(focuser)
+		await waitUntil(() => camera.connected && focuser.connected)
+		cameraManager.snoop(camera, undefined, focuser)
+
+		cameraManager.frame(camera, 512, 352, 256, 256)
+		client.sendSwitch({ device: camera.name, name: 'SIMULATOR_NOISE_FEATURES', elements: { SKY_ENABLED: false, MOON_ENABLED: false, LIGHT_POLLUTION_ENABLED: false, AMP_GLOW_ENABLED: false } })
+		client.sendNumber({ device: camera.name, name: 'SIMULATOR_NOISE_EXPOSURE', elements: { EXPOSURE_TIME: 0.05 } })
+		client.sendNumber({ device: camera.name, name: 'SIMULATOR_SCENE', elements: { SCENE_SEED: 0x5eed, STAR_DENSITY: 0.001, SEEING: 0, HFD_MIN: 1.5, HFD_MAX: 1.5, FLUX_MIN: 5, FLUX_MAX: 5 } })
+		client.sendNumber({ device: camera.name, name: 'SIMULATOR_NOISE_SENSOR', elements: { READ_NOISE: 0, BIAS_ELECTRONS: 0, BLACK_LEVEL_ELECTRONS: 0, DARK_CURRENT_AT_REFERENCE_TEMP: 0, DARK_SIGNAL_NON_UNIFORMITY: 0 } })
+		client.sendNumber({
+			device: camera.name,
+			name: 'SIMULATOR_NOISE_ARTIFACTS',
+			elements: { FIXED_PATTERN_NOISE_STRENGTH: 0, ROW_NOISE_STRENGTH: 0, COLUMN_NOISE_STRENGTH: 0, BANDING_STRENGTH: 0, HOT_PIXEL_RATE: 0, WARM_PIXEL_RATE: 0, DEAD_PIXEL_RATE: 0 },
+		})
+		client.sendNumber({ device: camera.name, name: 'SIMULATOR_STAR_PLOT_OPTIONS', elements: { BEST_FOCUS: 50000 } })
+		client.sendSwitch({ device: camera.name, name: 'SIMULATOR_ABERRATION_FEATURES', elements: { SENSOR_TILT: true } })
+		client.sendNumber({ device: camera.name, name: 'SIMULATOR_ABERRATION_FOCUS', elements: { FOCUS_RANGE: 4000, TILT: 10, TILT_ANGLE: 0 } })
+
+		await waitUntil(() => camera.frame.width.value === 256 && camera.frame.height.value === 256 && cameraSimulator.activeFocuser?.name === focuser.name)
+		focuserManager.syncTo(focuser, 50000)
+		await waitUntil(() => focuser.position.value === 50000)
+		focuserManager.moveTo(focuser, 49000)
+		await waitUntil(() => focuser.moving)
+		await waitUntil(() => !focuser.moving, 3000, 20)
+		expect(focuserSimulator.effectivePosition).toBe(49000)
+
+		const points: BacklashProbePoint[] = []
+		for (let traveled = 0; traveled <= 900; traveled += 100) {
+			if (traveled > 0) {
+				focuserManager.moveTo(focuser, 49000 + traveled)
+				await waitUntil(() => focuser.moving)
+				await waitUntil(() => !focuser.moving, 3000, 20)
+			}
+
+			points.push({ position: focuser.position.value, traveled, value: await measureMedianHfd(cameraSimulator, frameReceiver), dispersion: 0, sampleCount: 1 })
+		}
+
+		const fit = fitBacklashBreakpoint(points, { probeStep: 100, minimumPlateauPoints: 2, minimumPostBreakPoints: 3, minimumSlope: 1e-5, huberTuning: 1.345 })
+		expect(fit.valid).toBeTrue()
+		expect(Math.abs(fit.breakpoint! - focuserSimulator.backlashOut)).toBeLessThanOrEqual(100)
+		expect(points[0].value).toBeCloseTo(points[3].value, 6)
+		expect(points.at(-1)!.value).toBeLessThan(points[3].value)
+	}, 5000)
 })
 
 describe('backlash run aggregation', () => {

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,4 +1,7 @@
 import { expect } from 'bun:test'
+import type { Camera } from '../src/devices/indi/device'
+import type { DeviceHandler } from '../src/devices/indi/manager'
+import type { PropertyState, BlobEncoding } from '../src/devices/indi/types'
 import type { NumberArray } from '../src/math/numerical/math'
 
 export function isNetworkTestSkipped() {
@@ -47,4 +50,33 @@ export function expectNumberArrayToBeCloseTo(a: Readonly<NumberArray> | undefine
 	if (a === undefined || a === null) return
 	expect(a.length).toBeGreaterThanOrEqual(b.length)
 	for (let i = 0; i < b.length; i++) expect(a[i]).toBeCloseTo(b[i], numDigits)
+}
+
+// Collects image BLOBs published by a simulated camera.
+export class CameraFrameReceiver implements DeviceHandler<Camera> {
+	readonly #frames: Buffer[] = []
+
+	// Device registration does not require receiver-side state.
+	added(device: Camera) {}
+
+	// Property updates do not affect the accumulated image frames.
+	updated(device: Camera, property: keyof Camera & string, state?: PropertyState) {}
+
+	// Device removal leaves captured frames available to the test.
+	removed(device: Camera) {}
+
+	// Appends a completed image BLOB in acquisition order.
+	blobReceived(device: Camera, data: Buffer, encoding: BlobEncoding) {
+		this.#frames.push(data)
+	}
+
+	// Number of completed frames received so far.
+	get length() {
+		return this.#frames.length
+	}
+
+	// Most recently completed camera frame.
+	get lastFrame() {
+		return this.#frames.at(-1)!
+	}
 }


### PR DESCRIPTION
Add robust bidirectional breakpoint fitting and a synchronous command/event state machine for measuring focuser backlash. Cover deterministic mechanical simulation, aggregation, quality scoring, cancellation, limits, and integration with BacklashCompensator.