### PR TITLE
Guider Client Improvement

### DIFF
--- a/src/devices/guiding/phd2.ts
+++ b/src/devices/guiding/phd2.ts
@@ -103,8 +103,8 @@ export interface PHD2Event<E extends PHD2EventType> {
 
 // PHD2 version/capability announcement sent on connect.
 export interface PHD2VersionEvent extends PHD2Event<'Version'> {
-	readonly PHD2Version: string
-	readonly PHD2Subver: string
+	readonly PHDVersion: string
+	readonly PHDSubver: string
 	readonly OverlapSupport: boolean
 	readonly MsgVersion: number
 }

--- a/src/devices/guiding/phd2.ts
+++ b/src/devices/guiding/phd2.ts
@@ -172,8 +172,9 @@ export interface PHD2GuideStepEvent extends PHD2Event<'GuideStep'> {
 	readonly SNR: number
 	readonly HFD: number
 	readonly AvgDist: number
-	readonly RALimited: boolean
-	readonly DecLimited: boolean
+	// Present only when the corresponding axis pulse was clipped by the maximum-duration limit.
+	readonly RALimited?: boolean
+	readonly DecLimited?: boolean
 	readonly ErrorCode: number
 }
 

--- a/src/devices/guiding/phd2.ts
+++ b/src/devices/guiding/phd2.ts
@@ -47,8 +47,8 @@ export type PHD2EventType =
 // PHD2 application/guiding state.
 export type PHD2AppState = 'Stopped' | 'Selected' | 'Calibrating' | 'Guiding' | 'LostLock' | 'Paused' | 'Looping'
 
-// Severity of an Alert event.
-export type PHD2AlertType = 'Info' | 'Question' | 'Warning' | 'Error'
+// Severity of an Alert event, using the lowercase values PHD2 sends on the wire.
+export type PHD2AlertType = 'info' | 'question' | 'warning' | 'error'
 
 // Guide pulse direction.
 export type PHD2GuideDirection = 'North' | 'South' | 'West' | 'East'

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -1255,15 +1255,19 @@ export class GuiderClient {
 		// this.emitEvent('AppState', { State: appState })
 	}
 
-	// Emits the capture-stop event that matches the current or paused-resume session mode.
+	// Emits the capture-stop events that match the current or paused-resume session mode.
+	// Guiding implies looping in PHD2, so stopping an active guiding session reports both that
+	// guiding ceased and that the exposure loop ceased, in that order.
 	#emitCaptureStoppedEvent() {
 		const appState = this.#appState === 'Paused' ? this.#resumeState : this.#appState
 
-		if (appState === 'Looping' || appState === 'Selected') {
-			this.emitEvent('LoopingExposuresStopped')
-		} else if (appState === 'Calibrating' || appState === 'Guiding' || appState === 'LostLock') {
+		if (appState === 'Stopped') return
+
+		if (appState === 'Calibrating' || appState === 'Guiding' || appState === 'LostLock') {
 			this.emitEvent('GuidingStopped')
 		}
+
+		this.emitEvent('LoopingExposuresStopped')
 	}
 
 	// Emits one passive frame event while exposures are looping.

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -1,6 +1,6 @@
 import { pixelScale } from '../../astronomy/formulas'
 import type { PartialOnly, Writable } from '../../core/types'
-import { DEFAULT_PHD2_SETTLE, type PHD2AppState, type PHD2CalibrationData, type PHD2DeclinationGuideMode, type PHD2EventMap, type PHD2Events, type PHD2GuideDirection, type PHD2LockShiftParams, type PHD2Settle, type PHD2StarImage } from '../../devices/guiding/phd2'
+import { DEFAULT_PHD2_SETTLE, type PHD2AppState, type PHD2CalibrationData, type PHD2DeclinationGuideMode, type PHD2EventMap, type PHD2Events, type PHD2GuideDirection, type PHD2GuideStepEvent, type PHD2LockShiftParams, type PHD2Settle, type PHD2StarImage } from '../../devices/guiding/phd2'
 import type { Camera, GuideDirection, GuideOutput } from '../../devices/indi/device'
 import type { CameraManager, DeviceHandler, GuideOutputManager } from '../../devices/indi/manager'
 import type { BlobEncoding } from '../../devices/indi/types'
@@ -1350,8 +1350,12 @@ export class GuiderClient {
 		const outputActive = !this.#paused && this.#guideOutputActive
 		const raDuration = outputActive ? Math.round(ra.duration) : 0
 		const decDuration = outputActive ? Math.round(dec.duration) : 0
+		// An axis is only reported as limited when a pulse was actually issued and clipped by the
+		// per-axis maximum duration, so a suppressed or zero-length pulse never claims a limit.
+		const raLimited = raDuration > 0 && ra.duration >= this.#guider.config.maxPulseMsRA
+		const decLimited = decDuration > 0 && dec.duration >= this.#guider.config.maxPulseMsDEC
 
-		this.emitEvent('GuideStep', {
+		const event: Omit<Writable<PHD2GuideStepEvent>, 'Event' | 'Timestamp' | 'Host' | 'Inst'> = {
 			Frame: frame.frameId ?? 0,
 			// Seconds since guiding started, matching PHD2's GuideStep.Time.
 			Time: this.#guidingElapsedTime(frame.timestamp ?? 0),
@@ -1374,10 +1378,15 @@ export class GuiderClient {
 			HFD: star?.hfd ?? 0,
 			// PHD2 reports the smoothed guide distance here, not the raw current-frame distance.
 			AvgDist: avgDistance,
-			RALimited: ra.duration >= this.#guider.config.maxPulseMsRA,
-			DecLimited: dec.duration >= this.#guider.config.maxPulseMsDEC,
 			ErrorCode: 0,
-		})
+		}
+
+		// PHD2 includes the limit flags only when the pulse was clipped, so they stay absent
+		// otherwise instead of being reported as false.
+		if (raLimited) event.RALimited = true
+		if (decLimited) event.DecLimited = true
+
+		this.emitEvent('GuideStep', event)
 	}
 
 	// Emits a star-lost event for the current frame.

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -880,7 +880,10 @@ export class GuiderClient {
 
 		if (command.state === 'lost') {
 			this.#emitStarLostEvent(frame, command)
-			this.emitEvent('LockPositionLost')
+			// PHD2 reports StarLost for every dropped frame but LockPositionLost only once, when the
+			// lock is actually given up. #resumeState tracks the session state even while paused, so
+			// it is the reliable edge test here.
+			if (this.#resumeState !== 'LostLock') this.emitEvent('LockPositionLost')
 			this.#resumeState = 'LostLock'
 			if (!this.#paused) this.#setAppState('LostLock')
 			this.#updateSettling(undefined, undefined, true, true, timestamp)

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -563,6 +563,12 @@ export class GuiderClient {
 		}
 
 		this.#abortGuidingAssistantForTransition('guiding restarted')
+
+		// PHD2 auto-selects a guide star when a guide request arrives with nothing selected. This is a
+		// no-op until a frame has been decoded, matching PHD2's behavior of guiding on the star found
+		// in the frames that follow.
+		if (this.#lockPosition === undefined) this.findStar()
+
 		this.#paused = false
 		this.#fullPause = true
 		this.#resumeState = 'Guiding'

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -25,6 +25,16 @@ const DEFAULT_GUIDER_EXPOSURE = 1000
 // Default star-image search-region side, in pixels.
 const DEFAULT_SEARCH_REGION = 64
 
+// PHD2 application version announced in the Version event on connect. The local guider is not PHD2,
+// so this reports the PHD2 release whose event protocol it reproduces.
+const PHD2_VERSION = '2.6.13'
+// PHD2 sub-version component of the Version event; empty for a non-PHD2 implementation.
+const PHD2_SUBVER = ''
+// Event protocol message version implemented by this client, matching PHD2's MsgVersion.
+const PHD2_MSG_VERSION = 1
+// Overlapping exposures are not implemented by the local guider.
+const PHD2_OVERLAP_SUPPORT = false
+
 // Exponential smoothing factor PHD2 applies to the guide distance reported as GuideStep.AvgDist.
 // Matches PHD2's Guider::UpdateCurrentDistance, which low-pass filters the per-frame distance so
 // clients see a stability indicator instead of raw frame-to-frame noise.
@@ -181,6 +191,10 @@ export class GuiderClient {
 		this.attachHandler()
 		this.cameraManager.enableBlob(camera)
 		this.#resetRuntimeState(true)
+		// PHD2 greets a newly connected client with Version followed by the current AppState. AppState
+		// is only sent here: afterwards clients track state through the individual lifecycle events.
+		this.emitEvent('Version', { PHDVersion: PHD2_VERSION, PHDSubver: PHD2_SUBVER, MsgVersion: PHD2_MSG_VERSION, OverlapSupport: PHD2_OVERLAP_SUPPORT })
+		this.emitEvent('AppState', { State: this.#appState })
 		this.emitEvent('ConfigurationChange')
 
 		return true
@@ -1245,14 +1259,11 @@ export class GuiderClient {
 		this.#eventHandler?.(this, event)
 	}
 
-	// Updates the app state and emits the paired PHD2 AppState event once.
+	// Updates the current app state. No event is emitted here on purpose: PHD2 sends AppState only
+	// when a client first connects, and clients are expected to track later transitions through the
+	// individual lifecycle events. See https://github.com/OpenPHDGuiding/phd2/wiki/EventMonitoring#appstate
 	#setAppState(appState: PHD2AppState) {
-		// if (this.#appState === appState) return
 		this.#appState = appState
-		// The AppState notification is only sent when the client first connects to PHD2.
-		// You will need to update its notion of AppState by handling individual notification events.
-		// https://github.com/OpenPHDGuiding/phd2/wiki/EventMonitoring#appstate
-		// this.emitEvent('AppState', { State: appState })
 	}
 
 	// Emits the capture-stop events that match the current or paused-resume session mode.

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -778,13 +778,16 @@ export class GuiderClient {
 	}
 
 	// Pauses or resumes guide pulses, optionally stopping exposures during full pause.
+	// PHD2 reports Paused and Resumed on the pause transition only, so a redundant call is silent.
 	setPaused(paused: boolean, full: boolean = true) {
+		const wasPaused = this.#paused
+
 		if (paused) {
-			if (!this.#paused) this.#resumeState = this.#appState === 'Paused' ? this.#resumeState : this.#appState
+			if (!wasPaused) this.#resumeState = this.#appState === 'Paused' ? this.#resumeState : this.#appState
 			this.#paused = true
 			this.#fullPause = full || this.#resumeState === 'Calibrating'
 			this.#lockShiftTimestamp = 0
-			this.emitEvent('Paused')
+			if (!wasPaused) this.emitEvent('Paused')
 			if (this.#guidingAssistant?.measuringBacklash === true) this.#finishGuidingAssistant(false, 'backlash test paused', true)
 			this.#setAppState('Paused')
 			if (this.#fullPause && this.#camera !== undefined) this.cameraManager.stopExposure(this.#camera)
@@ -794,7 +797,7 @@ export class GuiderClient {
 		this.#paused = false
 		this.#fullPause = true
 		this.#lockShiftTimestamp = 0
-		this.emitEvent('Resumed')
+		if (wasPaused) this.emitEvent('Resumed')
 		this.#setAppState(this.#resumeState === 'Paused' ? 'Looping' : this.#resumeState)
 
 		if (this.#appState !== 'Stopped' && this.#camera !== undefined) {

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -25,6 +25,11 @@ const DEFAULT_GUIDER_EXPOSURE = 1000
 // Default star-image search-region side, in pixels.
 const DEFAULT_SEARCH_REGION = 64
 
+// Exponential smoothing factor PHD2 applies to the guide distance reported as GuideStep.AvgDist.
+// Matches PHD2's Guider::UpdateCurrentDistance, which low-pass filters the per-frame distance so
+// clients see a stability indicator instead of raw frame-to-frame noise.
+const AVG_DISTANCE_SMOOTHING_ALPHA = 0.3
+
 // Placeholder calibration data returned before any calibration is solved.
 const EMPTY_CALIBRATION_DATA: Readonly<PHD2CalibrationData> = {
 	calibrated: false,
@@ -93,6 +98,8 @@ export class GuiderClient {
 	#appState: PHD2AppState = 'Stopped'
 	#resumeState: PHD2AppState = 'Stopped'
 	#guidingStartTime = 0
+	#avgDistance = 0
+	#avgDistanceNeedReset = true
 	#declinationGuideMode: PHD2DeclinationGuideMode = 'Auto'
 	#guider = this.#makeGuider(undefined)
 	#exposure = DEFAULT_GUIDER_EXPOSURE
@@ -267,6 +274,8 @@ export class GuiderClient {
 		this.#lockShiftTimestamp = 0
 		this.#lockShiftLimitReached = false
 		this.#guidingStartTime = 0
+		this.#avgDistance = 0
+		this.#avgDistanceNeedReset = true
 		this.#resumeState = 'Stopped'
 		this.#setAppState('Stopped')
 
@@ -349,6 +358,10 @@ export class GuiderClient {
 		this.#settleStableSince = 0
 		this.#settleFrameCount = 0
 		this.#settleDroppedFrameCount = 0
+
+		// The lock target jumped, so the smoothed distance is reseeded from the next measured frame
+		// instead of decaying from the pre-dither error.
+		this.#avgDistanceNeedReset = true
 
 		this.emitEvent('GuidingDithered', { dx, dy })
 		this.emitEvent('SettleBegin')
@@ -550,6 +563,7 @@ export class GuiderClient {
 		} else {
 			this.#guider = this.#makeGuider(this.#calibration)
 			this.#guidingStartTime = Date.now()
+			this.#avgDistanceNeedReset = true
 			this.emitEvent('StartGuiding')
 			this.#setAppState('Guiding')
 		}
@@ -645,6 +659,7 @@ export class GuiderClient {
 		this.#lockShiftOffsetY = 0
 		this.#lockShiftTimestamp = 0
 		this.#lockShiftLimitReached = false
+		this.#avgDistanceNeedReset = true
 		this.emitEvent('LockPositionSet', { X: lockX, Y: lockY })
 
 		if (this.#appState === 'Guiding' || this.#appState === 'LostLock' || this.#appState === 'Paused') {
@@ -844,6 +859,7 @@ export class GuiderClient {
 			this.#calibration = step.completed
 			this.#guider = this.#makeGuider(this.#calibration)
 			this.#guidingStartTime = Date.now()
+			this.#avgDistanceNeedReset = true
 			this.emitEvent('CalibrationComplete', { Mount: this.#guideOutput?.name ?? '' })
 			this.emitEvent('StartGuiding')
 			this.#resumeState = 'Guiding'
@@ -872,7 +888,7 @@ export class GuiderClient {
 			return 0
 		}
 
-		this.#emitGuideStepEvent(frame, command)
+		this.#emitGuideStepEvent(frame, command, this.#updateAvgDistance(command.diagnostics.dx ?? 0, command.diagnostics.dy ?? 0))
 		const assistantDelay = this.#processGuidingAssistantFrame(frame, command)
 
 		this.#resumeState = 'Guiding'
@@ -1166,6 +1182,8 @@ export class GuiderClient {
 		this.#appState = 'Stopped'
 		this.#resumeState = 'Stopped'
 		this.#guidingStartTime = 0
+		this.#avgDistance = 0
+		this.#avgDistanceNeedReset = true
 		this.#paused = false
 		this.#fullPause = true
 		this.#guideOutputEnabled = true
@@ -1280,7 +1298,7 @@ export class GuiderClient {
 	}
 
 	// Emits one guide-step event using the latest guider command and diagnostics.
-	#emitGuideStepEvent(frame: GuideFrame, command: GuideCommand) {
+	#emitGuideStepEvent(frame: GuideFrame, command: GuideCommand, avgDistance: number) {
 		const { diagnostics, ra, dec } = command
 		const star = frame.stars[0]
 		const dx = diagnostics.dx ?? 0
@@ -1310,7 +1328,8 @@ export class GuiderClient {
 			StarMass: star?.flux ?? 0,
 			SNR: star?.snr ?? 0,
 			HFD: star?.hfd ?? 0,
-			AvgDist: Math.hypot(dx, dy),
+			// PHD2 reports the smoothed guide distance here, not the raw current-frame distance.
+			AvgDist: avgDistance,
 			RALimited: ra.duration >= this.#guider.config.maxPulseMsRA,
 			DecLimited: dec.duration >= this.#guider.config.maxPulseMsDEC,
 			ErrorCode: 0,
@@ -1320,8 +1339,6 @@ export class GuiderClient {
 	// Emits a star-lost event for the current frame.
 	#emitStarLostEvent(frame: GuideFrame, command: GuideCommand) {
 		const star = frame.stars[0]
-		const dx = command.diagnostics.dx ?? 0
-		const dy = command.diagnostics.dy ?? 0
 
 		this.emitEvent('StarLost', {
 			Frame: frame.frameId ?? 0,
@@ -1330,10 +1347,28 @@ export class GuiderClient {
 			// Uses zero defaults when the lost-lock frame has no guide star measurement.
 			StarMass: star?.flux ?? 0,
 			SNR: star?.snr ?? 0,
-			AvgDist: Math.hypot(dx, dy),
+			// PHD2 reports the smoothed distance from the last successfully measured frames; a lost
+			// frame has no usable error of its own, so the running average is left untouched.
+			AvgDist: this.#avgDistance,
 			ErrorCode: 1,
 			Status: command.diagnostics.notes.join(','),
 		})
+	}
+
+	// Updates and returns PHD2's smoothed guide distance in pixels from the current frame error.
+	// The average is seeded with the first distance measured after guiding starts or after the lock
+	// target moves, then low-pass filtered so it tracks sustained error instead of single-frame noise.
+	#updateAvgDistance(dx: number, dy: number) {
+		const distance = Math.hypot(dx, dy)
+
+		if (this.#avgDistanceNeedReset) {
+			this.#avgDistanceNeedReset = false
+			this.#avgDistance = distance
+		} else {
+			this.#avgDistance += AVG_DISTANCE_SMOOTHING_ALPHA * (distance - this.#avgDistance)
+		}
+
+		return this.#avgDistance
 	}
 
 	// Converts a frame timestamp (ms since the Unix epoch) into PHD2's guide-relative time in seconds,

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -92,6 +92,7 @@ export class GuiderClient {
 	#stickyLockPosition = false
 	#appState: PHD2AppState = 'Stopped'
 	#resumeState: PHD2AppState = 'Stopped'
+	#guidingStartTime = 0
 	#declinationGuideMode: PHD2DeclinationGuideMode = 'Auto'
 	#guider = this.#makeGuider(undefined)
 	#exposure = DEFAULT_GUIDER_EXPOSURE
@@ -265,6 +266,7 @@ export class GuiderClient {
 		this.#settleDroppedFrameCount = 0
 		this.#lockShiftTimestamp = 0
 		this.#lockShiftLimitReached = false
+		this.#guidingStartTime = 0
 		this.#resumeState = 'Stopped'
 		this.#setAppState('Stopped')
 
@@ -547,6 +549,7 @@ export class GuiderClient {
 			this.#setAppState('Calibrating')
 		} else {
 			this.#guider = this.#makeGuider(this.#calibration)
+			this.#guidingStartTime = Date.now()
 			this.emitEvent('StartGuiding')
 			this.#setAppState('Guiding')
 		}
@@ -840,6 +843,7 @@ export class GuiderClient {
 		if (step.completed !== undefined) {
 			this.#calibration = step.completed
 			this.#guider = this.#makeGuider(this.#calibration)
+			this.#guidingStartTime = Date.now()
 			this.emitEvent('CalibrationComplete', { Mount: this.#guideOutput?.name ?? '' })
 			this.emitEvent('StartGuiding')
 			this.#resumeState = 'Guiding'
@@ -1161,6 +1165,7 @@ export class GuiderClient {
 		this.#exactLockPosition = false
 		this.#appState = 'Stopped'
 		this.#resumeState = 'Stopped'
+		this.#guidingStartTime = 0
 		this.#paused = false
 		this.#fullPause = true
 		this.#guideOutputEnabled = true
@@ -1286,7 +1291,8 @@ export class GuiderClient {
 
 		this.emitEvent('GuideStep', {
 			Frame: frame.frameId ?? 0,
-			Time: (frame.timestamp ?? 0) / 1000,
+			// Seconds since guiding started, matching PHD2's GuideStep.Time.
+			Time: this.#guidingElapsedTime(frame.timestamp ?? 0),
 			// Uses an empty mount name if the guide-output device is unavailable.
 			Mount: this.#guideOutput?.name ?? '',
 			dx,
@@ -1319,8 +1325,8 @@ export class GuiderClient {
 
 		this.emitEvent('StarLost', {
 			Frame: frame.frameId ?? 0,
-			// Seconds, matching GuideStep.Time and PHD2's convention (frame.timestamp is Date.now() in ms).
-			Time: (frame.timestamp ?? 0) / 1000,
+			// Seconds since guiding started, matching GuideStep.Time and PHD2's convention.
+			Time: this.#guidingElapsedTime(frame.timestamp ?? 0),
 			// Uses zero defaults when the lost-lock frame has no guide star measurement.
 			StarMass: star?.flux ?? 0,
 			SNR: star?.snr ?? 0,
@@ -1328,6 +1334,13 @@ export class GuiderClient {
 			ErrorCode: 1,
 			Status: command.diagnostics.notes.join(','),
 		})
+	}
+
+	// Converts a frame timestamp (ms since the Unix epoch) into PHD2's guide-relative time in seconds,
+	// measured from the moment guiding started. Returns 0 while no guiding session is running.
+	#guidingElapsedTime(timestamp: number) {
+		if (this.#guidingStartTime === 0 || timestamp <= 0) return 0
+		return (timestamp - this.#guidingStartTime) / 1000
 	}
 
 	// Emits one in-progress settle event using PHD2's time-in-range and requested settle duration fields.

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -545,8 +545,22 @@ export class GuiderClient {
 	}
 
 	// Starts guiding and triggers calibration first when requested or when no solution exists yet.
+	// A guide request issued while already guiding does not restart the session: like PHD2, it only
+	// begins a new settle cycle, so the accumulated dither and lock-shift target offsets survive.
 	guide(recalibrate: boolean = false, settle?: Partial<PHD2Settle>) {
 		if (!this.#connected || this.#camera === undefined || this.#guideOutput === undefined) return false
+
+		if (!recalibrate && !this.#paused && this.#calibration !== undefined && (this.#appState === 'Guiding' || this.#appState === 'LostLock')) {
+			this.#settle = { ...DEFAULT_PHD2_SETTLE, ...settle }
+			this.#settling = true
+			this.#settleStartTime = 0
+			this.#settleStableSince = 0
+			this.#settleFrameCount = 0
+			this.#settleDroppedFrameCount = 0
+			this.emitEvent('SettleBegin')
+
+			return true
+		}
 
 		this.#abortGuidingAssistantForTransition('guiding restarted')
 		this.#paused = false

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -11,7 +11,7 @@ import { base64Source, bufferSource } from '../../io/io'
 import { clamp } from '../../math/numerical/math'
 import { GuidingAssistant, type GuidingAssistantConfig, type GuidingAssistantResult } from './assistant'
 import { type CalibrationPulseCommand, flipGuidingCalibration, type GuidingCalibrationDiagnostics, type GuidingCalibrationResult, GuidingCalibrator } from './calibrator'
-import { type AxisPulse, type DeclinationGuideMode, type GuideCommand, type GuideFrame, Guider, type GuideStar } from './guider'
+import { type AxisPulse, type DeclinationGuideMode, DEFAULT_GUIDER_CONFIG, type GuideCommand, type GuideFrame, Guider, type GuideStar } from './guider'
 
 // Local autoguiding orchestrator exposing a PHD2-compatible API over INDI camera and guide-output
 // devices. It decodes each camera BLOB, detects stars, drives the GuidingCalibrator and Guider state
@@ -1262,8 +1262,22 @@ export class GuiderClient {
 	#makeGuider(calibration: GuidingCalibrationResult | undefined) {
 		if (calibration === undefined) return new Guider({ decMode: toDeclinationGuideMode(this.#declinationGuideMode), referencePosition: this.#guiderReferencePosition, initialPosition: this.#guiderInitialPosition })
 
+		// The solved image-to-axis matrix converts a pixel error into the milliseconds of pulse that
+		// would reproduce it, while the guider expects a matrix that yields the pulse cancelling it,
+		// so the matrix is negated here; feeding it unchanged closes the loop with positive feedback.
+		// Its output is already in milliseconds, so the per-unit scaling must be neutral: keeping the
+		// uncalibrated default would apply the mount rate twice and saturate every correction. The dead
+		// bands, expressed in pixels for the uncalibrated guider, are converted with the solved rates.
+		const [m00, m01, m10, m11] = calibration.imageToAxis
+		const raRate = calibration.ra.ratePxPerMs
+		const decRate = calibration.dec.ratePxPerMs
+
 		return new Guider({
-			calibration: calibration.imageToAxis,
+			calibration: [-m00, -m01, -m10, -m11],
+			msPerRAUnit: 1,
+			msPerDECUnit: 1,
+			minMoveRA: raRate > 0 ? DEFAULT_GUIDER_CONFIG.minMoveRA / raRate : DEFAULT_GUIDER_CONFIG.minMoveRA,
+			minMoveDEC: decRate > 0 ? DEFAULT_GUIDER_CONFIG.minMoveDEC / decRate : DEFAULT_GUIDER_CONFIG.minMoveDEC,
 			raPositiveDirection: calibration.ra.direction,
 			decPositiveDirection: calibration.dec.direction,
 			decMode: toDeclinationGuideMode(this.#declinationGuideMode),

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -10,7 +10,7 @@ import { detectStars } from '../../imaging/stars/detector'
 import { base64Source, bufferSource } from '../../io/io'
 import { clamp } from '../../math/numerical/math'
 import { GuidingAssistant, type GuidingAssistantConfig, type GuidingAssistantResult } from './assistant'
-import { type CalibrationPulseCommand, flipGuidingCalibration, type GuidingCalibrationDiagnostics, type GuidingCalibrationResult, GuidingCalibrator } from './calibrator'
+import { type CalibrationPulseCommand, flipGuidingCalibration, type GuidingCalibrationConfig, type GuidingCalibrationDiagnostics, type GuidingCalibrationResult, GuidingCalibrator } from './calibrator'
 import { type AxisPulse, type DeclinationGuideMode, DEFAULT_GUIDER_CONFIG, type GuideCommand, type GuideFrame, Guider, type GuideStar } from './guider'
 
 // Local autoguiding orchestrator exposing a PHD2-compatible API over INDI camera and guide-output
@@ -74,6 +74,10 @@ export interface GuiderClientOptions {
 	readonly stickyLockPosition?: boolean
 	// Dither pattern used by dither().
 	readonly ditherMode?: GuiderDitherMode
+	// Overrides for the calibration state machine, merged over DEFAULT_GUIDING_CALIBRATOR_CONFIG. Pulse
+	// durations are milliseconds and distances are pixels; an invalid combination throws at
+	// construction. Mounts with a fast guide rate usually only need shorter raPulse/decPulse.
+	readonly calibrator?: Partial<GuidingCalibrationConfig>
 }
 
 // Optics parameters supplied at connect time to derive the guider pixel scale.
@@ -95,7 +99,7 @@ export class GuiderClient {
 	#connected = false
 	#camera?: Camera
 	#guideOutput?: GuideOutput
-	readonly #calibrator = new GuidingCalibrator()
+	readonly #calibrator: GuidingCalibrator
 	#calibration?: GuidingCalibrationResult
 	#frame?: GuideFrame
 	#image?: Image
@@ -157,6 +161,7 @@ export class GuiderClient {
 		readonly guideOutputManager: GuideOutputManager,
 		readonly options?: GuiderClientOptions,
 	) {
+		this.#calibrator = new GuidingCalibrator(options?.calibrator)
 		this.#searchRegion = clamp(options?.searchRegion || DEFAULT_SEARCH_REGION, 16, 128)
 		this.#stickyLockPosition = options?.stickyLockPosition === true
 		this.#ditherMode = options?.ditherMode ?? 'random'

--- a/src/observation/guiding/client.ts
+++ b/src/observation/guiding/client.ts
@@ -881,6 +881,9 @@ export class GuiderClient {
 
 		if (step.failure !== undefined) {
 			this.emitEvent('CalibrationFailed', { Reason: step.failure.message })
+			// PHD2 raises a user-facing alert alongside the failure so clients without a calibration
+			// UI still surface the reason.
+			this.emitEvent('Alert', { Msg: `Calibration failed: ${step.failure.message}`, Type: 'error' })
 
 			if (this.#settling) {
 				this.#settling = false

--- a/src/observation/guiding/guider.ts
+++ b/src/observation/guiding/guider.ts
@@ -126,11 +126,13 @@ export interface GuideDiagnostics {
 // Row-major 2×2 image-to-axis calibration matrix [a, b, c, d].
 export type CalibrationMatrix = readonly [number, number, number, number]
 
-// Quality and geometry thresholds used to accept or reject guide stars.
+// Quality and geometry thresholds used to accept or reject guide stars. Photometric thresholds
+// (minStarSnr, minFlux, saturationPeak) share the sample scale of the images the stars were
+// measured from; the defaults target the normalized 0..1 processing scale used across imaging.
 export interface StarFilterConfig {
-	// Minimum signal-to-noise ratio.
+	// Minimum signal-to-noise ratio, as reported by the star detector for the frame's sample scale.
 	readonly minStarSnr: number
-	// Minimum integrated flux.
+	// Minimum integrated flux above background, in the frame's sample scale.
 	readonly minFlux: number
 	// Maximum half-flux diameter, in pixels.
 	readonly maxHfd: number
@@ -140,7 +142,7 @@ export interface StarFilterConfig {
 	readonly maxEllipticity: number
 	// Maximum allowed FWHM, in pixels.
 	readonly maxFwhm?: number
-	// Peak value at/above which a star is treated as saturated.
+	// Peak value at/above which a star is treated as saturated, in the frame's sample scale.
 	readonly saturationPeak?: number
 }
 
@@ -365,13 +367,20 @@ export const DEFAULT_GUIDER_CONFIG: Readonly<GuiderConfig> = {
 	decReversalThreshold: 0.08,
 	decBacklashAccumThreshold: 0.32,
 	filter: {
-		minStarSnr: 8,
-		minFlux: 100,
+		// Detector SNR is flux / sqrt(flux + aperturePixels * backgroundVariance), so on the normalized
+		// 0..1 scale it cannot exceed sqrt(flux) and flux itself is bounded by the ~49-pixel aperture.
+		// A usable guide star measures around 2..6 there; 2 keeps faint-but-trackable stars and still
+		// rejects noise blobs, which stay near or below 1.
+		minStarSnr: 2,
+		// Integrated flux above background on the normalized scale; a single-pixel noise excursion
+		// contributes far less than 1, while a trackable star reaches several units.
+		minFlux: 1,
 		maxHfd: 10,
 		borderMarginPx: 10,
 		maxEllipticity: 0.5,
 		maxFwhm: 12,
-		saturationPeak: 65500,
+		// Normalized full-scale clipping level: pixels at or above this are at the sensor ceiling.
+		saturationPeak: 0.98,
 	},
 }
 

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -224,6 +224,25 @@ describe('connect / disconnect', () => {
 		expect(eventsOf(harness.events, 'ConfigurationChange')).toHaveLength(1)
 	})
 
+	test('greets a connecting client with Version and the current AppState', () => {
+		connect(harness)
+
+		// PHD2 sends Version as the first message, immediately followed by AppState.
+		expect(harness.events[0]).toMatchObject({ Event: 'Version', PHDVersion: '2.6.13', MsgVersion: 1, OverlapSupport: false })
+		expect(harness.events[1]).toMatchObject({ Event: 'AppState', State: 'Stopped' })
+	})
+
+	test('AppState is not re-emitted on later state transitions', () => {
+		connect(harness)
+		harness.client.loop()
+		harness.client.setPaused(true)
+		harness.client.setPaused(false)
+		harness.client.stopCapture()
+
+		// Clients track state through the individual lifecycle events after the initial handshake.
+		expect(eventsOf(harness.events, 'AppState')).toHaveLength(1)
+	})
+
 	test('rejects a second connect while already connected', () => {
 		expect(connect(harness)).toBeTrue()
 		expect(connect(harness)).toBeFalse()

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -551,6 +551,17 @@ describe('mode transitions', () => {
 		expect(eventsOf(harness.events, 'SettleBegin')).toHaveLength(1)
 	})
 
+	test('a repeated guide request while still calibrating restarts calibration', () => {
+		connect(harness)
+		harness.client.guide()
+		harness.client.guide()
+
+		// The re-settle shortcut only applies to an established guiding session, never while the
+		// calibration is still being solved.
+		expect(eventsOf(harness.events, 'StartCalibration')).toHaveLength(2)
+		expect(eventsOf(harness.events, 'SettleBegin')).toHaveLength(2)
+	})
+
 	test('guiding assistant requires the internal guider to be locked', () => {
 		connect(harness)
 		expect(harness.client.guide(false)).toBeTrue()

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -886,8 +886,13 @@ describe('closed-loop calibration and guiding', () => {
 	// PHD2's Guider::UpdateCurrentDistance.
 	const AVG_DIST_ALPHA = 0.3
 
-	// Runs a full calibration against the simulated mount and leaves the client guiding.
+	// Creates a dedicated harness, runs a full calibration against its simulated mount and returns it
+	// while the client is guiding. Every test owns its harness so the sessions, which spend nearly all
+	// of their wall time asleep waiting for commanded pulses, can run concurrently without sharing
+	// state through the module-level harness.
 	async function calibrateAndGuide() {
+		const harness = makeHarness()
+
 		connect(harness)
 		harness.client.loop()
 		await feedFrame(harness)
@@ -895,14 +900,14 @@ describe('closed-loop calibration and guiding', () => {
 
 		for (let i = 0; i < MAX_CALIBRATION_FRAMES; i++) {
 			await feedFrame(harness)
-			if (harness.client.getCalibrated()) return
+			if (harness.client.getCalibrated()) return harness
 		}
 
 		throw new Error('calibration did not converge against the simulated mount')
 	}
 
 	// Feeds enough frames for the guider to finish averaging its lock reference.
-	async function establishLockReference() {
+	async function establishLockReference(harness: Harness) {
 		for (let i = 0; i < LOCK_AVERAGING_FRAMES; i++) await feedFrame(harness)
 	}
 
@@ -927,10 +932,10 @@ describe('closed-loop calibration and guiding', () => {
 		return [(distance * dx) / length, (distance * dy) / length] as const
 	}
 
-	test(
+	test.concurrent(
 		'calibration recovers the simulated mount rate and camera angle on both axes',
 		async () => {
-			await calibrateAndGuide()
+			const harness = await calibrateAndGuide()
 
 			const calibration = harness.client.getCalibrationData()
 			expect(calibration.calibrated).toBeTrue()
@@ -950,10 +955,10 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'flipping the calibration rotates the solved axes by half a turn',
 		async () => {
-			await calibrateAndGuide()
+			const harness = await calibrateAndGuide()
 
 			const before = harness.client.getCalibrationData()
 			expect(harness.client.flipCalibration()).toBeTrue()
@@ -966,11 +971,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'guide steps timestamp their frames from the start of guiding',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			const steps = eventsOf(harness.events, 'GuideStep')
 			expect(steps.length).toBeGreaterThan(1)
@@ -990,11 +995,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'the reported average distance is a low-pass filter over the per-frame distance',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			// A steady drift larger than the residual the guider can remove in one frame keeps the
 			// measured error non-zero, so the smoothing is observable.
@@ -1017,11 +1022,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'axis limit flags are omitted while the pulses stay inside the maximum duration',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			const steps = eventsOf(harness.events, 'GuideStep')
 			expect(steps.length).toBeGreaterThan(0)
@@ -1035,11 +1040,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'an error large enough to saturate the right ascension pulse reports RALimited',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			// Moving the lock target instead of the star creates an arbitrarily large guide error without
 			// tripping the frame-jump rejection, and a sticky lock keeps the guider from re-averaging its
@@ -1069,11 +1074,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'star-free frames report a lost star every frame but a lost lock position only once',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			// The guider tolerates a few missing frames before declaring the star lost, so the first
 			// star-free frames produce no StarLost at all.
@@ -1092,11 +1097,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'guiding recovers the star after a run of star-free frames',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			for (let i = 0; i < 8; i++) await feedEmptyFrame(harness)
 			expect(harness.client.getAppState()).toBe('LostLock')
@@ -1113,11 +1118,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'dithering offsets the lock position and starts a new settle cycle',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			const before = harness.client.getLockPosition()
 			expect(before).toBeDefined()
@@ -1144,11 +1149,11 @@ describe('closed-loop calibration and guiding', () => {
 		CLOSED_LOOP_TIMEOUT,
 	)
 
-	test(
+	test.concurrent(
 		'stopping a guiding session reports both stop events and keeps the calibration',
 		async () => {
-			await calibrateAndGuide()
-			await establishLockReference()
+			const harness = await calibrateAndGuide()
+			await establishLockReference(harness)
 
 			harness.client.stopCapture()
 

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -282,6 +282,28 @@ describe('capture control', () => {
 		expect(harness.client.getAppState()).toBe('Stopped')
 		expect(harness.cameraManager.stopExposureCount).toBeGreaterThanOrEqual(1)
 		expect(eventsOf(harness.events, 'LoopingExposuresStopped')).toHaveLength(1)
+		expect(eventsOf(harness.events, 'GuidingStopped')).toHaveLength(0)
+	})
+
+	test('stopCapture during a guiding session reports both guiding and looping stops', () => {
+		connect(harness)
+		harness.client.guide()
+		expect(harness.client.getAppState()).toBe('Calibrating')
+
+		expect(harness.client.stopCapture()).toBeTrue()
+		// Guiding implies looping in PHD2, so both stop notifications are sent, guiding first.
+		expect(eventsOf(harness.events, 'GuidingStopped')).toHaveLength(1)
+		expect(eventsOf(harness.events, 'LoopingExposuresStopped')).toHaveLength(1)
+
+		const stops = harness.events.filter((event) => event.Event === 'GuidingStopped' || event.Event === 'LoopingExposuresStopped')
+		expect(stops.map((event) => event.Event)).toEqual(['GuidingStopped', 'LoopingExposuresStopped'])
+	})
+
+	test('stopCapture on an already stopped client emits no stop events', () => {
+		connect(harness)
+		expect(harness.client.stopCapture()).toBeTrue()
+		expect(eventsOf(harness.events, 'GuidingStopped')).toHaveLength(0)
+		expect(eventsOf(harness.events, 'LoopingExposuresStopped')).toHaveLength(0)
 	})
 })
 

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -614,6 +614,19 @@ describe('mode transitions', () => {
 		expect(eventsOf(harness.events, 'Resumed')).toHaveLength(1)
 	})
 
+	test('redundant pause and resume requests emit no extra events', () => {
+		connect(harness)
+		harness.client.loop()
+
+		harness.client.setPaused(true)
+		harness.client.setPaused(true)
+		expect(eventsOf(harness.events, 'Paused')).toHaveLength(1)
+
+		harness.client.setPaused(false)
+		harness.client.setPaused(false)
+		expect(eventsOf(harness.events, 'Resumed')).toHaveLength(1)
+	})
+
 	test('a partial pause keeps exposures running', () => {
 		connect(harness)
 		harness.client.loop()

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import { pixelScale } from '../../../src/astronomy/formulas'
+import { DEG2RAD } from '../../../src/core/constants'
 import type { PHD2Events } from '../../../src/devices/guiding/phd2'
 import { type Camera, DEFAULT_CAMERA, DEFAULT_GUIDE_OUTPUT, type GuideDirection, type GuideOutput } from '../../../src/devices/indi/device'
 import type { CameraManager, DeviceHandler, GuideOutputManager } from '../../../src/devices/indi/manager'
 import { writeImageToFits } from '../../../src/imaging/model/image'
 import type { Image } from '../../../src/imaging/model/types'
+import { plotStar } from '../../../src/imaging/stars/generator'
 import { bufferSink } from '../../../src/io/io'
 import { GuiderClient, type GuiderClientConnectOptions, type GuiderClientOptions } from '../../../src/observation/guiding/client'
 
@@ -61,33 +63,37 @@ class FakeGuideOutputManager {
 	}
 }
 
-// Star centers (image pixels) plotted into the synthetic guide frame.
+// Star centers (image pixels) plotted into the synthetic guide frame at zero mount offset.
 const STAR_A = [70, 70] as const
 const STAR_B = [165, 150] as const
 const FRAME_WIDTH = 240
 const FRAME_HEIGHT = 240
 
-// Adds one circular Gaussian star to a flat float background, in ADU.
-function plotGaussianStar(raw: Float32Array, width: number, height: number, cx: number, cy: number, peak: number, sigma: number) {
-	const radius = Math.ceil(sigma * 5)
-	const twoSigmaSq = 2 * sigma * sigma
+// Integrated flux of the primary synthetic star, in normalized full-scale units. Chosen so the
+// detector measures SNR ~3 with a peak near 0.6: above the guide-star filter thresholds while
+// staying clear of the saturation ceiling.
+const STAR_FLUX = 10
+// Flux of the secondary star as a fraction of the primary, keeping the two stars distinguishable.
+const SECONDARY_STAR_FLUX_RATIO = 0.6
+// Half-flux diameter of the synthetic stars, in pixels.
+const STAR_HFD = 3
+// Nominal SNR requested from the star plotter; high enough that the rendered profile is noise-free
+// and the detector recovers the plotted centroid exactly.
+const STAR_PLOT_SNR = 80
+// Flat background level under the stars, in normalized full-scale units.
+const FRAME_BACKGROUND = 0.005
 
-	for (let dy = -radius; dy <= radius; dy++) {
-		for (let dx = -radius; dx <= radius; dx++) {
-			const x = cx + dx
-			const y = cy + dy
-			if (x < 0 || y < 0 || x >= width || y >= height) continue
-			raw[y * width + x] += peak * Math.exp(-(dx * dx + dy * dy) / twoSigmaSq)
-		}
+// Builds an in-memory FITS buffer with two well-separated stars on a flat background, both shifted
+// by the same image-space offset (pixels) so a whole-frame mount motion can be simulated. Passing
+// no stars renders an empty background frame, which the detector reports as a lost star.
+async function buildFrameBuffer(offsetX = 0, offsetY = 0, stars = true): Promise<Buffer> {
+	const raw = new Float32Array(FRAME_WIDTH * FRAME_HEIGHT).fill(FRAME_BACKGROUND)
+
+	if (stars) {
+		const options = { background: FRAME_BACKGROUND, saturationLevel: 1 }
+		plotStar(raw, FRAME_WIDTH, FRAME_HEIGHT, 1, STAR_A[0] + offsetX, STAR_A[1] + offsetY, STAR_FLUX, STAR_HFD, STAR_PLOT_SNR, 0, undefined, options)
+		plotStar(raw, FRAME_WIDTH, FRAME_HEIGHT, 1, STAR_B[0] + offsetX, STAR_B[1] + offsetY, STAR_FLUX * SECONDARY_STAR_FLUX_RATIO, STAR_HFD, STAR_PLOT_SNR, 0, undefined, options)
 	}
-}
-
-// Builds an in-memory FITS buffer with two well-separated stars on a flat background.
-// The flat background keeps star detection deterministic (exactly the two plotted centroids).
-async function buildFrameBuffer(): Promise<Buffer> {
-	const raw = new Float32Array(FRAME_WIDTH * FRAME_HEIGHT).fill(300)
-	plotGaussianStar(raw, FRAME_WIDTH, FRAME_HEIGHT, STAR_A[0], STAR_A[1], 30000, 1.5)
-	plotGaussianStar(raw, FRAME_WIDTH, FRAME_HEIGHT, STAR_B[0], STAR_B[1], 21000, 1.6)
 
 	const image: Image = {
 		header: { SIMPLE: true, BITPIX: -32, NAXIS: 2, NAXIS1: FRAME_WIDTH, NAXIS2: FRAME_HEIGHT },
@@ -100,7 +106,55 @@ async function buildFrameBuffer(): Promise<Buffer> {
 	return buffer
 }
 
+// Frame with both stars at their nominal positions, reused by tests that never move the mount.
 const FRAME_BUFFER = await buildFrameBuffer()
+
+// Image-space star displacement produced by one millisecond of guide pulse on either axis, in
+// pixels/ms. The calibrator's default 650 ms pulses then move the star ~7.5 px per step: below its
+// 8 px maximum accepted frame jump, yet large enough that two steps already exceed the minimum net
+// travel each axis requires, which keeps the wall-clock cost of a calibration run low.
+const MOUNT_RATE_PX_PER_MS = 0.0115
+// Camera rotation relative to the mount axes, in radians. A non-zero angle keeps the solved
+// calibration matrix off-diagonal, so an axis mix-up cannot pass unnoticed.
+const MOUNT_ANGLE = 20 * DEG2RAD
+// Unit vector, in image space, along which a west pulse moves the star.
+const RA_AXIS = [Math.cos(MOUNT_ANGLE), Math.sin(MOUNT_ANGLE)] as const
+// Unit vector, in image space, along which a north pulse moves the star; orthogonal to RA_AXIS so
+// the two calibration legs are always well separated.
+const DEC_AXIS = [-Math.sin(MOUNT_ANGLE), Math.cos(MOUNT_ANGLE)] as const
+
+// Turns the pulses recorded by the fake guide output into image-space star motion, so calibration
+// and guiding run against frames that actually respond to the commands the client issues.
+// West and north move the star along the positive axis unit vectors; east and south reverse it.
+class MountSimulator {
+	// Accumulated star displacement, in pixels.
+	offsetX = 0
+	offsetY = 0
+	// Constant open-loop drift added once per rendered frame, in pixels; models a mount the guider
+	// has to correct for.
+	driftX = 0
+	driftY = 0
+
+	// Number of recorded pulses already converted into motion.
+	#consumed = 0
+
+	// Applies every pulse recorded since the previous frame, then the per-frame drift.
+	advance(pulses: readonly PulseRecord[]) {
+		for (let i = this.#consumed; i < pulses.length; i++) {
+			const { direction, duration } = pulses[i]
+			const travel = duration * MOUNT_RATE_PX_PER_MS
+			const axis = direction === 'WEST' || direction === 'EAST' ? RA_AXIS : DEC_AXIS
+			const sign = direction === 'WEST' || direction === 'NORTH' ? 1 : -1
+
+			this.offsetX += sign * travel * axis[0]
+			this.offsetY += sign * travel * axis[1]
+		}
+
+		this.#consumed = pulses.length
+		this.offsetX += this.driftX
+		this.offsetY += this.driftY
+	}
+}
 
 // Builds a connected-capable camera with sensible defaults overridable per test.
 function makeCamera(overrides: Partial<Camera> = {}): Camera {
@@ -133,6 +187,7 @@ interface Harness {
 	readonly events: PHD2Events[]
 	readonly camera: Camera
 	readonly guideOutput: GuideOutput
+	readonly mount: MountSimulator
 	frameCount: number
 }
 
@@ -146,7 +201,7 @@ function makeHarness(options: GuiderClientOptions = {}): Harness {
 		handler: { event: (_client, event) => events.push(event) },
 	})
 
-	return { client, cameraManager, guideOutputManager, events, camera: makeCamera(), guideOutput: makeGuideOutput(), frameCount: 0 }
+	return { client, cameraManager, guideOutputManager, events, camera: makeCamera(), guideOutput: makeGuideOutput(), mount: new MountSimulator(), frameCount: 0 }
 }
 
 // Connects the harness client to its camera/guide output.
@@ -154,21 +209,58 @@ function connect(harness: Harness, options?: GuiderClientConnectOptions) {
 	return harness.client.connect(harness.camera, harness.guideOutput, options)
 }
 
-// Feeds one synthetic frame through the captured blob handler and waits until the client has processed it.
-async function feedFrame(harness: Harness) {
+// Feeds one already-built BLOB through the captured blob handler and waits until the client has
+// fully processed it. Completion is detected by the request for the next exposure, which the client
+// only issues after the frame has been processed and any commanded pulse has elapsed; feeding the
+// next BLOB earlier would simply be dropped as a concurrent frame. States that stop the exposure
+// loop never request another exposure, so a processed frame that produced events also completes.
+async function feedBuffer(harness: Harness, buffer: Buffer) {
 	const handler = harness.cameraManager.handler
 	expect(handler?.blobReceived).toBeDefined()
 
 	const expected = ++harness.frameCount
-	handler!.blobReceived!(harness.camera, FRAME_BUFFER, 'raw')
 
-	for (let i = 0; i < 1000; i++) {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		const eventsBefore = harness.events.length
+		const exposuresBefore = harness.cameraManager.startExposureCalls.length
+		handler!.blobReceived!(harness.camera, buffer, 'raw')
+
+		// Every processed frame emits at least one event while it is being handled, so a short silence
+		// means the BLOB arrived while the previous frame was still processing and was dropped: retry.
+		let accepted = false
+
+		for (let i = 0; i < 100 && !accepted; i++) {
+			accepted = harness.events.length > eventsBefore
+			if (!accepted) await Bun.sleep(1)
+		}
+
+		if (!accepted) continue
+
+		// The frame is only fully processed once the client asks for the next exposure, which happens
+		// after any commanded pulse has elapsed.
+		for (let i = 0; i < 10000; i++) {
+			if (harness.cameraManager.startExposureCalls.length > exposuresBefore) break
+			await Bun.sleep(1)
+		}
+
 		const image = harness.client.getStarImage()
-		if (image !== undefined && image.frame >= expected) return image
-		await Bun.sleep(1)
+		return image !== undefined && image.frame >= expected ? image : undefined
 	}
 
 	throw new Error('frame was not processed in time')
+}
+
+// Advances the simulated mount with the pulses issued so far, renders the resulting frame and feeds
+// it to the client. This closes the loop: the corrections the client commands move the next frame.
+async function feedFrame(harness: Harness) {
+	harness.mount.advance(harness.guideOutputManager.pulses)
+	return await feedBuffer(harness, await buildFrameBuffer(harness.mount.offsetX, harness.mount.offsetY))
+}
+
+// Feeds a star-free frame, which the client must report as a lost star.
+async function feedEmptyFrame(harness: Harness) {
+	harness.mount.advance(harness.guideOutputManager.pulses)
+	return await feedBuffer(harness, await buildFrameBuffer(0, 0, false))
 }
 
 // Returns all recorded events of one type.
@@ -688,7 +780,7 @@ describe('frame-driven behavior', () => {
 	test('getStarImage crops a square ROI sized by the search region', async () => {
 		connect(harness)
 		harness.client.loop()
-		const image = await feedFrame(harness)
+		const image = (await feedFrame(harness))!
 
 		expect(image.width).toBe(64)
 		expect(image.height).toBe(64)
@@ -775,4 +867,297 @@ describe('frame processing robustness', () => {
 		await waitForLoopingExposures(before + 1)
 		expect(harness.client.getStarImage()).toBeUndefined()
 	})
+})
+
+describe('closed-loop calibration and guiding', () => {
+	// Upper bound on the frames a calibration run may consume before the test gives up. The simulated
+	// mount converges in about 14, so this only guards against a run that never completes.
+	const MAX_CALIBRATION_FRAMES = 40
+	// Frames fed after calibration so the guider finishes averaging its lock reference (the guider
+	// default is 6) before a test asserts on measured errors.
+	const LOCK_AVERAGING_FRAMES = 8
+	// Settle parameters that complete as soon as the frame is inside tolerance, so tests do not wait
+	// out the ten-second PHD2 default.
+	const IMMEDIATE_SETTLE = { pixels: 5, time: 0, timeout: 5 } as const
+	// Per-test timeout, in milliseconds. A closed-loop run feeds tens of frames, each waiting for the
+	// commanded pulse to elapse before the next exposure is requested.
+	const CLOSED_LOOP_TIMEOUT = 30000
+	// Exponential smoothing factor the guider applies to the reported average distance, matching
+	// PHD2's Guider::UpdateCurrentDistance.
+	const AVG_DIST_ALPHA = 0.3
+
+	// Runs a full calibration against the simulated mount and leaves the client guiding.
+	async function calibrateAndGuide() {
+		connect(harness)
+		harness.client.loop()
+		await feedFrame(harness)
+		expect(harness.client.guide(false, IMMEDIATE_SETTLE)).toBeTrue()
+
+		for (let i = 0; i < MAX_CALIBRATION_FRAMES; i++) {
+			await feedFrame(harness)
+			if (harness.client.getCalibrated()) return
+		}
+
+		throw new Error('calibration did not converge against the simulated mount')
+	}
+
+	// Feeds enough frames for the guider to finish averaging its lock reference.
+	async function establishLockReference() {
+		for (let i = 0; i < LOCK_AVERAGING_FRAMES; i++) await feedFrame(harness)
+	}
+
+	// Lock-target displacement, in pixels, large enough that the right ascension share of it asks for
+	// a pulse longer than the guider's 2000 ms maximum on the very first guided frame, even after the
+	// hysteresis filter has damped it. At the simulated mount rate that takes a target well outside
+	// the frame, which is fine: the star itself never moves, so nothing else about the frame changes.
+	const LARGE_LOCK_OFFSET_PX = 250
+
+	// Returns a displacement of `distance` pixels pointing from the star currently locked towards the
+	// far side of it, that is, directly away from the other synthetic star. Moving the lock along it
+	// keeps the locked star the one nearest to the new target, so the guider does not switch stars.
+	function offsetAwayFromOtherStar(harness: Harness, lockX: number, lockY: number, distance: number) {
+		const ax = STAR_A[0] + harness.mount.offsetX
+		const ay = STAR_A[1] + harness.mount.offsetY
+		const bx = STAR_B[0] + harness.mount.offsetX
+		const by = STAR_B[1] + harness.mount.offsetY
+		const lockedOnA = Math.hypot(lockX - ax, lockY - ay) <= Math.hypot(lockX - bx, lockY - by)
+		const dx = lockedOnA ? ax - bx : bx - ax
+		const dy = lockedOnA ? ay - by : by - ay
+		const length = Math.hypot(dx, dy)
+		return [(distance * dx) / length, (distance * dy) / length] as const
+	}
+
+	test(
+		'calibration recovers the simulated mount rate and camera angle on both axes',
+		async () => {
+			await calibrateAndGuide()
+
+			const calibration = harness.client.getCalibrationData()
+			expect(calibration.calibrated).toBeTrue()
+			expect(calibration.xRate).toBeCloseTo(MOUNT_RATE_PX_PER_MS, 3)
+			expect(calibration.yRate).toBeCloseTo(MOUNT_RATE_PX_PER_MS, 3)
+			// Both axes are recovered with the camera rotation baked in, and stay orthogonal.
+			expect(calibration.xAngle).toBeCloseTo(MOUNT_ANGLE, 1)
+			expect(Math.abs(calibration.yAngle - calibration.xAngle)).toBeCloseTo(Math.PI / 2, 1)
+
+			expect(eventsOf(harness.events, 'StartCalibration')).toHaveLength(1)
+			expect(eventsOf(harness.events, 'CalibrationFailed')).toBeEmpty()
+			expect(eventsOf(harness.events, 'Calibrating').length).toBeGreaterThan(1)
+			expect(eventsOf(harness.events, 'CalibrationComplete')).toHaveLength(1)
+			expect(eventsOf(harness.events, 'StartGuiding')).toHaveLength(1)
+			expect(harness.client.getAppState()).toBe('Guiding')
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'flipping the calibration rotates the solved axes by half a turn',
+		async () => {
+			await calibrateAndGuide()
+
+			const before = harness.client.getCalibrationData()
+			expect(harness.client.flipCalibration()).toBeTrue()
+			const after = harness.client.getCalibrationData()
+
+			expect(after.xRate).toBeCloseTo(before.xRate, 6)
+			expect(Math.cos(after.xAngle - before.xAngle)).toBeCloseTo(-1, 6)
+			expect(eventsOf(harness.events, 'CalibrationDataFlipped')).toHaveLength(1)
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'guide steps timestamp their frames from the start of guiding',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			const steps = eventsOf(harness.events, 'GuideStep')
+			expect(steps.length).toBeGreaterThan(1)
+
+			// PHD2 reports the elapsed guiding time in seconds, so the first step is near zero rather
+			// than an absolute epoch, and the sequence never goes backwards.
+			expect(steps[0].Time).toBeGreaterThanOrEqual(0)
+			expect(steps[0].Time).toBeLessThan(5)
+
+			for (let i = 1; i < steps.length; i++) {
+				expect(steps[i].Time).toBeGreaterThanOrEqual(steps[i - 1].Time)
+				expect(steps[i].Frame).toBeGreaterThan(steps[i - 1].Frame)
+			}
+
+			expect(steps.at(-1)!.Time).toBeGreaterThan(0)
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'the reported average distance is a low-pass filter over the per-frame distance',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			// A steady drift larger than the residual the guider can remove in one frame keeps the
+			// measured error non-zero, so the smoothing is observable.
+			harness.mount.driftX = 3
+			harness.mount.driftY = 2
+
+			for (let i = 0; i < 8; i++) await feedFrame(harness)
+
+			const steps = eventsOf(harness.events, 'GuideStep').slice(-6)
+			expect(steps.length).toBe(6)
+
+			expect(steps.at(-1)!.AvgDist).toBeGreaterThan(0)
+
+			for (let i = 1; i < steps.length; i++) {
+				const distance = Math.hypot(steps[i].dx, steps[i].dy)
+				const expected = steps[i - 1].AvgDist + AVG_DIST_ALPHA * (distance - steps[i - 1].AvgDist)
+				expect(steps[i].AvgDist).toBeCloseTo(expected, 6)
+			}
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'axis limit flags are omitted while the pulses stay inside the maximum duration',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			const steps = eventsOf(harness.events, 'GuideStep')
+			expect(steps.length).toBeGreaterThan(0)
+
+			// PHD2 only serializes RALimited/DecLimited when the pulse was actually clipped.
+			for (const step of steps) {
+				expect(step).not.toHaveProperty('RALimited')
+				expect(step).not.toHaveProperty('DecLimited')
+			}
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'an error large enough to saturate the right ascension pulse reports RALimited',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			// Moving the lock target instead of the star creates an arbitrarily large guide error without
+			// tripping the frame-jump rejection, and a sticky lock keeps the guider from re-averaging its
+			// reference back onto the star. The offset points away from the other star so the guider keeps
+			// tracking the same one, and its right ascension component alone exceeds the axis maximum.
+			harness.client.setStickyLockPositionEnabled(true)
+			const [lockX, lockY] = harness.client.getLockPosition()!
+			const [awayX, awayY] = offsetAwayFromOtherStar(harness, lockX, lockY, LARGE_LOCK_OFFSET_PX)
+			expect(harness.client.setLockPosition(lockX + awayX, lockY + awayY, true)).toBeTrue()
+
+			let steps = eventsOf(harness.events, 'GuideStep')
+			let limited: (typeof steps)[number] | undefined
+
+			// The moved lock target restarts the reference averaging, so the first frames report no error.
+			for (let i = 0; i < 14 && limited === undefined; i++) {
+				await feedFrame(harness)
+				steps = eventsOf(harness.events, 'GuideStep')
+				limited = steps.find((step) => step.RALimited === true)
+			}
+
+			expect(limited).toBeDefined()
+			// The clipped pulse is reported at exactly the configured right ascension maximum, while the
+			// declination axis, which sees a much smaller share of the offset, is never clipped.
+			expect(limited!.RADuration).toBe(2000)
+			expect(limited!.DecLimited).toBeUndefined()
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'star-free frames report a lost star every frame but a lost lock position only once',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			// The guider tolerates a few missing frames before declaring the star lost, so the first
+			// star-free frames produce no StarLost at all.
+			for (let i = 0; i < 10; i++) await feedEmptyFrame(harness)
+
+			expect(harness.client.getAppState()).toBe('LostLock')
+			// PHD2 emits StarLost for every frame the star is missing, but LockPositionLost only on the
+			// transition into the lost-lock state.
+			expect(eventsOf(harness.events, 'StarLost').length).toBeGreaterThanOrEqual(6)
+			expect(eventsOf(harness.events, 'LockPositionLost')).toHaveLength(1)
+
+			const lost = eventsOf(harness.events, 'StarLost')
+
+			for (let i = 1; i < lost.length; i++) expect(lost[i].Frame).toBeGreaterThan(lost[i - 1].Frame)
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'guiding recovers the star after a run of star-free frames',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			for (let i = 0; i < 8; i++) await feedEmptyFrame(harness)
+			expect(harness.client.getAppState()).toBe('LostLock')
+
+			const stepsWhileLost = eventsOf(harness.events, 'GuideStep').length
+
+			for (let i = 0; i < 4; i++) await feedFrame(harness)
+
+			expect(harness.client.getAppState()).toBe('Guiding')
+			expect(eventsOf(harness.events, 'GuideStep').length).toBeGreaterThan(stepsWhileLost)
+			// The recovery does not report a second lost lock position.
+			expect(eventsOf(harness.events, 'LockPositionLost')).toHaveLength(1)
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'dithering offsets the lock position and starts a new settle cycle',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			const before = harness.client.getLockPosition()
+			expect(before).toBeDefined()
+
+			const settleEvents = eventsOf(harness.events, 'SettleBegin').length
+			expect(harness.client.dither(3, false, IMMEDIATE_SETTLE)).toBeTrue()
+
+			const dithered = eventsOf(harness.events, 'GuidingDithered')
+			expect(dithered).toHaveLength(1)
+			expect(Math.hypot(dithered[0].dx, dithered[0].dy)).toBeGreaterThan(0)
+			expect(eventsOf(harness.events, 'SettleBegin').length).toBe(settleEvents + 1)
+
+			const after = harness.client.getLockPosition()!
+			expect(after[0]).toBeCloseTo(before![0] + dithered[0].dx, 6)
+			expect(after[1]).toBeCloseTo(before![1] + dithered[0].dy, 6)
+
+			// The dither moves the lock target, so the guider re-averages its reference before reporting
+			// usable errors again; the settle cycle only completes after those frames.
+			for (let i = 0; i < 10; i++) await feedFrame(harness)
+
+			expect(eventsOf(harness.events, 'SettleDone')).not.toBeEmpty()
+			expect(harness.client.getSettling()).toBeFalse()
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
+
+	test(
+		'stopping a guiding session reports both stop events and keeps the calibration',
+		async () => {
+			await calibrateAndGuide()
+			await establishLockReference()
+
+			harness.client.stopCapture()
+
+			expect(harness.client.getAppState()).toBe('Stopped')
+			expect(eventsOf(harness.events, 'GuidingStopped')).toHaveLength(1)
+			expect(eventsOf(harness.events, 'LoopingExposuresStopped')).toHaveLength(1)
+			// A stop does not invalidate the solved calibration, so guiding can resume without one.
+			expect(harness.client.getCalibrated()).toBeTrue()
+		},
+		CLOSED_LOOP_TIMEOUT,
+	)
 })

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -296,6 +296,14 @@ describe('construction', () => {
 		expect(defaults.client.getDitherMode()).toBe('random')
 	})
 
+	test('rejects a calibrator configuration the calibrator itself would reject', () => {
+		// The overrides are merged over the calibrator defaults and validated at construction, so an
+		// impossible combination fails immediately instead of on the first calibration frame.
+		expect(() => makeHarness({ calibrator: { raPulse: 0 } })).toThrowError(/invalid guiding calibrator config/)
+		expect(() => makeHarness({ calibrator: { maxRatePxPerMs: 1e-6 } })).toThrowError(/invalid guiding calibrator config/)
+		expect(() => makeHarness({ calibrator: { raPulse: 250, decPulse: 250 } })).not.toThrow()
+	})
+
 	test('starts stopped, uncalibrated, unpaused and without a lock', () => {
 		expect(harness.client.getAppState()).toBe('Stopped')
 		expect(harness.client.getCalibrated()).toBeFalse()
@@ -885,13 +893,20 @@ describe('closed-loop calibration and guiding', () => {
 	// Exponential smoothing factor the guider applies to the reported average distance, matching
 	// PHD2's Guider::UpdateCurrentDistance.
 	const AVG_DIST_ALPHA = 0.3
+	// Calibrator overrides that cut the pulses a session has to command. Almost all of its wall time is
+	// the client sleeping out those pulses, and their total is the required travel divided by the mount
+	// rate. The clearing move only exists to undo the right ascension leg on a real mount, so dropping
+	// it removes a third of the pulses without affecting the solve. The travel thresholds keep their
+	// defaults: shortening them to a single sample per leg leaves the solved camera angle at the mercy
+	// of the centroid error over a seven-pixel baseline.
+	const FAST_CALIBRATION = { clearingMoveEnabled: false } as const
 
 	// Creates a dedicated harness, runs a full calibration against its simulated mount and returns it
 	// while the client is guiding. Every test owns its harness so the sessions, which spend nearly all
 	// of their wall time asleep waiting for commanded pulses, can run concurrently without sharing
 	// state through the module-level harness.
 	async function calibrateAndGuide() {
-		const harness = makeHarness()
+		const harness = makeHarness({ calibrator: FAST_CALIBRATION })
 
 		connect(harness)
 		harness.client.loop()

--- a/tests/observation/guiding/client.test.ts
+++ b/tests/observation/guiding/client.test.ts
@@ -551,6 +551,27 @@ describe('mode transitions', () => {
 		expect(eventsOf(harness.events, 'SettleBegin')).toHaveLength(1)
 	})
 
+	test('guide without a decoded frame cannot select a star and still starts', () => {
+		connect(harness)
+
+		expect(harness.client.guide()).toBeTrue()
+		// The auto-selection attempt is a no-op until frames arrive; guiding still starts.
+		expect(eventsOf(harness.events, 'StarSelected')).toHaveLength(0)
+		expect(harness.client.getLockPosition()).toBeUndefined()
+		expect(harness.client.getAppState()).toBe('Calibrating')
+	})
+
+	test('guide keeps an already selected star instead of reselecting', async () => {
+		connect(harness)
+		harness.client.loop()
+		await feedFrame(harness)
+		harness.client.setLockPosition(STAR_B[0], STAR_B[1], true)
+
+		expect(harness.client.guide()).toBeTrue()
+		expect(eventsOf(harness.events, 'StarSelected')).toHaveLength(0)
+		expect(harness.client.getLockPosition()).toEqual([STAR_B[0], STAR_B[1]])
+	})
+
 	test('a repeated guide request while still calibrating restarts calibration', () => {
 		connect(harness)
 		harness.client.guide()


### PR DESCRIPTION
# O que está verificado

O loop fechado converge e é estável contra o mount simulado: a calibração recupera taxa e ângulo dos dois eixos (xRate ≈ 0,0115 px/ms com 3 casas, eixos ortogonais em ~1°), o guiding remove o erro em vez de amplificá-lo, o AvgDist segue a recorrência do PHD2, os flags de saturação aparecem só quando o pulso é clipado, e os ciclos de star-lost/recovery, dither+settle e stop se comportam como o PHD2 documenta. 177/177 em tests/observation/guiding/.

Vale lembrar por que isso importa: até este harness existir, os testes eram todos unitários e passavam — e mesmo assim havia dois P0 (escala em ms aplicada duas vezes e sinal invertido da correção) que tornavam o guiding calibrado inoperante, mais thresholds de filtro inalcançáveis que rejeitariam toda estrela. Nenhum teste unitário pegou isso. Agora existe uma rede que pega essa classe de regressão.

# O que o simulador não cobre

Isso é o que eu levaria para o céu real com atenção:

* Mount é um integrador linear perfeito. Sem backlash, erro periódico, stiction ou assimetria de taxa entre direções. Todo o caminho decBacklashClearing / maxDecNoMotionSteps nunca foi exercitado contra backlash de verdade — é justamente onde calibrações reais falham.
* Frames sem ruído nem seeing. O centróide é quase exato. As tolerâncias de minMovePerStepPx, maxFrameJumpPx e minFrameQuality nunca foram pressionadas por uma estrela tremendo.
* Pulsos instantâneos e exatos. Latência do INDI e do driver não é modelada; o Bun.sleep do #queueNextExposure é só um proxy.
* Sem dependência de declinação. A taxa de RA real cai com cos(δ); calibrar num alvo e guiar em outro não é testado.
* Meridian flip só foi testado como matemática (flipCalibration()), não como flip real com reverseDecOutputAfterMeridianFlip.
* Guiding assistant e lock-shift têm cobertura unitária, mas não closed-loop.

# Recomendação

Pode dar como finalizado e partir para testes reais. Nas primeiras sessões eu observaria, nesta ordem:

* A calibração converge ou estoura maxDecNoMotionSteps por backlash;
* O sinal da correção está certo nos dois eixos — se o erro crescer em vez de cair, é sinal invertido de novo, agora por convenção de direção do driver e não pelo bug já corrigido; 
* minStarSnr: 2 / minFlux: 1 na escala normalizada com estrelas reais — foram calibrados analiticamente, não empiricamente.

Se algum desses tropeçar, o harness já está pronto para reproduzir o caso em segundos.